### PR TITLE
feat: add the decision resolver for exit codes and hook JSON

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -370,7 +370,7 @@ export default defineConfig([
     // still reaches every static directory; nothing here narrows that
     // assertion, only what a handful of named files may additionally do.
     name: "tests/static-layer-unit-tests",
-    files: ["tests/settings.test.ts", "tests/spec.test.ts"],
+    files: ["tests/settings.test.ts", "tests/spec.test.ts", "tests/decision.test.ts"],
     rules: {
       "no-restricted-imports": "off",
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,13 @@
  * @packageDocumentation
  */
 
-export type { EventName, Provenance, ResolvedHook, SettingsLayer } from "./types.js";
+export type {
+  Decision,
+  EventName,
+  ExecOutcome,
+  Provenance,
+  ResolvedHook,
+  SettingsLayer,
+  UnknownReason,
+  VersionSourceName,
+} from "./types.js";

--- a/src/internal/decision/factory.ts
+++ b/src/internal/decision/factory.ts
@@ -15,7 +15,7 @@ import type { Decision, UnknownReason } from "../../types.js";
 
 /** The action is blocked. */
 export function denied(
-  source: "exit-2" | "permission-decision",
+  source: "exit-code" | "permission-decision",
   exitCode: number,
 ): Decision {
   return { kind: "deny", source, exitCode };

--- a/src/internal/decision/factory.ts
+++ b/src/internal/decision/factory.ts
@@ -1,0 +1,53 @@
+/**
+ * The only place a {@link Decision} object literal is written.
+ *
+ * @remarks
+ * Static layer: pure construction, no I/O. `resolve.ts` and every later
+ * consumer builds a `Decision` through these functions rather than writing
+ * the shape out at the call site — enforced as a lint/review-time rule, not a
+ * mechanical one, per this issue's design. `unknownDecision`'s required
+ * `first` parameter is what makes `Decision.unknown.reasons`'s non-empty
+ * tuple constructible everywhere without repeating an array literal: calling
+ * `unknownDecision()` with no arguments fails to compile.
+ */
+
+import type { Decision, UnknownReason } from "../../types.js";
+
+/** The action is blocked. */
+export function denied(
+  source: "exit-2" | "permission-decision",
+  exitCode: number,
+): Decision {
+  return { kind: "deny", source, exitCode };
+}
+
+/** Stdout JSON explicitly granted the action. */
+export function allowed(exitCode: number): Decision {
+  return { kind: "allow", exitCode };
+}
+
+/** No decision is present; the normal permission flow proceeds. */
+export function passed(exitCode: number): Decision {
+  return { kind: "pass", exitCode };
+}
+
+/** The outcome could not be turned into a decision at all. */
+export function errored(
+  exitCode: number,
+  cause: "nonzero-exit-without-json" | "invalid-json" | "schema-violation",
+): Decision {
+  return { kind: "error", exitCode, cause };
+}
+
+/**
+ * Build an `"unknown"` decision from at least one {@link UnknownReason}.
+ *
+ * @param first - The first reason nothing else could be asserted.
+ * @param rest - Any further reasons; a caller with several may pass them all.
+ */
+export function unknownDecision(
+  first: UnknownReason,
+  ...rest: UnknownReason[]
+): Decision {
+  return { kind: "unknown", reasons: [first, ...rest] };
+}

--- a/src/internal/decision/index.ts
+++ b/src/internal/decision/index.ts
@@ -1,0 +1,15 @@
+/**
+ * The decision vocabulary's own internal surface.
+ *
+ * @remarks
+ * `Decision`, `UnknownReason`, and `ExecOutcome` — the vocabulary itself —
+ * are published straight from `src/types.ts` and `src/index.ts`; what lives
+ * here is the machinery that produces a `Decision` (`factory.ts`,
+ * `resolve.ts`), which stays internal until a later executor issue's
+ * composition root wires it in. `src/cli.ts` is that composition root — see
+ * `spec/index.ts`'s doc comment for why nothing here is re-exported from
+ * `src/index.ts` in the meantime.
+ */
+
+export { allowed, denied, errored, passed, unknownDecision } from "./factory.js";
+export { exit2OverridesAllowJson, resolveDecision } from "./resolve.js";

--- a/src/internal/decision/resolve.ts
+++ b/src/internal/decision/resolve.ts
@@ -11,18 +11,49 @@
  * literals: the shipped spec documents at least one event (`WorktreeCreate`)
  * whose non-`2` exit code also blocks, so "exit 2 means deny" is only true
  * because that is what most events' `exitCodeEffects` happen to say, not
- * because `2` is special to this resolver.
+ * because `2` is special to this resolver. The JSON channel is gated the
+ * same way: whether a `permissionDecision`/`decision` value denies or allows
+ * is decided from the event's own `jsonDecisions`, never from `blockable` —
+ * `blockable` only ever describes the exit-code channel (it is defined as
+ * equal to `honorsExit2` for every one of the spec's 33 events), and several
+ * events (`PermissionRequest`, `PostToolUse`, `PostToolUseFailure`) deny
+ * exclusively through JSON while being `blockable: false`.
  */
 
 import type { Decision, EventName, ExecOutcome } from "../../types.js";
 import type { EventSpec, ExitCodeEffect, Spec } from "../spec/index.js";
 import { allowed, denied, errored, passed, unknownDecision } from "./factory.js";
 
-/** `permissionDecision` values that mean "block this action." */
-const DENY_VALUES: ReadonlySet<string> = new Set(["deny", "block"]);
+/**
+ * Words meaning "block this action," wherever an event's own `jsonDecisions`
+ * documents one of them.
+ */
+const DENY_SHAPED_WORDS: ReadonlySet<string> = new Set([
+  "deny",
+  "block",
+  "decline",
+  "cancel",
+]);
 
-/** `permissionDecision` values that mean "allow this action." */
-const ALLOW_VALUES: ReadonlySet<string> = new Set(["allow"]);
+/**
+ * Words meaning "allow this action," wherever an event's own `jsonDecisions`
+ * documents one of them.
+ */
+const ALLOW_SHAPED_WORDS: ReadonlySet<string> = new Set(["allow", "accept"]);
+
+/** The subset of `eventSpec.jsonDecisions` that are deny-shaped. */
+function denyValuesFor(eventSpec: EventSpec): ReadonlySet<string> {
+  return new Set(
+    eventSpec.jsonDecisions.filter((value) => DENY_SHAPED_WORDS.has(value)),
+  );
+}
+
+/** The subset of `eventSpec.jsonDecisions` that are allow-shaped. */
+function allowValuesFor(eventSpec: EventSpec): ReadonlySet<string> {
+  return new Set(
+    eventSpec.jsonDecisions.filter((value) => ALLOW_SHAPED_WORDS.has(value)),
+  );
+}
 
 function looksLikeJson(text: string): boolean {
   return text.startsWith("{") || text.startsWith("[");
@@ -32,6 +63,35 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Read the raw decision value out of a parsed stdout object, checking the
+ * locations Claude Code itself emits in order and returning the first one
+ * present:
+ *
+ * 1. `hookSpecificOutput.permissionDecision` — `PreToolUse`, `PermissionRequest`.
+ * 2. Top-level `decision` — the `jsonDecisions: ["block"]` events
+ *    (`UserPromptSubmit`, `Stop`, `PostToolUse`, ...).
+ * 3. Top-level `permissionDecision` — a fallback for any hook that emits the
+ *    field unnested.
+ *
+ * `undefined` means none of the three locations carry a value at all, which
+ * is not an error: a hook may validly emit JSON with no decision in it (a
+ * log line, a status payload).
+ */
+function readDecisionValue(record: Record<string, unknown>): unknown {
+  const hookSpecificOutput = record["hookSpecificOutput"];
+  if (isPlainRecord(hookSpecificOutput) && "permissionDecision" in hookSpecificOutput) {
+    return hookSpecificOutput["permissionDecision"];
+  }
+  if ("decision" in record) {
+    return record["decision"];
+  }
+  if ("permissionDecision" in record) {
+    return record["permissionDecision"];
+  }
+  return undefined;
+}
+
 type JsonDecision =
   | { readonly kind: "none" }
   | { readonly kind: "malformed" }
@@ -39,15 +99,13 @@ type JsonDecision =
   | { readonly kind: "decision"; readonly value: string };
 
 /**
- * Read a hook's stdout for a `permissionDecision` value valid for `event`.
+ * Read a hook's stdout for a decision value valid for `event`.
  *
  * @remarks
  * Only text that looks like JSON (`{`/`[`-prefixed after trimming) is even
  * attempted — most hooks print plain text and exit, and that is not an
  * error, since Claude Code itself only tries to parse stdout as JSON when it
- * looks like one. A JSON object with no `permissionDecision` key is
- * `"none"` too: a hook may validly emit JSON that carries no decision at
- * all (a log line, a status payload).
+ * looks like one.
  */
 function classifyJsonDecision(eventSpec: EventSpec, stdout: string): JsonDecision {
   const trimmed = stdout.trim();
@@ -62,16 +120,20 @@ function classifyJsonDecision(eventSpec: EventSpec, stdout: string): JsonDecisio
     return { kind: "malformed" };
   }
 
-  if (!isPlainRecord(parsed) || !("permissionDecision" in parsed)) {
+  if (!isPlainRecord(parsed)) {
     return { kind: "none" };
   }
 
-  const value = parsed["permissionDecision"];
-  if (typeof value !== "string" || !eventSpec.jsonDecisions.includes(value)) {
+  const raw = readDecisionValue(parsed);
+  if (raw === undefined) {
+    return { kind: "none" };
+  }
+
+  if (typeof raw !== "string" || !eventSpec.jsonDecisions.includes(raw)) {
     return { kind: "schema-violation" };
   }
 
-  return { kind: "decision", value };
+  return { kind: "decision", value: raw };
 }
 
 function findExitCodeEffect(
@@ -105,9 +167,9 @@ export function resolveDecision(
     // whose `EventName` union has drifted ahead of the spec file it loaded —
     // exactly what "unknown" exists to report rather than throw on.
     return unknownDecision({
-      kind: "version-out-of-spec-range",
-      detected: event,
-      specRange: spec.claudeCodeRange,
+      kind: "event-not-in-spec",
+      event,
+      specVersion: spec.specVersion,
     });
   }
 
@@ -124,26 +186,57 @@ export function resolveDecision(
     // still exit whatever code it wants regardless of what Claude Code
     // honors, so this is the check that keeps a spec/reality mismatch from
     // being promoted into a false deny for an event that cannot deny at all.
+    // The mismatch is the *spec entry* contradicting itself (`blockable:
+    // false` alongside a documented `block` effect), not the hook's own
+    // output, so it is reported as `unknown` rather than blamed on the hook
+    // as a `schema-violation`.
     return eventSpec.blockable
-      ? denied("exit-2", outcome.exitCode)
-      : errored(outcome.exitCode, "schema-violation");
+      ? denied("exit-code", outcome.exitCode)
+      : unknownDecision({
+          kind: "contradictory-exit-code-effect",
+          event,
+          exitCode: outcome.exitCode,
+        });
   }
 
   if (jsonDecision.kind === "decision") {
-    if (eventSpec.blockable && DENY_VALUES.has(jsonDecision.value)) {
+    // Gated on this event's own `jsonDecisions`, never on `blockable`:
+    // `classifyJsonDecision` already rejected any value outside
+    // `eventSpec.jsonDecisions` as a `schema-violation`, so by this point
+    // `jsonDecision.value` is one the event itself documents as a valid
+    // decision — including events such as `PermissionRequest` and
+    // `PostToolUse` that deny exclusively through this channel while being
+    // `blockable: false`.
+    if (denyValuesFor(eventSpec).has(jsonDecision.value)) {
       return denied("permission-decision", outcome.exitCode);
     }
-    if (ALLOW_VALUES.has(jsonDecision.value)) {
+    if (allowValuesFor(eventSpec).has(jsonDecision.value)) {
       return allowed(outcome.exitCode);
     }
-    // A recognized decision value that is neither deny/block nor allow (for
-    // example "ask" or "defer") hands the action back to Claude Code's own
-    // normal flow — hookassert has nothing more specific to assert.
+    // A documented decision value that is neither deny-shaped nor
+    // allow-shaped (for example `PreToolUse`'s "ask"/"defer") hands the
+    // action back to Claude Code's own normal flow — hookassert has nothing
+    // more specific to assert.
     return passed(outcome.exitCode);
   }
 
   if (jsonDecision.kind === "schema-violation") {
     return errored(outcome.exitCode, "schema-violation");
+  }
+
+  // Malformed JSON is reported here — above the "documented exit code"
+  // branch below — whenever the exit code is one Claude Code actually
+  // attaches meaning to (a successful `0`, or a `non-blocking-error`/
+  // `ignored` row this event documents): a hook whose JSON writer crashed
+  // mid-output should not be reported as a clean pass or a policy no-op just
+  // because its exit code was otherwise unremarkable. An undocumented
+  // nonzero exit code still falls through to `nonzero-exit-without-json`
+  // below, which already covers "no idea what this exit code means."
+  if (
+    jsonDecision.kind === "malformed" &&
+    (outcome.exitCode === 0 || effect !== undefined)
+  ) {
+    return errored(outcome.exitCode, "invalid-json");
   }
 
   if (effect !== undefined) {
@@ -155,9 +248,7 @@ export function resolveDecision(
   }
 
   if (outcome.exitCode === 0) {
-    return jsonDecision.kind === "malformed"
-      ? errored(outcome.exitCode, "invalid-json")
-      : passed(outcome.exitCode);
+    return passed(outcome.exitCode);
   }
 
   // A non-zero exit code the spec does not document for this event (neither
@@ -169,7 +260,7 @@ export function resolveDecision(
 /**
  * Whether `outcome` is the specific combination `resolveDecision` resolves
  * to `deny` despite stdout JSON saying `allow`: an `exit 2`-equivalent
- * block effect alongside an `allow` `permissionDecision`.
+ * block effect alongside an allow-shaped decision value.
  *
  * @remarks
  * `resolveDecision`'s return type is the closed `Decision` shape this
@@ -193,5 +284,8 @@ export function exit2OverridesAllowJson(
     return false;
   }
   const jsonDecision = classifyJsonDecision(eventSpec, outcome.stdout);
-  return jsonDecision.kind === "decision" && ALLOW_VALUES.has(jsonDecision.value);
+  return (
+    jsonDecision.kind === "decision" &&
+    allowValuesFor(eventSpec).has(jsonDecision.value)
+  );
 }

--- a/src/internal/decision/resolve.ts
+++ b/src/internal/decision/resolve.ts
@@ -1,0 +1,197 @@
+/**
+ * Maps a hook's raw exit code and stdout to the closed `Decision` vocabulary.
+ *
+ * @remarks
+ * Static layer: pure function, no I/O — `outcome` is a value the caller
+ * already obtained (a later executor issue's `Spawner`, or a test's stub),
+ * and `resolveDecision` never spawns anything itself.
+ *
+ * Every branch reads `spec.events[event]`'s own data (`blockable`,
+ * `jsonDecisions`, `exitCodeEffects`) rather than hard-coding exit-code
+ * literals: the shipped spec documents at least one event (`WorktreeCreate`)
+ * whose non-`2` exit code also blocks, so "exit 2 means deny" is only true
+ * because that is what most events' `exitCodeEffects` happen to say, not
+ * because `2` is special to this resolver.
+ */
+
+import type { Decision, EventName, ExecOutcome } from "../../types.js";
+import type { EventSpec, ExitCodeEffect, Spec } from "../spec/index.js";
+import { allowed, denied, errored, passed, unknownDecision } from "./factory.js";
+
+/** `permissionDecision` values that mean "block this action." */
+const DENY_VALUES: ReadonlySet<string> = new Set(["deny", "block"]);
+
+/** `permissionDecision` values that mean "allow this action." */
+const ALLOW_VALUES: ReadonlySet<string> = new Set(["allow"]);
+
+function looksLikeJson(text: string): boolean {
+  return text.startsWith("{") || text.startsWith("[");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type JsonDecision =
+  | { readonly kind: "none" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "schema-violation" }
+  | { readonly kind: "decision"; readonly value: string };
+
+/**
+ * Read a hook's stdout for a `permissionDecision` value valid for `event`.
+ *
+ * @remarks
+ * Only text that looks like JSON (`{`/`[`-prefixed after trimming) is even
+ * attempted — most hooks print plain text and exit, and that is not an
+ * error, since Claude Code itself only tries to parse stdout as JSON when it
+ * looks like one. A JSON object with no `permissionDecision` key is
+ * `"none"` too: a hook may validly emit JSON that carries no decision at
+ * all (a log line, a status payload).
+ */
+function classifyJsonDecision(eventSpec: EventSpec, stdout: string): JsonDecision {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0 || !looksLikeJson(trimmed)) {
+    return { kind: "none" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return { kind: "malformed" };
+  }
+
+  if (!isPlainRecord(parsed) || !("permissionDecision" in parsed)) {
+    return { kind: "none" };
+  }
+
+  const value = parsed["permissionDecision"];
+  if (typeof value !== "string" || !eventSpec.jsonDecisions.includes(value)) {
+    return { kind: "schema-violation" };
+  }
+
+  return { kind: "decision", value };
+}
+
+function findExitCodeEffect(
+  eventSpec: EventSpec,
+  exitCode: number,
+): ExitCodeEffect | undefined {
+  return eventSpec.exitCodeEffects.find((row) => row.exitCode === exitCode);
+}
+
+/**
+ * Map a hook's raw exit code and stdout to a {@link Decision}.
+ *
+ * @remarks
+ * A timed-out hook is never treated as a block: Claude Code does not honor a
+ * hook that never finished as an `exit 2`-equivalent signal, and asserting a
+ * deny that will not really happen in production is exactly the
+ * over-cautious failure mode this project exists to avoid alongside the
+ * under-cautious one.
+ */
+export function resolveDecision(
+  spec: Spec,
+  event: EventName,
+  outcome: ExecOutcome,
+): Decision {
+  const eventSpec = spec.events[event];
+  if (eventSpec === undefined) {
+    // `EventName`'s 33 members are kept in lockstep with `spec.events`'s keys
+    // (see src/types.ts's doc comment) and a real spec never omits one, but
+    // `noUncheckedIndexedAccess` still types this lookup as possibly
+    // undefined. The one way this genuinely fires is a hookassert build
+    // whose `EventName` union has drifted ahead of the spec file it loaded —
+    // exactly what "unknown" exists to report rather than throw on.
+    return unknownDecision({
+      kind: "version-out-of-spec-range",
+      detected: event,
+      specRange: spec.claudeCodeRange,
+    });
+  }
+
+  if (outcome.timedOut) {
+    return passed(outcome.exitCode);
+  }
+
+  const effect = findExitCodeEffect(eventSpec, outcome.exitCode);
+  const jsonDecision = classifyJsonDecision(eventSpec, outcome.stdout);
+
+  if (effect?.effect === "block") {
+    // Guarded on `blockable` even though the shipped spec never actually
+    // pairs a "block" effect with a non-blockable event: a hook process can
+    // still exit whatever code it wants regardless of what Claude Code
+    // honors, so this is the check that keeps a spec/reality mismatch from
+    // being promoted into a false deny for an event that cannot deny at all.
+    return eventSpec.blockable
+      ? denied("exit-2", outcome.exitCode)
+      : errored(outcome.exitCode, "schema-violation");
+  }
+
+  if (jsonDecision.kind === "decision") {
+    if (eventSpec.blockable && DENY_VALUES.has(jsonDecision.value)) {
+      return denied("permission-decision", outcome.exitCode);
+    }
+    if (ALLOW_VALUES.has(jsonDecision.value)) {
+      return allowed(outcome.exitCode);
+    }
+    // A recognized decision value that is neither deny/block nor allow (for
+    // example "ask" or "defer") hands the action back to Claude Code's own
+    // normal flow — hookassert has nothing more specific to assert.
+    return passed(outcome.exitCode);
+  }
+
+  if (jsonDecision.kind === "schema-violation") {
+    return errored(outcome.exitCode, "schema-violation");
+  }
+
+  if (effect !== undefined) {
+    // A documented, non-blocking exit code (`non-blocking-error` or
+    // `ignored`) with no JSON decision. This is the "exit 1 from a policy
+    // hook is a no-op" case: the hook's own exit code carries no weight for
+    // this event, so the action proceeds unchanged.
+    return passed(outcome.exitCode);
+  }
+
+  if (outcome.exitCode === 0) {
+    return jsonDecision.kind === "malformed"
+      ? errored(outcome.exitCode, "invalid-json")
+      : passed(outcome.exitCode);
+  }
+
+  // A non-zero exit code the spec does not document for this event (neither
+  // 1 nor 2) with no recognizable JSON decision: nothing tells us what the
+  // hook intended.
+  return errored(outcome.exitCode, "nonzero-exit-without-json");
+}
+
+/**
+ * Whether `outcome` is the specific combination `resolveDecision` resolves
+ * to `deny` despite stdout JSON saying `allow`: an `exit 2`-equivalent
+ * block effect alongside an `allow` `permissionDecision`.
+ *
+ * @remarks
+ * `resolveDecision`'s return type is the closed `Decision` shape this
+ * issue's design pins verbatim, which has no room for a side note on the
+ * `"deny"` variant it returns for this case. This predicate is the "side
+ * value the resolver exposes" that design calls for, so a later `report/`
+ * issue can render a dedicated warning instead of silently treating this
+ * deny the same as any other.
+ */
+export function exit2OverridesAllowJson(
+  spec: Spec,
+  event: EventName,
+  outcome: ExecOutcome,
+): boolean {
+  const eventSpec = spec.events[event];
+  if (eventSpec === undefined || outcome.timedOut) {
+    return false;
+  }
+  const effect = findExitCodeEffect(eventSpec, outcome.exitCode);
+  if (effect?.effect !== "block" || !eventSpec.blockable) {
+    return false;
+  }
+  const jsonDecision = classifyJsonDecision(eventSpec, outcome.stdout);
+  return jsonDecision.kind === "decision" && ALLOW_VALUES.has(jsonDecision.value);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,3 +144,161 @@ export interface ResolvedHook {
    */
   readonly dedupeKey: string;
 }
+
+/**
+ * A hook's raw exit code, stdout, stderr, and whether it timed out.
+ *
+ * @remarks
+ * The input the static decision resolver (`src/internal/decision/`) and the
+ * future executor's `Spawner` seam both speak: whatever actually spawns a
+ * hook produces one of these, and the decision resolver consumes it without
+ * ever spawning anything itself.
+ *
+ * @public
+ */
+export interface ExecOutcome {
+  /** The process's exit status. */
+  readonly exitCode: number;
+
+  /** Everything the hook wrote to stdout. */
+  readonly stdout: string;
+
+  /** Everything the hook wrote to stderr. */
+  readonly stderr: string;
+
+  /** Whether the hook was killed for exceeding its deadline. */
+  readonly timedOut: boolean;
+}
+
+/**
+ * Which mechanism a version probe tried, and failed, to read Claude Code's
+ * own version from.
+ *
+ * @remarks
+ * Named here only because {@link UnknownReason}'s `"version-undetermined"`
+ * member needs a closed vocabulary for `triedSources` — nothing in
+ * `src/internal/decision/` actually produces that reason today. Probing
+ * Claude Code's version at runtime is a later executor issue's job; this is
+ * the vocabulary that probe reports against, extended there if it needs a
+ * source this issue did not anticipate.
+ *
+ * @public
+ */
+export type VersionSourceName =
+  "cli-flag" | "environment-variable" | "package-manifest";
+
+/**
+ * A reason the decision resolver could not assert a {@link Decision} with
+ * confidence.
+ *
+ * @public
+ */
+export type UnknownReason =
+  | {
+      /** The detected Claude Code version falls outside the loaded spec's `claudeCodeRange`, so its documented behavior cannot be trusted for this run. */
+      readonly kind: "version-out-of-spec-range";
+      /** The Claude Code version that was actually detected. */
+      readonly detected: string;
+      /** The loaded spec's own `claudeCodeRange`, which `detected` falls outside of. */
+      readonly specRange: string;
+    }
+  | {
+      /** No probe could determine which Claude Code version is running at all. */
+      readonly kind: "version-undetermined";
+      /** Every {@link VersionSourceName} a probe tried before giving up. */
+      readonly triedSources: readonly VersionSourceName[];
+    }
+  | {
+      /**
+       * The event's JSON payload shape has never been confirmed against a
+       * live Claude Code instance (`spec.events[event].payloadShape.verified
+       * === false`), so a payload-shaped assertion about it cannot be
+       * trusted.
+       */
+      readonly kind: "payload-shape-unverified";
+      /** The event whose payload shape is unverified. */
+      readonly event: EventName;
+      /** The loaded spec's own `specVersion`. */
+      readonly specVersion: string;
+    }
+  | {
+      /** One or more plugin-declared hook files exist that hookassert has not read, so the effective hook set is incomplete. */
+      readonly kind: "plugin-hooks-present";
+      /** Absolute paths of the unread plugin hook files. */
+      readonly files: readonly string[];
+    }
+  | {
+      /** A managed settings file was treated as present without being able to confirm it, because reading it is outside hookassert's reach. */
+      readonly kind: "managed-settings-assumed";
+      /** Absolute path of the assumed managed settings file. */
+      readonly path: string;
+    };
+
+/**
+ * The closed vocabulary a hook's raw exit code and stdout resolve to.
+ *
+ * @remarks
+ * Constructed only through `src/internal/decision/factory.ts`'s functions —
+ * see that module's own doc comment — never by writing one of these object
+ * shapes out at a call site.
+ *
+ * @public
+ */
+export type Decision =
+  | {
+      /**
+       * The action is blocked, either because the hook exited with the
+       * event's documented block-effect exit code (`source: "exit-2"`) or
+       * because its stdout JSON carried a recognized deny/block
+       * `permissionDecision` on a blockable event (`source:
+       * "permission-decision"`).
+       */
+      readonly kind: "deny";
+      /** Which channel produced the deny. */
+      readonly source: "exit-2" | "permission-decision";
+      /** The hook's raw exit code. */
+      readonly exitCode: number;
+    }
+  | {
+      /** Stdout JSON explicitly granted the action. */
+      readonly kind: "allow";
+      /** The hook's raw exit code. */
+      readonly exitCode: number;
+    }
+  | {
+      /**
+       * No decision is present; the normal permission flow proceeds
+       * unchanged. This is the required outcome for a hook that exits a
+       * non-blocking code while intending to act as a policy check: exiting
+       * `1` to "block" is a no-op, not a deny, and `"pass"` is what carries
+       * that fact forward truthfully rather than mislabeling it a failed
+       * block.
+       */
+      readonly kind: "pass";
+      /** The hook's raw exit code. */
+      readonly exitCode: number;
+    }
+  | {
+      /** The outcome could not be turned into a decision at all. */
+      readonly kind: "error";
+      /** The hook's raw exit code. */
+      readonly exitCode: number;
+      /**
+       * `"nonzero-exit-without-json"` — a non-zero, non-documented exit with
+       * no recognizable JSON on stdout.
+       * `"invalid-json"` — stdout looked like JSON and failed to parse.
+       * `"schema-violation"` — stdout parsed but its decision value is not
+       * one the event documents.
+       */
+      readonly cause: "nonzero-exit-without-json" | "invalid-json" | "schema-violation";
+    }
+  | {
+      /**
+       * Nothing above can be asserted; `reasons` is a non-empty tuple, so an
+       * `unknown` without at least one {@link UnknownReason} cannot be
+       * constructed, at the type level, by any call site.
+       */
+      readonly kind: "unknown";
+      /** Every reason nothing more specific could be asserted. */
+      readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+    };

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,22 @@ export type UnknownReason =
       readonly kind: "managed-settings-assumed";
       /** Absolute path of the assumed managed settings file. */
       readonly path: string;
+    }
+  | {
+      /** `event` has no entry in the loaded spec's `events` map, so nothing about its documented behavior can be read — a hookassert build whose `EventName` union has drifted ahead of the spec file it loaded. */
+      readonly kind: "event-not-in-spec";
+      /** The event with no corresponding entry in the loaded spec. */
+      readonly event: EventName;
+      /** The loaded spec's own `specVersion`. */
+      readonly specVersion: string;
+    }
+  | {
+      /** The loaded spec documents a `block` effect for `exitCode` on `event` while also declaring `event` not `blockable` — the spec entry contradicts itself, so the hook's own output cannot be blamed for it. */
+      readonly kind: "contradictory-exit-code-effect";
+      /** The event whose spec entry contradicts itself. */
+      readonly event: EventName;
+      /** The exit code whose documented `block` effect the event's own `blockable: false` contradicts. */
+      readonly exitCode: number;
     };
 
 /**
@@ -248,14 +264,14 @@ export type Decision =
   | {
       /**
        * The action is blocked, either because the hook exited with the
-       * event's documented block-effect exit code (`source: "exit-2"`) or
-       * because its stdout JSON carried a recognized deny/block
-       * `permissionDecision` on a blockable event (`source:
+       * event's documented block-effect exit code (`source: "exit-code"`) or
+       * because its stdout JSON carried a recognized deny-shaped decision
+       * value on that event's own `jsonDecisions` (`source:
        * "permission-decision"`).
        */
       readonly kind: "deny";
       /** Which channel produced the deny. */
-      readonly source: "exit-2" | "permission-decision";
+      readonly source: "exit-code" | "permission-decision";
       /** The hook's raw exit code. */
       readonly exitCode: number;
     }

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -1,0 +1,402 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  allowed,
+  denied,
+  errored,
+  exit2OverridesAllowJson,
+  passed,
+  resolveDecision,
+  unknownDecision,
+} from "../src/internal/decision/index.js";
+import type { EventSpec, Spec } from "../src/internal/spec/index.js";
+import { loadSpecFile } from "../src/internal/spec/index.js";
+import type { Decision, EventName, ExecOutcome, UnknownReason } from "../src/types.js";
+
+// Reaching src/internal/decision/ and src/internal/spec/ directly (rather
+// than through src/index.ts's exports, per the writing-tests skill) is a
+// deliberate, narrowly scoped exception: neither module has a public runtime
+// surface in this issue and won't have one until a later executor issue's
+// composition root wires them in — see eslint.config.mjs's
+// "tests/static-layer-unit-tests" block for the full reasoning. The
+// *published types* (`Decision`, `UnknownReason`, `ExecOutcome`) are already
+// part of the public contract, so those come from "../src/types.js" like any
+// other type test's imports.
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
+const spec = loadSpecFile(REAL_SPEC_PATH);
+
+function makeOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
+  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
+}
+
+/** `spec` with `event`'s own entry removed entirely, for the "spec/EventName drift" cases. */
+function specWithoutEvent(base: Spec, event: EventName): Spec {
+  const events = Object.fromEntries(
+    Object.entries(base.events).filter(([name]) => name !== event),
+  );
+  return { ...base, events };
+}
+
+/** `spec` with `event`'s entry replaced by one that contradicts its real data. */
+function specWithOverriddenEvent(
+  base: Spec,
+  event: EventName,
+  overrides: Partial<EventSpec>,
+): Spec {
+  const current = base.events[event];
+  if (current === undefined) {
+    throw new Error(`fixture setup: spec is missing ${event}`);
+  }
+  return { ...base, events: { ...base.events, [event]: { ...current, ...overrides } } };
+}
+
+/**
+ * Every (event, exitCodeEffects row) pair the real spec declares, flattened
+ * for `it.each`. Built from the loaded spec rather than hand-transcribed, on
+ * purpose: this is the table `resolveDecision` must agree with, not a value
+ * it computes the same way it does internally.
+ */
+const exitCodeEffectCases = Object.entries(spec.events).flatMap(([event, eventSpec]) =>
+  eventSpec.exitCodeEffects.map((effect) => ({
+    event: event as EventName,
+    exitCode: effect.exitCode,
+    effect: effect.effect,
+  })),
+);
+
+describe("resolveDecision: every event's documented exitCodeEffects", () => {
+  it.each(exitCodeEffectCases)(
+    "$event exitCode $exitCode ($effect) resolves to the matching Decision.kind",
+    ({ event, exitCode, effect }) => {
+      const outcome = makeOutcome({ exitCode });
+      const decision = resolveDecision(spec, event, outcome);
+      const expectedKind = effect === "block" ? "deny" : "pass";
+      expect(decision.kind).toBe(expectedKind);
+    },
+  );
+});
+
+describe("table-health: the generated exitCodeEffects cases are not empty", () => {
+  it("every event has at least one exitCodeEffects row", () => {
+    for (const [name, eventSpec] of Object.entries(spec.events)) {
+      expect(
+        eventSpec.exitCodeEffects.length,
+        `${name} has no exitCodeEffects rows`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("the generated it.each table covers every event in the spec", () => {
+    const coveredEvents = new Set(
+      exitCodeEffectCases.map((testCase) => testCase.event),
+    );
+    for (const name of Object.keys(spec.events)) {
+      expect(
+        coveredEvents.has(name as EventName),
+        `${name} has no generated test case`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("a policy hook that exits 1 resolves to pass, not deny", () => {
+  it("PreToolUse exiting 1 is a no-op, not a block", () => {
+    const decision = resolveDecision(spec, "PreToolUse", makeOutcome({ exitCode: 1 }));
+    expect(decision.kind).toBe("pass");
+    if (decision.kind === "pass") {
+      expect(decision.exitCode).toBe(1);
+    }
+  });
+});
+
+describe("exit 2 vs. an allow JSON payload", () => {
+  it("exit 2 overrides an allow JSON payload and resolves to deny, with the override detectable on the result", () => {
+    const outcome = makeOutcome({
+      exitCode: 2,
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("deny");
+    if (decision.kind === "deny") {
+      expect(decision.source).toBe("exit-2");
+    }
+    expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(true);
+  });
+
+  it("an allow JSON payload without exit 2 resolves to allow, with no override", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("allow");
+    expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(false);
+  });
+
+  it("exit 2 with no JSON payload denies without an override", () => {
+    const outcome = makeOutcome({ exitCode: 2 });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("deny");
+    expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(false);
+  });
+
+  it("exit2OverridesAllowJson is false when the outcome did not exit 2", () => {
+    const outcome = makeOutcome({
+      exitCode: 1,
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(false);
+  });
+
+  it("exit2OverridesAllowJson is false for an undocumented exit code", () => {
+    expect(
+      exit2OverridesAllowJson(spec, "PreToolUse", makeOutcome({ exitCode: 42 })),
+    ).toBe(false);
+  });
+
+  it("exit2OverridesAllowJson is false when the hook timed out", () => {
+    const outcome = makeOutcome({
+      exitCode: 2,
+      timedOut: true,
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(false);
+  });
+
+  it("exit2OverridesAllowJson is false when the spec is missing the event", () => {
+    const incompleteSpec = specWithoutEvent(spec, "PreToolUse");
+    const outcome = makeOutcome({
+      exitCode: 2,
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    expect(exit2OverridesAllowJson(incompleteSpec, "PreToolUse", outcome)).toBe(false);
+  });
+});
+
+describe("a JSON permissionDecision denies on a blockable event even without exit 2", () => {
+  it("PreToolUse exiting 0 with a deny JSON payload still resolves to deny", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: "deny" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("deny");
+    if (decision.kind === "deny") {
+      expect(decision.source).toBe("permission-decision");
+    }
+  });
+});
+
+describe("a timed-out PreToolUse hook does not resolve to deny", () => {
+  it("timing out is not the same as exit 2", () => {
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: 2, timedOut: true }),
+    );
+    expect(decision.kind).not.toBe("deny");
+    expect(decision.kind).toBe("pass");
+  });
+});
+
+describe("a non-zero, non-2 exit with no valid JSON resolves to error", () => {
+  it.each([
+    ["malformed JSON-looking stdout", "{not valid json"],
+    ["empty stdout", ""],
+  ])(
+    "exitCode 127 with %s resolves to error/nonzero-exit-without-json",
+    (_label, stdout) => {
+      const decision = resolveDecision(
+        spec,
+        "PreToolUse",
+        makeOutcome({ exitCode: 127, stdout }),
+      );
+      expect(decision.kind).toBe("error");
+      if (decision.kind === "error") {
+        expect(decision.cause).toBe("nonzero-exit-without-json");
+      }
+    },
+  );
+});
+
+describe("stdout JSON that fails schema validation resolves to error with cause schema-violation", () => {
+  it("a permissionDecision value the event does not document", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: "maybe" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("schema-violation");
+    }
+  });
+
+  it("a permissionDecision value that is not a string", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: 1 }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("schema-violation");
+    }
+  });
+});
+
+describe("exit 0 with malformed JSON-looking stdout resolves to error with cause invalid-json", () => {
+  it("a successful exit that tried and failed to emit JSON", () => {
+    const outcome = makeOutcome({ exitCode: 0, stdout: "{not valid json" });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("invalid-json");
+    }
+  });
+});
+
+describe("PostToolUse never resolves to deny even given exitCode 2", () => {
+  it("PostToolUse is not blockable, and the real spec agrees exit 2 is non-blocking for it", () => {
+    const decision = resolveDecision(spec, "PostToolUse", makeOutcome({ exitCode: 2 }));
+    expect(decision.kind).not.toBe("deny");
+    expect(decision.kind).toBe("pass");
+  });
+
+  it("treats a block effect on a non-blockable event as a contract violation, not a deny", () => {
+    // The shipped spec never actually pairs a "block" effect with a
+    // non-blockable event, so this exercises resolveDecision's defensive
+    // guard directly with a hand-built, self-contradictory event entry.
+    const contradictorySpec = specWithOverriddenEvent(spec, "PostToolUse", {
+      blockable: false,
+      exitCodeEffects: [{ exitCode: 2, effect: "block", stderrTo: "user" }],
+    });
+    const decision = resolveDecision(
+      contradictorySpec,
+      "PostToolUse",
+      makeOutcome({ exitCode: 2 }),
+    );
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("schema-violation");
+    }
+  });
+});
+
+describe("JSON decisions outside deny/allow fall through to the normal flow", () => {
+  it("a recognized decision value that is neither deny/block nor allow resolves to pass", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: "ask" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("pass");
+  });
+
+  it("a block permissionDecision on a non-blockable event resolves to pass, not deny", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ permissionDecision: "block" }),
+    });
+    const decision = resolveDecision(spec, "PostToolUse", outcome);
+    expect(decision.kind).toBe("pass");
+  });
+
+  it("valid JSON with no permissionDecision key resolves to pass, not an error", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({ foo: "bar" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("pass");
+  });
+
+  it("a JSON array on stdout resolves to pass, not schema-violation", () => {
+    const outcome = makeOutcome({ exitCode: 0, stdout: "[1,2,3]" });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("pass");
+  });
+
+  it("exit 0 with empty stdout resolves to pass", () => {
+    const decision = resolveDecision(spec, "PreToolUse", makeOutcome({ exitCode: 0 }));
+    expect(decision.kind).toBe("pass");
+    if (decision.kind === "pass") {
+      expect(decision.exitCode).toBe(0);
+    }
+  });
+});
+
+describe("resolveDecision when the loaded spec and EventName have drifted apart", () => {
+  it("returns unknown/version-out-of-spec-range rather than throwing", () => {
+    const incompleteSpec = specWithoutEvent(spec, "PostToolUse");
+    const decision = resolveDecision(incompleteSpec, "PostToolUse", makeOutcome());
+    expect(decision.kind).toBe("unknown");
+    if (decision.kind === "unknown") {
+      expect(decision.reasons[0]).toEqual({
+        kind: "version-out-of-spec-range",
+        detected: "PostToolUse",
+        specRange: spec.claudeCodeRange,
+      });
+    }
+  });
+});
+
+describe("unknownDecision requires at least one UnknownReason", () => {
+  it("unknownDecision(reason) builds a decision carrying exactly that reason", () => {
+    const reason: UnknownReason = {
+      kind: "plugin-hooks-present",
+      files: ["/home/dev/project/.claude-plugin/hooks.json"],
+    };
+    const decision = unknownDecision(reason);
+    expect(decision).toEqual({ kind: "unknown", reasons: [reason] });
+  });
+
+  it("unknownDecision(first, ...rest) carries every reason passed to it", () => {
+    const first: UnknownReason = {
+      kind: "managed-settings-assumed",
+      path: "/etc/claude-code/managed-settings.json",
+    };
+    const second: UnknownReason = {
+      kind: "version-undetermined",
+      triedSources: ["cli-flag", "environment-variable"],
+    };
+    const decision = unknownDecision(first, second);
+    expect(decision).toEqual({ kind: "unknown", reasons: [first, second] });
+  });
+});
+
+describe("factory functions build exactly the Decision shape they name", () => {
+  it("denied carries its source and exit code", () => {
+    const bySource: Record<"exit-2" | "permission-decision", Decision> = {
+      "exit-2": denied("exit-2", 2),
+      "permission-decision": denied("permission-decision", 0),
+    };
+    expect(bySource["exit-2"]).toEqual({ kind: "deny", source: "exit-2", exitCode: 2 });
+    expect(bySource["permission-decision"]).toEqual({
+      kind: "deny",
+      source: "permission-decision",
+      exitCode: 0,
+    });
+  });
+
+  it("allowed carries its exit code", () => {
+    expect(allowed(0)).toEqual({ kind: "allow", exitCode: 0 });
+  });
+
+  it("passed carries its exit code", () => {
+    expect(passed(1)).toEqual({ kind: "pass", exitCode: 1 });
+  });
+
+  it("errored carries its exit code and cause", () => {
+    expect(errored(127, "nonzero-exit-without-json")).toEqual({
+      kind: "error",
+      exitCode: 127,
+      cause: "nonzero-exit-without-json",
+    });
+  });
+});

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -123,7 +123,7 @@ describe("exit 2 vs. an allow JSON payload", () => {
     const decision = resolveDecision(spec, "PreToolUse", outcome);
     expect(decision.kind).toBe("deny");
     if (decision.kind === "deny") {
-      expect(decision.source).toBe("exit-2");
+      expect(decision.source).toBe("exit-code");
     }
     expect(exit2OverridesAllowJson(spec, "PreToolUse", outcome)).toBe(true);
   });
@@ -261,6 +261,35 @@ describe("exit 0 with malformed JSON-looking stdout resolves to error with cause
   });
 });
 
+describe("malformed JSON is not swallowed by a documented non-blocking exit code", () => {
+  it("PreToolUse exit 1 with malformed stdout resolves to error/invalid-json, not pass", () => {
+    // exit 1 is PreToolUse's documented `non-blocking-error` exit code: a
+    // hook whose JSON writer crashed mid-output while still exiting 1 must
+    // not be reported as a clean policy no-op.
+    const outcome = makeOutcome({ exitCode: 1, stdout: "{oops" });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("invalid-json");
+    }
+  });
+
+  it("an undocumented nonzero exit with malformed stdout still resolves to nonzero-exit-without-json", () => {
+    // Contrast with the case above: an exit code the spec says nothing
+    // about at all keeps its existing "no idea what this exit code means"
+    // cause rather than being reinterpreted as an invalid-JSON failure.
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: 127, stdout: "{oops" }),
+    );
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("nonzero-exit-without-json");
+    }
+  });
+});
+
 describe("PostToolUse never resolves to deny even given exitCode 2", () => {
   it("PostToolUse is not blockable, and the real spec agrees exit 2 is non-blocking for it", () => {
     const decision = resolveDecision(spec, "PostToolUse", makeOutcome({ exitCode: 2 }));
@@ -268,10 +297,14 @@ describe("PostToolUse never resolves to deny even given exitCode 2", () => {
     expect(decision.kind).toBe("pass");
   });
 
-  it("treats a block effect on a non-blockable event as a contract violation, not a deny", () => {
+  it("treats a block effect on a non-blockable event as a spec contradiction, not the hook's fault", () => {
     // The shipped spec never actually pairs a "block" effect with a
     // non-blockable event, so this exercises resolveDecision's defensive
-    // guard directly with a hand-built, self-contradictory event entry.
+    // guard directly with a hand-built, self-contradictory event entry. The
+    // spec entry is what is wrong here, not the hook's own JSON, so this
+    // resolves to `unknown` rather than `error/schema-violation` — that
+    // cause is reserved for a hook's own output failing to match what the
+    // event documents.
     const contradictorySpec = specWithOverriddenEvent(spec, "PostToolUse", {
       blockable: false,
       exitCodeEffects: [{ exitCode: 2, effect: "block", stderrTo: "user" }],
@@ -281,9 +314,13 @@ describe("PostToolUse never resolves to deny even given exitCode 2", () => {
       "PostToolUse",
       makeOutcome({ exitCode: 2 }),
     );
-    expect(decision.kind).toBe("error");
-    if (decision.kind === "error") {
-      expect(decision.cause).toBe("schema-violation");
+    expect(decision.kind).toBe("unknown");
+    if (decision.kind === "unknown") {
+      expect(decision.reasons[0]).toEqual({
+        kind: "contradictory-exit-code-effect",
+        event: "PostToolUse",
+        exitCode: 2,
+      });
     }
   });
 });
@@ -295,15 +332,6 @@ describe("JSON decisions outside deny/allow fall through to the normal flow", ()
       stdout: JSON.stringify({ permissionDecision: "ask" }),
     });
     const decision = resolveDecision(spec, "PreToolUse", outcome);
-    expect(decision.kind).toBe("pass");
-  });
-
-  it("a block permissionDecision on a non-blockable event resolves to pass, not deny", () => {
-    const outcome = makeOutcome({
-      exitCode: 0,
-      stdout: JSON.stringify({ permissionDecision: "block" }),
-    });
-    const decision = resolveDecision(spec, "PostToolUse", outcome);
     expect(decision.kind).toBe("pass");
   });
 
@@ -331,16 +359,122 @@ describe("JSON decisions outside deny/allow fall through to the normal flow", ()
   });
 });
 
+describe("the JSON decision channel is gated on jsonDecisions, not blockable", () => {
+  it("PermissionRequest denies via JSON despite being blockable: false", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({ permissionDecision: "deny" }),
+    });
+    const decision = resolveDecision(spec, "PermissionRequest", outcome);
+    expect(decision.kind).toBe("deny");
+    if (decision.kind === "deny") {
+      expect(decision.source).toBe("permission-decision");
+    }
+  });
+
+  it("PermissionRequest allows via JSON despite being blockable: false", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    const decision = resolveDecision(spec, "PermissionRequest", outcome);
+    expect(decision.kind).toBe("allow");
+  });
+
+  it.each([["PostToolUse"], ["PostToolUseFailure"]] as const)(
+    '%s denies via a top-level `decision: "block"` payload despite being blockable: false',
+    (event) => {
+      const outcome = makeOutcome({
+        stdout: JSON.stringify({ decision: "block", reason: "policy violation" }),
+      });
+      const decision = resolveDecision(spec, event, outcome);
+      expect(decision.kind).toBe("deny");
+      if (decision.kind === "deny") {
+        expect(decision.source).toBe("permission-decision");
+      }
+    },
+  );
+});
+
+describe("the decision value is read from hookSpecificOutput.permissionDecision, top-level decision, or top-level permissionDecision, in that order", () => {
+  it("reads hookSpecificOutput.permissionDecision for PreToolUse", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({
+        hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "deny" },
+      }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("deny");
+  });
+
+  it("reads a top-level decision when hookSpecificOutput carries no permissionDecision", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({ decision: "block" }),
+    });
+    const decision = resolveDecision(spec, "Stop", outcome);
+    expect(decision.kind).toBe("deny");
+  });
+
+  it("falls back to a top-level permissionDecision when neither of the other two locations is present", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({ permissionDecision: "allow" }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("allow");
+  });
+
+  it("prefers hookSpecificOutput.permissionDecision over a conflicting top-level decision", () => {
+    const outcome = makeOutcome({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+        },
+        decision: "block",
+      }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("allow");
+  });
+
+  it("falls through to top-level decision when hookSpecificOutput is present but carries no permissionDecision key", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({
+        hookSpecificOutput: { hookEventName: "PreToolUse" },
+        decision: "deny",
+      }),
+    });
+    const decision = resolveDecision(spec, "PreToolUse", outcome);
+    expect(decision.kind).toBe("deny");
+  });
+});
+
+describe("deny-shaped and allow-shaped jsonDecisions values are derived per event", () => {
+  it.each([
+    ["accept", "allow"],
+    ["decline", "deny"],
+    ["cancel", "deny"],
+  ] as const)(
+    "Elicitation permissionDecision %s resolves to %s",
+    (value, expectedKind) => {
+      const outcome = makeOutcome({
+        stdout: JSON.stringify({ permissionDecision: value }),
+      });
+      const decision = resolveDecision(spec, "Elicitation", outcome);
+      expect(decision.kind).toBe(expectedKind);
+    },
+  );
+});
+
 describe("resolveDecision when the loaded spec and EventName have drifted apart", () => {
-  it("returns unknown/version-out-of-spec-range rather than throwing", () => {
+  it("returns unknown/event-not-in-spec rather than throwing", () => {
     const incompleteSpec = specWithoutEvent(spec, "PostToolUse");
     const decision = resolveDecision(incompleteSpec, "PostToolUse", makeOutcome());
     expect(decision.kind).toBe("unknown");
     if (decision.kind === "unknown") {
       expect(decision.reasons[0]).toEqual({
-        kind: "version-out-of-spec-range",
-        detected: "PostToolUse",
-        specRange: spec.claudeCodeRange,
+        kind: "event-not-in-spec",
+        event: "PostToolUse",
+        specVersion: spec.specVersion,
       });
     }
   });
@@ -372,11 +506,15 @@ describe("unknownDecision requires at least one UnknownReason", () => {
 
 describe("factory functions build exactly the Decision shape they name", () => {
   it("denied carries its source and exit code", () => {
-    const bySource: Record<"exit-2" | "permission-decision", Decision> = {
-      "exit-2": denied("exit-2", 2),
+    const bySource: Record<"exit-code" | "permission-decision", Decision> = {
+      "exit-code": denied("exit-code", 2),
       "permission-decision": denied("permission-decision", 0),
     };
-    expect(bySource["exit-2"]).toEqual({ kind: "deny", source: "exit-2", exitCode: 2 });
+    expect(bySource["exit-code"]).toEqual({
+      kind: "deny",
+      source: "exit-code",
+      exitCode: 2,
+    });
     expect(bySource["permission-decision"]).toEqual({
       kind: "deny",
       source: "permission-decision",

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type {
+  Decision,
   EventName,
+  ExecOutcome,
   Provenance,
   ResolvedHook,
   SettingsLayer,
+  UnknownReason,
+  VersionSourceName,
 } from "../src/index.js";
 
 // These are compile-time assertions about the public surface. They run under
@@ -179,6 +183,197 @@ describe("ResolvedHook", () => {
         dedupeKey: "k",
       };
       void hook;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+});
+
+describe("VersionSourceName", () => {
+  it("is the closed set a version probe can report having tried", () => {
+    expectTypeOf<VersionSourceName>().toEqualTypeOf<
+      "cli-flag" | "environment-variable" | "package-manifest"
+    >();
+  });
+
+  it("rejects a source name outside the closed set", () => {
+    const rejected = (): void => {
+      // @ts-expect-error not one of the three sources this issue names
+      const source: VersionSourceName = "registry-lookup";
+      void source;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+});
+
+describe("UnknownReason", () => {
+  it("narrows on kind to each variant's own fields", () => {
+    const narrow = (reason: UnknownReason): void => {
+      switch (reason.kind) {
+        case "version-out-of-spec-range": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "version-out-of-spec-range";
+            readonly detected: string;
+            readonly specRange: string;
+          }>();
+          break;
+        }
+        case "version-undetermined": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "version-undetermined";
+            readonly triedSources: readonly VersionSourceName[];
+          }>();
+          break;
+        }
+        case "payload-shape-unverified": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "payload-shape-unverified";
+            readonly event: EventName;
+            readonly specVersion: string;
+          }>();
+          break;
+        }
+        case "plugin-hooks-present": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "plugin-hooks-present";
+            readonly files: readonly string[];
+          }>();
+          break;
+        }
+        case "managed-settings-assumed": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "managed-settings-assumed";
+            readonly path: string;
+          }>();
+          break;
+        }
+      }
+    };
+    narrow({
+      kind: "version-out-of-spec-range",
+      detected: "2.1.0",
+      specRange: ">=2.1.251",
+    });
+    narrow({ kind: "version-undetermined", triedSources: ["cli-flag"] });
+    narrow({
+      kind: "payload-shape-unverified",
+      event: "PreToolUse",
+      specVersion: "1.0.0",
+    });
+    narrow({ kind: "plugin-hooks-present", files: [] });
+    narrow({ kind: "managed-settings-assumed", path: "/etc/managed.json" });
+  });
+
+  it("rejects an event name outside EventName in payload-shape-unverified", () => {
+    const rejected = (): void => {
+      const reason: UnknownReason = {
+        kind: "payload-shape-unverified",
+        // @ts-expect-error an undocumented event name is not a valid EventName
+        event: "BeforeToolUse",
+        specVersion: "1.0.0",
+      };
+      void reason;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+});
+
+describe("Decision", () => {
+  it("narrows on kind to each variant's own fields", () => {
+    const narrow = (decision: Decision): void => {
+      switch (decision.kind) {
+        case "deny": {
+          expectTypeOf(decision).toEqualTypeOf<{
+            readonly kind: "deny";
+            readonly source: "exit-2" | "permission-decision";
+            readonly exitCode: number;
+          }>();
+          break;
+        }
+        case "allow": {
+          expectTypeOf(decision).toEqualTypeOf<{
+            readonly kind: "allow";
+            readonly exitCode: number;
+          }>();
+          break;
+        }
+        case "pass": {
+          expectTypeOf(decision).toEqualTypeOf<{
+            readonly kind: "pass";
+            readonly exitCode: number;
+          }>();
+          break;
+        }
+        case "error": {
+          expectTypeOf(decision).toEqualTypeOf<{
+            readonly kind: "error";
+            readonly exitCode: number;
+            readonly cause:
+              "nonzero-exit-without-json" | "invalid-json" | "schema-violation";
+          }>();
+          break;
+        }
+        case "unknown": {
+          expectTypeOf(decision).toEqualTypeOf<{
+            readonly kind: "unknown";
+            readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+          }>();
+          break;
+        }
+      }
+    };
+    narrow({ kind: "deny", source: "exit-2", exitCode: 2 });
+    narrow({ kind: "allow", exitCode: 0 });
+    narrow({ kind: "pass", exitCode: 1 });
+    narrow({ kind: "error", exitCode: 127, cause: "nonzero-exit-without-json" });
+    narrow({
+      kind: "unknown",
+      reasons: [{ kind: "plugin-hooks-present", files: [] }],
+    });
+  });
+
+  it("rejects a deny variant missing its source", () => {
+    const rejected = (): void => {
+      // @ts-expect-error a deny decision must say which channel produced it
+      const decision: Decision = { kind: "deny", exitCode: 2 };
+      void decision;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("unknownDecision requires at least one UnknownReason: reasons rejects an empty array at compile time", () => {
+    const rejected = (): void => {
+      // @ts-expect-error reasons is a non-empty tuple, not a plain array — an empty array cannot construct it
+      const decision: Decision = { kind: "unknown", reasons: [] };
+      void decision;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("accepts an unknown variant with exactly one reason", () => {
+    const reason: UnknownReason = { kind: "plugin-hooks-present", files: [] };
+    const decision: Decision = { kind: "unknown", reasons: [reason] };
+    expectTypeOf(decision.reasons).toEqualTypeOf<
+      readonly [UnknownReason, ...UnknownReason[]]
+    >();
+  });
+});
+
+describe("ExecOutcome", () => {
+  it("requires exitCode, stdout, stderr, timedOut with no optional fields", () => {
+    expectTypeOf<ExecOutcome>().toEqualTypeOf<{
+      readonly exitCode: number;
+      readonly stdout: string;
+      readonly stderr: string;
+      readonly timedOut: boolean;
+    }>();
+    expectTypeOf<Required<ExecOutcome>>().toEqualTypeOf<ExecOutcome>();
+  });
+
+  it("rejects an outcome missing timedOut", () => {
+    const rejected = (): void => {
+      // @ts-expect-error every field is required, including timedOut
+      const outcome: ExecOutcome = { exitCode: 0, stdout: "", stderr: "" };
+      void outcome;
     };
     expect(rejected).toBeTypeOf("function");
   });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -246,6 +246,22 @@ describe("UnknownReason", () => {
           }>();
           break;
         }
+        case "event-not-in-spec": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "event-not-in-spec";
+            readonly event: EventName;
+            readonly specVersion: string;
+          }>();
+          break;
+        }
+        case "contradictory-exit-code-effect": {
+          expectTypeOf(reason).toEqualTypeOf<{
+            readonly kind: "contradictory-exit-code-effect";
+            readonly event: EventName;
+            readonly exitCode: number;
+          }>();
+          break;
+        }
       }
     };
     narrow({
@@ -261,6 +277,16 @@ describe("UnknownReason", () => {
     });
     narrow({ kind: "plugin-hooks-present", files: [] });
     narrow({ kind: "managed-settings-assumed", path: "/etc/managed.json" });
+    narrow({
+      kind: "event-not-in-spec",
+      event: "PreToolUse",
+      specVersion: "1.0.0",
+    });
+    narrow({
+      kind: "contradictory-exit-code-effect",
+      event: "PostToolUse",
+      exitCode: 2,
+    });
   });
 
   it("rejects an event name outside EventName in payload-shape-unverified", () => {
@@ -284,7 +310,7 @@ describe("Decision", () => {
         case "deny": {
           expectTypeOf(decision).toEqualTypeOf<{
             readonly kind: "deny";
-            readonly source: "exit-2" | "permission-decision";
+            readonly source: "exit-code" | "permission-decision";
             readonly exitCode: number;
           }>();
           break;
@@ -321,7 +347,7 @@ describe("Decision", () => {
         }
       }
     };
-    narrow({ kind: "deny", source: "exit-2", exitCode: 2 });
+    narrow({ kind: "deny", source: "exit-code", exitCode: 2 });
     narrow({ kind: "allow", exitCode: 0 });
     narrow({ kind: "pass", exitCode: 1 });
     narrow({ kind: "error", exitCode: 127, cause: "nonzero-exit-without-json" });


### PR DESCRIPTION
Adds `Decision`, `UnknownReason`, `ExecOutcome` and `VersionSourceName` to the published type vocabulary, plus `src/internal/decision/` (`factory.ts` + `resolve.ts`) — the pure, static-layer resolver that maps a hook's raw `ExecOutcome` onto that vocabulary. Every branch is driven by the loaded spec's own per-event data rather than hardcoded rules: `exitCodeEffects` for the exit-code channel and `jsonDecisions` for the JSON channel.

Closes #6

Release impact: yes — MINOR. Adds `Decision`, `UnknownReason`, `ExecOutcome` and `VersionSourceName` to the published surface. `Decision.deny.source`'s `"exit-2"` member is renamed to `"exit-code"`, which is technically breaking for an exhaustive switch on that literal, but the package is pre-1.0 and unreleased, so this does not raise the bump.

## Where this supersedes the issue

Issue #6's design table was written before the spec module landed, and the shipped spec contradicts it in two places. The review caught both; each is now driven by spec data instead:

- **The JSON channel is gated on `jsonDecisions`, not `blockable`.** `blockable` describes only the exit-code channel — it equals `honorsExit2` for all 33 events. Several events decide exclusively through JSON while carrying `blockable: false`: `PermissionRequest` is `blockable: false` with `jsonDecisions: ["allow","deny"]`, and denying via stdout JSON is that event's entire purpose. Under the issue's rule a working permission-denying hook resolved to `pass`.
- **The decision value is read from the shapes Claude Code actually emits.** The issue specifies a top-level `permissionDecision`, which is not a shape Claude Code produces. Real hooks emit `hookSpecificOutput.permissionDecision` (PreToolUse, PermissionRequest) or a top-level `decision` (UserPromptSubmit, Stop, PostToolUse). Both previously resolved to `pass`, so every production deny-by-JSON hook was reported as a no-op. All three locations are now read, first-present wins.

The deny/allow vocabulary is likewise derived per event from `jsonDecisions` rather than module constants, so `Elicitation`'s `accept`/`decline`/`cancel` resolve instead of falling through to `pass`.

## Also fixed from review

- Malformed JSON is no longer swallowed by a documented non-blocking exit code — a hook whose JSON writer crashed mid-output while exiting 1 was reported as a clean pass.
- A missing `spec.events[event]` gets its own `UnknownReason` variant (`event-not-in-spec`) instead of reusing `version-out-of-spec-range` with the event name stuffed into `detected`, a field documented as holding a version string.
- A spec pairing a `block` effect with a non-blockable event gets its own variant (`contradictory-exit-code-effect`) rather than being reported as the user's `schema-violation` — the fault is in the spec, and the two were indistinguishable downstream.
- `Decision.deny.source` no longer labels a block `"exit-2"` when it came from another exit code (`WorktreeCreate` blocks on exit 1, called out in the module's own header).

## Test plan

- `pnpm exec vitest run tests/decision.test.ts tests/types.test.ts` — 131 tests, including the `it.each` sweep over every event's `exitCodeEffects` row and the table-health guard.
- `pnpm check:quick` — format, lint, typecheck, 977 tests.
- `pnpm test:coverage` — `src/**` at 96.42% statements / 91.66% branches, above the 90% floor; `src/internal/decision/` at 100%.
- `pnpm check` — the full gate, since `src/index.ts`'s exported surface changed: build, docs, publint, Are the Types Wrong?, and the consumer smoke test.

## Noted, not fixed

Two naming observations left out of scope deliberately: `"permission-decision"` is now also the `source` for a value read from the top-level `decision` field, and the helper `exit2OverridesAllowJson` keeps its name after the `"exit-2"` → `"exit-code"` rename. Neither affects behavior.