### PR TITLE
feat: implement the explain subcommand with real argv parsing and the pretty reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ hookassert --help
 
 ## Commands
 
-- `hookassert explain` shows which hooks a tool event fires, and why.
+- `hookassert explain <event> [tool]` shows which hooks a tool event fires, and why:
+  every firing hook printed with its settings layer, absolute source file, and line, and
+  every matcher that did not fire printed with the reason. It never spawns a process —
+  the Claude Code version it runs against comes only from `--claude-version` or the
+  `HOOKASSERT_CLAUDE_VERSION` environment variable, falling back to `"undetermined"`.
 - `hookassert lint` checks hook declarations for matcher and command mistakes.
 - `hookassert record` captures real hook payloads from a Claude Code session.
 - `hookassert test` replays recorded events and asserts on what the hooks did.
 
-None of the four has behavior yet: each currently exits `4` with `ERR_USAGE`, so a
-script that wires one up fails loudly instead of silently reporting success.
+`lint`, `record`, and `test` have no behavior yet: each currently exits `4` with
+`ERR_USAGE`, so a script that wires one up fails loudly instead of silently reporting
+success.
 
 ## API
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -375,6 +375,8 @@ export default defineConfig([
       "tests/spec.test.ts",
       "tests/decision.test.ts",
       "tests/matcher.test.ts",
+      "tests/cli.test.ts",
+      "tests/report.test.ts",
     ],
     rules: {
       "no-restricted-imports": "off",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,27 @@
 #!/usr/bin/env node
 
 import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 
-import { UsageError } from "./internal/errors.js";
+import { HookassertError, UsageError } from "./internal/errors.js";
+import { matchHooks, type VersionContext } from "./internal/matcher/index.js";
+import {
+  buildReportHeader,
+  renderPretty,
+  type ExplainReport,
+} from "./internal/report/index.js";
+import {
+  discoverSources,
+  hooksForEvent,
+  loadSettings,
+} from "./internal/settings/index.js";
+import { loadSpecFile, parseClaudeVersion } from "./internal/spec/index.js";
+import { createUnimplementedSpawner, type Spawner } from "./internal/spawner.js";
+import type { EventName } from "./types.js";
 
 export interface CliResult {
   exitCode: number;
@@ -14,13 +30,35 @@ export interface CliResult {
 }
 
 /**
+ * The environment variable `explain` and `lint` read a Claude Code version
+ * from, when `--claude-version` was not given.
+ *
+ * @remarks
+ * Named here rather than inline so the two places that read it (this
+ * module's `resolveVersionContext`) and describe it (the README, the design
+ * section of the `cli-explain` issue) stay in agreement.
+ */
+const CLAUDE_VERSION_ENV_VAR = "HOOKASSERT_CLAUDE_VERSION";
+
+/**
+ * The shipped hooks spec `explain` and `lint` load. `#7`'s design leaves
+ * multi-spec selection to a later issue; today exactly one spec file ships,
+ * and both commands load it unconditionally.
+ */
+const SPEC_PATH = fileURLToPath(
+  new URL("../spec/claude-code-2.1.251-2.2.0.json", import.meta.url),
+);
+
+/**
  * The commands hookassert ships, with the one-line summary each gets in the
  * usage text.
  *
  * @remarks
- * None of them has behavior yet. Naming all four here anyway is what makes the
- * usage text and the "unknown command" message agree with each other, and with
- * the routing that replaces this dispatch once the first command lands.
+ * `explain` is the first of the four with real behavior, wired in by this
+ * issue. `lint`, `record`, and `test` are still stubs: naming all four here
+ * anyway is what makes the usage text and the "unknown command" message
+ * agree with each other, and with the routing that replaces each stub once
+ * its own issue lands.
  */
 const COMMANDS = [
   ["explain", "Show which hooks a tool event fires, and why."],
@@ -39,6 +77,57 @@ function isSubcommand(value: string): value is Subcommand {
   return commandNames().some((name) => name === value);
 }
 
+/**
+ * The full set of officially documented event names, mirroring
+ * `src/types.ts`'s `EventName` union.
+ *
+ * @remarks
+ * Typed as `Record<EventName, true>` rather than an array so the mirror
+ * cannot silently drift, the same technique `settings/load.ts`'s own
+ * `KNOWN_EVENT_NAMES` uses: widening `EventName` without extending this map
+ * is a type error here rather than an `explain <event>` invocation that
+ * silently accepts an event this build does not actually know.
+ */
+const EVENT_NAMES: Readonly<Record<EventName, true>> = {
+  SessionStart: true,
+  Setup: true,
+  InstructionsLoaded: true,
+  UserPromptSubmit: true,
+  UserPromptExpansion: true,
+  MessageDisplay: true,
+  PreToolUse: true,
+  PermissionRequest: true,
+  PostToolUse: true,
+  PostToolUseFailure: true,
+  PostToolBatch: true,
+  PermissionDenied: true,
+  Notification: true,
+  SubagentStart: true,
+  SubagentStop: true,
+  TaskCreated: true,
+  TaskCompleted: true,
+  Stop: true,
+  StopFailure: true,
+  TeammateIdle: true,
+  ConfigChange: true,
+  CwdChanged: true,
+  DirectoryAdded: true,
+  FileChanged: true,
+  WorktreeCreate: true,
+  WorktreeRemove: true,
+  PreCompact: true,
+  PostCompact: true,
+  PreModelSwitch: true,
+  PostModelSwitch: true,
+  SessionEnd: true,
+  Elicitation: true,
+  ElicitationResult: true,
+};
+
+function isEventName(value: string): value is EventName {
+  return Object.hasOwn(EVENT_NAMES, value);
+}
+
 function usage(executable: string): string {
   const width = Math.max(...commandNames().map((name) => name.length));
   const commands = COMMANDS.map(
@@ -53,13 +142,16 @@ function usage(executable: string): string {
 }
 
 /**
- * Render a usage error the way a terminal and a CI log both read it.
+ * Render a `HookassertError` the way a terminal and a CI log both read it.
  *
  * @remarks
  * The `code` leads, because that is the half a wrapper script may branch on;
- * the prose after it may be reworded in a patch release.
+ * the prose after it may be reworded in a patch release. Not scoped to
+ * `UsageError`: `explain` can also fail with a load error (`ERR_SETTINGS_PARSE`,
+ * `ERR_SPEC_SCHEMA`, `ERR_SPEC_NOT_FOUND`) when a `--settings` file or the
+ * shipped spec cannot be read, and both report through this same shape.
  */
-function usageFailure(error: UsageError, executable: string): CliResult {
+function failureResult(error: HookassertError, executable: string): CliResult {
   return {
     exitCode: error.exitCode,
     stdout: "",
@@ -69,21 +161,166 @@ function usageFailure(error: UsageError, executable: string): CliResult {
   };
 }
 
+/** The dependencies `explain` and `lint` are threaded through, for injection in tests. */
+export interface CliDeps {
+  /** Directory `project` and `local` settings, and a relative `--settings <file>`, resolve against. */
+  readonly cwd: string;
+
+  /** Directory `user` settings resolve against. */
+  readonly home: string;
+
+  /** Environment variables, read only for {@link CLAUDE_VERSION_ENV_VAR}. */
+  readonly env: Readonly<Record<string, string | undefined>>;
+
+  /**
+   * The command-execution seam. `explain` and `lint` accept it but never
+   * call it — see `src/internal/spawner.ts`'s own remark — so a
+   * `CountingSpawner` injected here is how `tests/cli.test.ts` proves the
+   * zero-spawn guarantee mechanically rather than by inspection.
+   */
+  readonly spawner: Spawner;
+}
+
+function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
+  return {
+    cwd: overrides.cwd ?? process.cwd(),
+    home: overrides.home ?? homedir(),
+    env: overrides.env ?? process.env,
+    spawner: overrides.spawner ?? createUnimplementedSpawner(),
+  };
+}
+
+/**
+ * Resolve the Claude Code version `explain` and `lint` run against, from the
+ * two-step order this issue implements.
+ *
+ * @remarks
+ * `--claude-version` beats {@link CLAUDE_VERSION_ENV_VAR}, which beats
+ * `"undetermined"`. Deliberately no third step: a `VersionProbe` spawning
+ * `claude --version`, and a fallback to the last `record` session's
+ * recorded version, are both `#11`'s work, and adding either here would spawn
+ * a process from a command whose whole point is guaranteeing it never does.
+ *
+ * @throws {UsageError} `claudeVersionFlag` (or the environment variable, when
+ * the flag is absent) is not a `major.minor.patch` string.
+ */
+function resolveVersionContext(
+  claudeVersionFlag: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+): VersionContext {
+  const text = claudeVersionFlag ?? env[CLAUDE_VERSION_ENV_VAR];
+  if (text === undefined) {
+    return { kind: "undetermined" };
+  }
+  try {
+    return { kind: "known", version: parseClaudeVersion(text) };
+  } catch {
+    throw new UsageError(
+      `"${text}" is not a valid major.minor.patch Claude Code version.`,
+    );
+  }
+}
+
+/** `explain`'s own option table: `common` plus `--emit-fixtures`. */
+const EXPLAIN_OPTIONS = {
+  settings: { type: "string", multiple: true },
+  "claude-version": { type: "string" },
+  format: { type: "string" },
+  "emit-fixtures": { type: "string" },
+  help: { type: "boolean", short: "h" },
+} as const;
+
+/**
+ * `parseArgs({ strict: true })` throws on an unknown option, a missing
+ * required value, or a value of the wrong type. Translated here into a
+ * `UsageError` rather than letting the raw exception escape `runCli`.
+ */
+function runExplain(args: readonly string[], deps: CliDeps): CliResult {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args,
+      strict: true,
+      allowPositionals: true,
+      options: EXPLAIN_OPTIONS,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new UsageError(`invalid options for explain: ${reason}`);
+  }
+
+  const [event, tool] = parsed.positionals;
+  if (event === undefined) {
+    throw new UsageError("explain requires an <event> argument.");
+  }
+  if (!isEventName(event)) {
+    throw new UsageError(
+      `unrecognized event ${JSON.stringify(event)}. ` +
+        `Expected one of the documented Claude Code hook events.`,
+    );
+  }
+
+  const format = parsed.values.format ?? "pretty";
+  if (format !== "pretty") {
+    throw new UsageError(
+      `the ${JSON.stringify(format)} report format is not implemented yet; only "pretty" renders.`,
+    );
+  }
+  if (parsed.values["emit-fixtures"] !== undefined) {
+    throw new UsageError("the --emit-fixtures option is not implemented yet.");
+  }
+
+  const versionContext = resolveVersionContext(
+    parsed.values["claude-version"],
+    deps.env,
+  );
+  const spec = loadSpecFile(SPEC_PATH);
+
+  const explicitSettings = parsed.values.settings;
+  const sources = discoverSources({
+    cwd: deps.cwd,
+    home: deps.home,
+    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
+  });
+  const settings = loadSettings(sources);
+  const hooks = hooksForEvent(settings, event);
+  const match = matchHooks(spec, versionContext, { event, hooks, target: tool });
+
+  const report: ExplainReport = {
+    header: buildReportHeader(versionContext, spec.claudeCodeRange),
+    event,
+    target: tool,
+    firing: match.firing,
+    matcherIgnored: match.matcherIgnored,
+    rejected: match.rejected,
+  };
+
+  return { exitCode: 0, stdout: renderPretty(report), stderr: "" };
+}
+
 /**
  * Run the package command without coupling its behavior to process globals.
  *
  * @param argv Arguments after the executable name.
  * @param executable Name or path shown in the usage line.
+ * @param deps Dependencies to override; anything omitted falls back to the
+ * live process (`process.cwd()`, `os.homedir()`, `process.env`) or, for
+ * `spawner`, a placeholder that rejects every call — see
+ * `src/internal/spawner.ts`.
  * @returns The process result a caller should observe.
  */
-export function runCli(argv: readonly string[], executable = "hookassert"): CliResult {
+export function runCli(
+  argv: readonly string[],
+  executable = "hookassert",
+  deps: Partial<CliDeps> = {},
+): CliResult {
   const [subcommand] = argv;
   if (subcommand === undefined || argv.includes("--help") || argv.includes("-h")) {
     return { exitCode: 0, stdout: usage(executable), stderr: "" };
   }
 
   if (!isSubcommand(subcommand)) {
-    return usageFailure(
+    return failureResult(
       new UsageError(
         `unknown command ${JSON.stringify(subcommand)}. ` +
           `Expected one of: ${commandNames().join(", ")}.`,
@@ -92,13 +329,28 @@ export function runCli(argv: readonly string[], executable = "hookassert"): CliR
     );
   }
 
-  // A recognised command with no implementation behind it is still a usage
-  // error: fabricating partial behavior would make the gap invisible to the
-  // issue that is supposed to close it.
-  return usageFailure(
-    new UsageError(`the ${JSON.stringify(subcommand)} command is not implemented yet.`),
-    executable,
-  );
+  const rest = argv.slice(1);
+
+  try {
+    switch (subcommand) {
+      case "explain":
+        return runExplain(rest, resolveDeps(deps));
+      case "lint":
+      case "record":
+      case "test":
+        // A recognised command with no implementation behind it is still a
+        // usage error: fabricating partial behavior would make the gap
+        // invisible to the issue that is supposed to close it.
+        throw new UsageError(
+          `the ${JSON.stringify(subcommand)} command is not implemented yet.`,
+        );
+    }
+  } catch (error) {
+    if (error instanceof HookassertError) {
+      return failureResult(error, executable);
+    }
+    throw error;
+  }
 }
 
 function canonicalize(target: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
-import { HookassertError, UsageError } from "./internal/errors.js";
+import {
+  HookassertError,
+  SettingsNotFoundError,
+  UsageError,
+} from "./internal/errors.js";
 import { matchHooks, type VersionContext } from "./internal/matcher/index.js";
 import {
   buildReportHeader,
@@ -148,7 +152,8 @@ function usage(executable: string): string {
  * The `code` leads, because that is the half a wrapper script may branch on;
  * the prose after it may be reworded in a patch release. Not scoped to
  * `UsageError`: `explain` can also fail with a load error (`ERR_SETTINGS_PARSE`,
- * `ERR_SPEC_SCHEMA`, `ERR_SPEC_NOT_FOUND`) when a `--settings` file or the
+ * `ERR_SETTINGS_NOT_FOUND`, `ERR_SPEC_SCHEMA`, `ERR_SPEC_NOT_FOUND`) when a
+ * `--settings` file or the
  * shipped spec cannot be read, and both report through this same shape.
  */
 function failureResult(error: HookassertError, executable: string): CliResult {
@@ -201,6 +206,13 @@ function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
  * recorded version, are both `#11`'s work, and adding either here would spawn
  * a process from a command whose whole point is guaranteeing it never does.
  *
+ * An environment variable that is set but empty counts as absent, not as a
+ * malformed version: `HOOKASSERT_CLAUDE_VERSION=` in a CI job, or an
+ * `export HOOKASSERT_CLAUDE_VERSION="$(… || true)"` that produced nothing, is
+ * the caller declaring the variable without a value, and must fall through to
+ * `"undetermined"` rather than failing the run. `--claude-version ""` is still
+ * an error: an explicitly passed flag was meant to carry a version.
+ *
  * @throws {UsageError} `claudeVersionFlag` (or the environment variable, when
  * the flag is absent) is not a `major.minor.patch` string.
  */
@@ -208,15 +220,22 @@ function resolveVersionContext(
   claudeVersionFlag: string | undefined,
   env: Readonly<Record<string, string | undefined>>,
 ): VersionContext {
-  const text = claudeVersionFlag ?? env[CLAUDE_VERSION_ENV_VAR];
+  const fromEnv = env[CLAUDE_VERSION_ENV_VAR];
+  const text =
+    claudeVersionFlag ??
+    (fromEnv === undefined || fromEnv === "" ? undefined : fromEnv);
   if (text === undefined) {
     return { kind: "undetermined" };
   }
   try {
     return { kind: "known", version: parseClaudeVersion(text) };
   } catch {
+    // Naming the source matters: a stale environment variable otherwise
+    // produces a usage error quoting a value the caller never typed.
+    const source =
+      claudeVersionFlag === undefined ? CLAUDE_VERSION_ENV_VAR : "--claude-version";
     throw new UsageError(
-      `"${text}" is not a valid major.minor.patch Claude Code version.`,
+      `${source}: "${text}" is not a valid major.minor.patch Claude Code version.`,
     );
   }
 }
@@ -253,6 +272,16 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   if (event === undefined) {
     throw new UsageError("explain requires an <event> argument.");
   }
+  if (parsed.positionals.length > 2) {
+    // Not cosmetic: `--settings a.json b.json` parses as one settings file
+    // plus a stray positional, so silently dropping the extras would let
+    // `b.json` become the matcher target and report a plausible — but
+    // wrong — firing set at exit 0.
+    throw new UsageError(
+      `explain accepts at most <event> and [tool]; unexpected extra argument ` +
+        `${JSON.stringify(parsed.positionals[2])}.`,
+    );
+  }
   if (!isEventName(event)) {
     throw new UsageError(
       `unrecognized event ${JSON.stringify(event)}. ` +
@@ -277,6 +306,16 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   const spec = loadSpecFile(SPEC_PATH);
 
   const explicitSettings = parsed.values.settings;
+  // The loader maps a missing settings file to zero hooks, which is right for
+  // the three discovered layers and wrong for one the caller named: a typo
+  // would otherwise print "Firing hooks: none" at exit 0. This is the only
+  // layer that can tell the two apart.
+  for (const file of explicitSettings ?? []) {
+    const resolved = path.resolve(deps.cwd, file);
+    if (!existsSync(resolved)) {
+      throw new SettingsNotFoundError(resolved);
+    }
+  }
   const sources = discoverSources({
     cwd: deps.cwd,
     home: deps.home,

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -155,3 +155,42 @@ export class SpecNotFoundError extends HookassertError {
     this.file = file;
   }
 }
+
+/**
+ * Thrown when a settings file named explicitly on the command line does not
+ * exist on disk.
+ *
+ * @remarks
+ * Deliberately narrower than it looks. A *discovered* settings file that is
+ * missing contributes zero hooks and is not an error — most projects declare
+ * only one or two of the three well-known layers, which is why
+ * `settings/load.ts` maps `ENOENT` to an empty hook list.
+ *
+ * A file the caller named is the opposite case: they asserted it exists, so
+ * silently reading zero hooks out of a typo turns `explain` into a tool that
+ * confidently reports "no hooks fire" for a settings file it never opened.
+ * Only the CLI can tell the two apart, because only the CLI knows which
+ * sources came from the user rather than from discovery.
+ *
+ * Mirrors {@link SpecNotFoundError}: the file's *content* is never inspected
+ * here because there is no content to read.
+ */
+export class SettingsNotFoundError extends HookassertError {
+  /** Stable discriminator, unchanged across non-breaking releases. */
+  readonly code = "ERR_SETTINGS_NOT_FOUND" as const;
+
+  /** Settings not-found failures always exit 5 (load error). */
+  readonly exitCode = 5;
+
+  /** Path that was named on the command line but does not exist. */
+  readonly file: string;
+
+  /**
+   * @param file - Path that was named on the command line but does not exist.
+   */
+  constructor(file: string) {
+    super(`Settings file not found: ${file}`);
+    this.name = "SettingsNotFoundError";
+    this.file = file;
+  }
+}

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The pretty reporter's own internal surface.
+ *
+ * @remarks
+ * `src/cli.ts` is the composition root that imports from here; nothing here
+ * is re-exported from `src/index.ts` — see `types.ts`'s doc comment for why
+ * that boundary is enforced mechanically, not just by convention.
+ */
+
+export { renderPretty } from "./pretty.js";
+export { buildReportHeader, formatClaudeVersion } from "./summary.js";
+export type { ExplainReport, ReportHeader } from "./summary.js";

--- a/src/internal/report/pretty.ts
+++ b/src/internal/report/pretty.ts
@@ -1,0 +1,66 @@
+/**
+ * The `pretty` reporter: a human-readable rendering of an `ExplainReport`.
+ *
+ * @remarks
+ * Static layer: pure string formatting — no I/O, no process, no write. The
+ * `json` and `github` reporters are the `reporters` issue's own work.
+ */
+
+import type { ResolvedHook } from "../../types.js";
+import type { ExplainReport } from "./summary.js";
+
+/** One firing or non-firing hook line: its layer, absolute file, and line. */
+function describeHook(hook: ResolvedHook): string {
+  const { provenance } = hook;
+  return `[${provenance.layer}] ${provenance.file}:${String(provenance.line)} ${hook.command}`;
+}
+
+/**
+ * Render an {@link ExplainReport} for a terminal.
+ *
+ * @remarks
+ * Always prints the header — the detected Claude Code version (or
+ * `"undetermined"`) and the spec's declared range — even when `firing` and
+ * `rejected` are both empty, so a caller who ran `explain` against an event
+ * with no hooks at all still sees what version and spec range the run
+ * evaluated against.
+ */
+export function renderPretty(report: ExplainReport): string {
+  const lines: string[] = [];
+
+  lines.push(`Claude Code version: ${report.header.claudeVersion}`);
+  lines.push(`Spec range: ${report.header.specRange}`);
+  for (const notice of report.header.notices) {
+    lines.push(`Notice: ${notice}`);
+  }
+
+  lines.push("");
+  lines.push(
+    report.target === undefined ? report.event : `${report.event} ${report.target}`,
+  );
+
+  lines.push("");
+  if (report.firing.length === 0) {
+    lines.push("Firing hooks: none");
+  } else {
+    lines.push("Firing hooks:");
+    for (const hook of report.firing) {
+      const ignoredNote = report.matcherIgnored.includes(hook)
+        ? " (matcher ignored: this event has no matcher support)"
+        : "";
+      lines.push(`  ${describeHook(hook)}${ignoredNote}`);
+    }
+  }
+
+  lines.push("");
+  if (report.rejected.length === 0) {
+    lines.push("Not firing: none");
+  } else {
+    lines.push("Not firing:");
+    for (const outcome of report.rejected) {
+      lines.push(`  ${describeHook(outcome.hook)} — ${outcome.reason}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/internal/report/pretty.ts
+++ b/src/internal/report/pretty.ts
@@ -44,8 +44,12 @@ export function renderPretty(report: ExplainReport): string {
     lines.push("Firing hooks: none");
   } else {
     lines.push("Firing hooks:");
+    // A set, not a repeated `matcherIgnored.includes(hook)`: the lookup is
+    // by identity either way, but scanning the list per firing hook is
+    // quadratic in the size of a settings tree's firing set.
+    const ignored = new Set(report.matcherIgnored);
     for (const hook of report.firing) {
-      const ignoredNote = report.matcherIgnored.includes(hook)
+      const ignoredNote = ignored.has(hook)
         ? " (matcher ignored: this event has no matcher support)"
         : "";
       lines.push(`  ${describeHook(hook)}${ignoredNote}`);

--- a/src/internal/report/summary.ts
+++ b/src/internal/report/summary.ts
@@ -1,0 +1,90 @@
+/**
+ * The shared data shape every report format renders, and how it is built from
+ * a `matchHooks` result.
+ *
+ * @remarks
+ * Static layer: pure — no I/O, no process, no write. Only `pretty.ts` renders
+ * this shape today; `json.ts` and `github.ts` are the `reporters` issue's
+ * work, and both will build on the same `ExplainReport`.
+ */
+
+import type { EventName, ResolvedHook } from "../../types.js";
+import type { MatcherOutcome, VersionContext } from "../matcher/index.js";
+
+/**
+ * The information every reporter format prints first, regardless of what
+ * `explain` found.
+ *
+ * @remarks
+ * `notices` is always empty in this issue: the incompleteness notices a
+ * header can carry (`UnknownReason`'s `"plugin-hooks-present"` and
+ * `"managed-settings-assumed"` kinds, from `src/types.ts`) are populated from
+ * a live `Decision`, and `explain` has none to draw from yet — see
+ * `buildReportHeader`'s own remark for where that becomes available.
+ */
+export interface ReportHeader {
+  /** The detected Claude Code version, formatted `major.minor.patch`, or the literal string `"undetermined"`. */
+  readonly claudeVersion: string;
+
+  /** The loaded spec's own `claudeCodeRange`. */
+  readonly specRange: string;
+
+  /** Incompleteness notices a reporter should surface, in no particular order. */
+  readonly notices: readonly string[];
+}
+
+/** The full result `explain <event> [tool]` renders. */
+export interface ExplainReport {
+  /** Printed first by every reporter format. */
+  readonly header: ReportHeader;
+
+  /** The event `explain` was asked about. */
+  readonly event: EventName;
+
+  /** The matcher target `explain` was asked about, or `undefined` when none was given. */
+  readonly target: string | undefined;
+
+  /** Hooks that fire, in firing order. */
+  readonly firing: readonly ResolvedHook[];
+
+  /**
+   * The subset of {@link ExplainReport.firing} whose declared matcher was
+   * ignored rather than evaluated, per `MatchResult.matcherIgnored`.
+   */
+  readonly matcherIgnored: readonly ResolvedHook[];
+
+  /** Every hook that did not fire, with its `MatcherOutcome` reason. */
+  readonly rejected: readonly MatcherOutcome[];
+}
+
+/** Format a detected Claude Code version the way every reporter prints it. */
+export function formatClaudeVersion(version: VersionContext): string {
+  if (version.kind === "undetermined") {
+    return "undetermined";
+  }
+  const { major, minor, patch } = version.version;
+  return `${String(major)}.${String(minor)}.${String(patch)}`;
+}
+
+/**
+ * Build the header every reporter format prints, from what `explain` and
+ * `lint` actually have available in this issue.
+ *
+ * @remarks
+ * `notices` is hardcoded empty here rather than sourced from a `Decision`:
+ * this issue's `explain` never has one (it only ever runs `matchHooks`, not
+ * the decision resolver), so there is nothing yet to read a
+ * `"plugin-hooks-present"` or `"managed-settings-assumed"` `UnknownReason`
+ * from. A later issue that threads a live `Decision` through `explain` (or a
+ * command that does) is what populates this list for real.
+ */
+export function buildReportHeader(
+  version: VersionContext,
+  specRange: string,
+): ReportHeader {
+  return {
+    claudeVersion: formatClaudeVersion(version),
+    specRange,
+    notices: [],
+  };
+}

--- a/src/internal/spawner.ts
+++ b/src/internal/spawner.ts
@@ -1,0 +1,77 @@
+/**
+ * The command-execution seam every hook eventually runs through.
+ *
+ * @remarks
+ * Declared here — a plain module directly under `src/internal/`, outside both
+ * `exec/` and `record/`, the package's dynamic layer — so the composition root
+ * (`src/cli.ts`) and its tests can name the interface without importing an
+ * implementation that actually spawns a process. `Spawner.spawn` returns
+ * `ExecOutcome` (`src/types.ts`) rather than a new result type: that is
+ * already the shape the static decision resolver consumes, so whatever
+ * eventually implements this interface (the `executor` issue's `NodeSpawner`,
+ * under `src/internal/exec/`) and the decision resolver speak the same
+ * vocabulary for a hook's raw result.
+ */
+
+import type { ExecOutcome } from "../types.js";
+
+/** One hook invocation, described the way a {@link Spawner} executes it. */
+export interface SpawnRequest {
+  /** Whether the command runs through a shell or is exec'd directly. */
+  readonly form: "shell" | "exec";
+
+  /** The command to run. */
+  readonly command: string;
+
+  /** Arguments passed to {@link SpawnRequest.command}. */
+  readonly args: readonly string[];
+
+  /** Working directory the process runs in. */
+  readonly cwd: string;
+
+  /** Environment variables the process runs with. */
+  readonly env: Readonly<Record<string, string>>;
+
+  /** Text written to the process's stdin. */
+  readonly stdin: string;
+
+  /** Deadline in milliseconds before the process is killed. */
+  readonly timeoutMs: number;
+}
+
+/**
+ * Runs one hook invocation and reports its outcome.
+ *
+ * @remarks
+ * The seam that keeps `explain` and `lint` static: both accept a `Spawner`
+ * through explicit dependency injection and never call it, which is what
+ * `tests/cli.test.ts`'s `CountingSpawner` proves by injecting itself and
+ * asserting `calls.length === 0`. A real implementation is a later issue's
+ * work; see {@link createUnimplementedSpawner} for the placeholder this
+ * package wires in until one exists.
+ */
+export interface Spawner {
+  spawn(req: SpawnRequest): Promise<ExecOutcome>;
+}
+
+/**
+ * A `Spawner` that rejects every call, for use where dependency injection
+ * requires a value but nothing has implemented the seam yet.
+ *
+ * @remarks
+ * `src/cli.ts` wires this in as its default `Spawner` so `main()` has a
+ * complete dependency graph to run against before `#11`'s `NodeSpawner`
+ * lands. Never reached by `explain` or `lint`, which never call `spawn` at
+ * all.
+ */
+export function createUnimplementedSpawner(): Spawner {
+  return {
+    spawn(): Promise<ExecOutcome> {
+      return Promise.reject(
+        new Error(
+          "spawning is not implemented yet: no Spawner has landed under src/internal/exec/",
+        ),
+      );
+    },
+  };
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -255,6 +255,47 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("NotARealEvent");
   });
 
+  it("treats a set-but-empty HOOKASSERT_CLAUDE_VERSION as no version at all", () => {
+    // A CI job that declares the variable without a value, or an
+    // `export HOOKASSERT_CLAUDE_VERSION="$(… || true)"` that produced
+    // nothing, must fall back to "undetermined" rather than failing the run.
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "" } }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Claude Code version: undetermined");
+  });
+
+  it("names HOOKASSERT_CLAUDE_VERSION when the invalid version came from it", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "not-a-version" } }),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("HOOKASSERT_CLAUDE_VERSION");
+  });
+
+  it("exits 4 with ERR_USAGE on an unexpected extra positional argument", () => {
+    // `--settings a.json b.json` parses as one settings file plus a stray
+    // positional; accepting it silently would make `b.json` the matcher
+    // target and report a wrong firing set at exit 0.
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "Write"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("Write");
+  });
+
   it("exits 4 with ERR_USAGE when --claude-version is not major.minor.patch", () => {
     const result = runCli(
       ["explain", "PreToolUse", "Bash", "--claude-version", "not-a-version"],
@@ -325,6 +366,35 @@ describe("runCli explain", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("[explicit]");
     expect(result.stdout).toContain("./scripts/explicit-guard.sh");
+  });
+
+  it("fails with ERR_SETTINGS_NOT_FOUND when a --settings file does not exist", () => {
+    // A missing *discovered* layer is not an error, but a file the caller
+    // named is: without this, a typo prints "Firing hooks: none" at exit 0 —
+    // a confident wrong answer from the command whose whole job is saying
+    // which hooks fire.
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--settings", "no-such-settings.json"],
+      "hookassert",
+      explainDeps({ cwd: PROJECT_WITH_HOOKS_DIR }),
+    );
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain("ERR_SETTINGS_NOT_FOUND");
+    expect(result.stdout).toBe("");
+  });
+
+  it("keeps a missing discovered settings layer lenient", () => {
+    // The mirror of the case above: discovery naming a file that does not
+    // exist stays a zero-hook contribution, so the strictness added for
+    // --settings must not leak into the three well-known layers.
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps({ cwd: NO_SUCH_DIR }),
+    );
+
+    expect(result.exitCode).toBe(0);
   });
 
   it("rethrows a non-HookassertError rather than reporting it as a usage failure", () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,11 +1,60 @@
-import { pathToFileURL } from "node:url";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { isMain, main, runCli } from "../src/cli.js";
+import { isMain, main, runCli, type CliDeps } from "../src/cli.js";
+import { createUnimplementedSpawner } from "../src/internal/spawner.js";
+import type { Spawner, SpawnRequest } from "../src/internal/spawner.js";
+import type { ExecOutcome } from "../src/types.js";
+
+// Reaching src/internal/spawner.ts directly (rather than through
+// src/index.ts's exports, per the writing-tests skill) is a deliberate,
+// narrowly scoped exception: explain's zero-spawn guarantee can only be
+// proven by injecting a real `Spawner` implementation into its dependency
+// graph, and that interface has no public surface — see
+// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
+// reasoning.
+
+const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/cli/", import.meta.url));
+const PROJECT_WITH_HOOKS_DIR = path.join(FIXTURES_DIR, "project-with-hooks");
+const PROJECT_SETTINGS_FILE = path.join(
+  PROJECT_WITH_HOOKS_DIR,
+  ".claude",
+  "settings.json",
+);
+const EXPLICIT_SETTINGS_FILE = path.join(FIXTURES_DIR, "explicit-settings.json");
+// Never created on disk: loadSourceHooks treats a missing settings file as
+// contributing zero hooks, so this is how a test opts a layer out entirely.
+const NO_SUCH_DIR = path.join(FIXTURES_DIR, "no-such-directory");
+
+/** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
+const SPEC_RANGE = ">=2.1.251 <2.2.0";
+
+/** Records every call rather than performing one, so a test can assert `calls.length === 0`. */
+class CountingSpawner implements Spawner {
+  readonly calls: SpawnRequest[] = [];
+
+  spawn(req: SpawnRequest): Promise<ExecOutcome> {
+    this.calls.push(req);
+    return Promise.resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+  }
+}
+
+function explainDeps(overrides: Partial<CliDeps> = {}): CliDeps {
+  return {
+    cwd: overrides.cwd ?? PROJECT_WITH_HOOKS_DIR,
+    home: overrides.home ?? NO_SUCH_DIR,
+    env: overrides.env ?? {},
+    spawner: overrides.spawner ?? new CountingSpawner(),
+  };
+}
 
 /** The commands hookassert will ship, in the order the usage text lists them. */
 const SUBCOMMANDS = ["explain", "lint", "record", "test"] as const;
+
+/** The commands with no behavior yet — `explain` is this issue's own subject. */
+const STUB_SUBCOMMANDS = ["lint", "record", "test"] as const;
 
 /** The `ERR_` shape AGENTS.md fixes for every published error code. */
 const ERROR_CODE = /^ERR_[A-Z0-9_]+$/;
@@ -72,14 +121,17 @@ describe("runCli dispatch", () => {
     expect(result.stderr).toContain('unknown command "--json"');
   });
 
-  it.each(SUBCOMMANDS)("exits 4 with a not-yet-implemented message for %s", (name) => {
-    const result = runCli([name], "my-tool");
-    expect(result.exitCode).toBe(4);
-    expect(result.stdout).toBe("");
-    expect(firstLine(result.stderr)).toBe(
-      `my-tool: ERR_USAGE: the "${name}" command is not implemented yet.`,
-    );
-  });
+  it.each(STUB_SUBCOMMANDS)(
+    "exits 4 with a not-yet-implemented message for %s",
+    (name) => {
+      const result = runCli([name], "my-tool");
+      expect(result.exitCode).toBe(4);
+      expect(result.stdout).toBe("");
+      expect(firstLine(result.stderr)).toBe(
+        `my-tool: ERR_USAGE: the "${name}" command is not implemented yet.`,
+      );
+    },
+  );
 
   it("points at the help flag on every usage error", () => {
     expect(runCli(["frobnicate"], "my-tool").stderr).toContain(
@@ -96,6 +148,215 @@ describe("runCli dispatch", () => {
 
   it("ends stderr with a newline so a terminal does not glue on the next line", () => {
     expect(runCli(["frobnicate"]).stderr.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("runCli explain", () => {
+  it("wires settings + spec + matcher and prints the firing set with layer, file, and line", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("[project]");
+    expect(result.stdout).toContain(`${PROJECT_SETTINGS_FILE}:7`);
+    expect(result.stdout).toContain("./scripts/guard.sh");
+  });
+
+  it("prints a non-firing matcher's MatcherOutcome reason", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.stdout).toContain(`${PROJECT_SETTINGS_FILE}:16`);
+    expect(result.stdout).toContain("./scripts/write-guard.sh");
+    expect(result.stdout).toContain(
+      "evaluated as an exact-match list and did not match Bash",
+    );
+  });
+
+  it("prints 'undetermined' when no Claude Code version can be resolved", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.stdout).toContain("Claude Code version: undetermined");
+  });
+
+  it("prints the resolved Claude Code version when one is known", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--claude-version", "2.1.300"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.stdout).toContain("Claude Code version: 2.1.300");
+  });
+
+  it("always prints the spec's declared claudeCodeRange", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.stdout).toContain(`Spec range: ${SPEC_RANGE}`);
+  });
+
+  it("--claude-version overrides HOOKASSERT_CLAUDE_VERSION", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--claude-version", "2.1.300"],
+      "hookassert",
+      explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "2.1.260" } }),
+    );
+
+    expect(result.stdout).toContain("Claude Code version: 2.1.300");
+    expect(result.stdout).not.toContain("2.1.260");
+  });
+
+  it("uses HOOKASSERT_CLAUDE_VERSION when --claude-version is absent", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "2.1.280" } }),
+    );
+
+    expect(result.stdout).toContain("Claude Code version: 2.1.280");
+  });
+
+  it("exits 4 with ERR_USAGE when explain is given an unrecognized option", () => {
+    const result = runCli(["explain", "--bogus"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ERR_USAGE");
+  });
+
+  it("exits 4 with ERR_USAGE when <event> is missing", () => {
+    const result = runCli(["explain"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("<event>");
+  });
+
+  it("exits 4 with ERR_USAGE when <event> is not a documented Claude Code event", () => {
+    const result = runCli(["explain", "NotARealEvent"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("NotARealEvent");
+  });
+
+  it("exits 4 with ERR_USAGE when --claude-version is not major.minor.patch", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--claude-version", "not-a-version"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+  });
+
+  it("performs exactly zero spawns", () => {
+    const spawner = new CountingSpawner();
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      explainDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+  });
+
+  it("accepts --format pretty explicitly", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", "pretty"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it.each(["json", "github"])(
+    "rejects the %s report format as not implemented yet",
+    (format) => {
+      const result = runCli(
+        ["explain", "PreToolUse", "Bash", "--format", format],
+        "hookassert",
+        explainDeps(),
+      );
+
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr).toContain("ERR_USAGE");
+      expect(result.stderr).toContain("not implemented yet");
+    },
+  );
+
+  it("rejects --emit-fixtures as not implemented yet", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--emit-fixtures", "/tmp/hookassert-out"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("--emit-fixtures");
+  });
+
+  it("adds an explicit-layer settings file with --settings", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--settings", EXPLICIT_SETTINGS_FILE],
+      "hookassert",
+      explainDeps({ cwd: NO_SUCH_DIR }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("[explicit]");
+    expect(result.stdout).toContain("./scripts/explicit-guard.sh");
+  });
+
+  it("rethrows a non-HookassertError rather than reporting it as a usage failure", () => {
+    // Passing a directory as --settings makes readFileSync fail with a plain
+    // EISDIR Error, not one of loadSourceHooks' own recognized cases — this
+    // proves runCli only turns a HookassertError into a graceful CliResult
+    // and lets anything else propagate rather than mislabeling it.
+    expect(() =>
+      runCli(
+        ["explain", "PreToolUse", "Bash", "--settings", PROJECT_WITH_HOOKS_DIR],
+        "hookassert",
+        explainDeps(),
+      ),
+    ).toThrow(/EISDIR/);
+  });
+});
+
+describe("createUnimplementedSpawner", () => {
+  it("rejects every call, as a placeholder until a real Spawner lands", async () => {
+    const spawner = createUnimplementedSpawner();
+
+    await expect(
+      spawner.spawn({
+        form: "exec",
+        command: "true",
+        args: [],
+        cwd: "/",
+        env: {},
+        stdin: "",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/spawning is not implemented yet/);
   });
 });
 

--- a/tests/fixtures/cli/explicit-settings.json
+++ b/tests/fixtures/cli/explicit-settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/explicit-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/cli/project-with-hooks/.claude/settings.json
+++ b/tests/fixtures/cli/project-with-hooks/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/write-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import type { MatcherOutcome } from "../src/internal/matcher/index.js";
+import { buildReportHeader, renderPretty } from "../src/internal/report/index.js";
+import type { ExplainReport } from "../src/internal/report/index.js";
+import type { Provenance, ResolvedHook } from "../src/types.js";
+
+// Reaching src/internal/report/ and src/internal/matcher/ directly (rather
+// than through src/index.ts's exports, per the writing-tests skill) is a
+// deliberate, narrowly scoped exception: neither module has a public surface
+// in this issue and never will one for its own plumbing types — see
+// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
+// reasoning.
+
+function makeProvenance(overrides: Partial<Provenance> = {}): Provenance {
+  return {
+    file: "/abs/project/.claude/settings.json",
+    layer: "project",
+    line: 7,
+    col: 11,
+    offset: 100,
+    ...overrides,
+  };
+}
+
+function makeHook(overrides: Partial<ResolvedHook> = {}): ResolvedHook {
+  return {
+    event: "PreToolUse",
+    matcher: "Bash",
+    command: "./scripts/guard.sh",
+    args: undefined,
+    timeoutMs: undefined,
+    provenance: makeProvenance(),
+    dedupeKey: '["PreToolUse","Bash","./scripts/guard.sh"]',
+    ...overrides,
+  };
+}
+
+describe("buildReportHeader", () => {
+  it("formats a known Claude Code version as major.minor.patch", () => {
+    const header = buildReportHeader(
+      { kind: "known", version: { major: 2, minor: 1, patch: 300 } },
+      ">=2.1.251 <2.2.0",
+    );
+
+    expect(header.claudeVersion).toBe("2.1.300");
+    expect(header.specRange).toBe(">=2.1.251 <2.2.0");
+    expect(header.notices).toEqual([]);
+  });
+
+  it("formats an undetermined version as the literal string 'undetermined'", () => {
+    const header = buildReportHeader({ kind: "undetermined" }, ">=2.1.251 <2.2.0");
+
+    expect(header.claudeVersion).toBe("undetermined");
+  });
+});
+
+describe("renderPretty", () => {
+  function baseReport(overrides: Partial<ExplainReport> = {}): ExplainReport {
+    return {
+      header: buildReportHeader({ kind: "undetermined" }, ">=2.1.251 <2.2.0"),
+      event: "PreToolUse",
+      target: "Bash",
+      firing: [],
+      matcherIgnored: [],
+      rejected: [],
+      ...overrides,
+    };
+  }
+
+  it("prints firing hooks with layer, absolute file path, and line", () => {
+    const hook = makeHook();
+    const output = renderPretty(baseReport({ firing: [hook] }));
+
+    expect(output).toContain("[project]");
+    expect(output).toContain("/abs/project/.claude/settings.json:7");
+    expect(output).toContain("./scripts/guard.sh");
+  });
+
+  it("prints the header even when there are zero firing or rejected cases", () => {
+    const output = renderPretty(
+      baseReport({
+        header: buildReportHeader(
+          { kind: "known", version: { major: 2, minor: 1, patch: 300 } },
+          ">=2.1.251 <2.2.0",
+        ),
+      }),
+    );
+
+    expect(output).toContain("Claude Code version: 2.1.300");
+    expect(output).toContain("Spec range: >=2.1.251 <2.2.0");
+    expect(output).toContain("Firing hooks: none");
+    expect(output).toContain("Not firing: none");
+  });
+
+  it("prints a rejected matcher's reason", () => {
+    const outcome: MatcherOutcome = {
+      hook: makeHook({ matcher: "Write", command: "./scripts/write-guard.sh" }),
+      kind: "exact-list",
+      reason: "evaluated as an exact-match list and did not match Bash",
+    };
+
+    const output = renderPretty(baseReport({ rejected: [outcome] }));
+
+    expect(output).toContain("./scripts/write-guard.sh");
+    expect(output).toContain("evaluated as an exact-match list and did not match Bash");
+  });
+
+  it("notes when a firing hook's matcher was ignored", () => {
+    const hook = makeHook({ matcher: "anything" });
+    const output = renderPretty(baseReport({ firing: [hook], matcherIgnored: [hook] }));
+
+    expect(output).toContain("matcher ignored");
+  });
+
+  it("prints the event alone when no target was given", () => {
+    const output = renderPretty(baseReport({ target: undefined }));
+
+    expect(output).toContain("PreToolUse");
+    expect(output).not.toContain("PreToolUse Bash");
+  });
+});


### PR DESCRIPTION
Turns `src/cli.ts` from #2's stub dispatch into the real composition root: `parseArgs`-based option tables per subcommand, the two-step `ClaudeVersion` resolution (`--claude-version` → `HOOKASSERT_CLAUDE_VERSION` → `undetermined`), and a working `explain <event> [tool]` that wires the settings loader, spec loader and matcher through to a new pretty reporter in `src/internal/report/`.

This is the first end-to-end path through the static layer. `lint`, `record` and `test` remain unimplemented stubs, unchanged.

Closes #7

Release impact: no — `src/index.ts`'s exported surface is unchanged. This adds behavior behind the `hookassert` command entry (`src/cli.ts`), which per `public-api-contract` is not an import surface.

## The zero-spawn guarantee

`explain` must never run a hook, and that is proven mechanically rather than asserted. `src/internal/spawner.ts` declares the `Spawner`/`SpawnRequest` seam; `explain` accepts one and never calls it, and `tests/cli.test.ts` injects a `CountingSpawner` and asserts the count is zero. The seam is declaration-only — implementing anything that actually spawns belongs to the executor issue.

`src/cli.ts` stays the only module importing both layers, so ESLint's `boundaries/static-does-not-reach-dynamic` zone still holds for everything under it.

## Fixed from review

- **A `--settings` path that does not exist was silently ignored.** The loader maps a missing file to zero hooks, which is correct for the three *discovered* layers and wrong for one the caller named: `--settings .claude/settings.jsonc` printed `Firing hooks: none` and exited 0, a confident wrong answer from the command whose whole job is explaining which hooks fire. Adds `SettingsNotFoundError` (`ERR_SETTINGS_NOT_FOUND`, exit 5) mirroring the existing `SpecNotFoundError`, with the check in `cli.ts` because that is the only layer that can tell a user-named source from a discovered one. A companion test pins that discovery stays lenient, so the new strictness cannot leak into the three well-known layers.
- **A set-but-empty `HOOKASSERT_CLAUDE_VERSION` aborted the run.** `HOOKASSERT_CLAUDE_VERSION=` from a CI `env:` entry, or an `export …="$(claude --version || true)"` that produced nothing, exited 4 instead of falling through to `undetermined` — contradicting the README line this PR adds.
- **A malformed version from the environment quoted a value the caller never typed**, and pointed at `--help` with nothing naming the variable. The message now names its source.
- **Extra positionals were silently dropped.** `explain PreToolUse --settings a.json b.json` parsed as one settings file plus a stray positional, so `b.json` silently became the *matcher target*: the second settings file was never read and a plausible-but-wrong firing set printed at exit 0. Now a `UsageError`, consistent with the strict rejection of unknown options.
- The pretty reporter's `matcherIgnored` lookup is a `Set` built once rather than a per-hook linear scan.

## Test plan

- `pnpm exec vitest run tests/cli.test.ts tests/report.test.ts` — 44 CLI tests including the `CountingSpawner` zero-spawn proof, the version-resolution order, and the settings-file cases above.
- `pnpm check:quick` — format, lint, typecheck, 1104 tests across 29 files.
- `pnpm test:coverage` — above the 90% `src/**` floor.
- `pnpm check` — the full gate: build, docs, packaging, publint, Are the Types Wrong?, and the consumer smoke test, which confirms `hookassert/dist/cli.js` is still refused as a deep import.

## Scope notes

`--version` and `--emit-fixtures` are recognized but not implemented — both are named in the issue's option tables, and neither has an acceptance criterion, so they parse and then report a not-yet-implemented `UsageError` rather than being built ahead of their owning issues. `Spawner`/`SpawnRequest` live in `src/internal/spawner.ts` rather than `src/types.ts`, which the issue left open; this keeps the published surface unchanged.

Two review findings were reported but deliberately not fixed here, and are filed separately: a non-`HookassertError` (`EISDIR`/`EACCES` from a `--settings` path) still escapes and crashes with exit 1, which `tests/cli.test.ts` currently pins as intended; and `EVENT_NAMES` is a second hand-kept mirror of `EventName` alongside the settings loader's, whose own copy is documented as temporary pending spec wiring.