### PR TITLE
feat: add the assert engine's expectation diffing and summary fold

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -378,6 +378,7 @@ export default defineConfig([
       "tests/cli.test.ts",
       "tests/report.test.ts",
       "tests/fixture.test.ts",
+      "tests/assert.test.ts",
     ],
     rules: {
       "no-restricted-imports": "off",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,13 +20,18 @@
  */
 
 export type {
+  CaseResult,
   Decision,
   EventName,
   ExecOutcome,
+  ExpectationDiff,
+  NonFiringExplanation,
   PayloadOrigin,
   Provenance,
+  RejectedMatch,
   ResolvedHook,
   SettingsLayer,
+  Summary,
   UnknownReason,
   VersionSourceName,
 } from "./types.js";

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -1,0 +1,199 @@
+/**
+ * Compares one fixture case's declared `expect` against what actually
+ * happened, producing a `CaseResult`.
+ *
+ * @remarks
+ * Static layer: pure comparison — no I/O, no process, no write. This module
+ * only consumes a `Decision`, an `ExecOutcome`, and the matcher engine's
+ * `MatcherOutcome`s for the case, all of which the caller already obtained;
+ * it never resolves a decision or classifies a matcher itself.
+ */
+
+import type {
+  CaseResult,
+  Decision,
+  EventName,
+  ExecOutcome,
+  ExpectationDiff,
+  NonFiringExplanation,
+  RejectedMatch,
+} from "../../types.js";
+import type { FixtureCase, FixtureExpectation } from "../fixture/index.js";
+import type { CaseObservation } from "./types.js";
+
+/** Whether `expect` declares no assertion at all — every field is `undefined`. */
+function isEmptyExpectation(expect: FixtureExpectation): boolean {
+  return (
+    expect.fires === undefined &&
+    expect.decision === undefined &&
+    expect.exitCode === undefined &&
+    expect.stdoutContains === undefined &&
+    expect.stderrContains === undefined &&
+    expect.context === undefined &&
+    expect.updatedInput === undefined &&
+    expect.timedOut === undefined
+  );
+}
+
+/**
+ * Whether `caseData` exists only to configure a stub, with nothing declared
+ * to assert against.
+ */
+function isStubOnly(caseData: FixtureCase): boolean {
+  return (
+    caseData.stub !== undefined &&
+    Object.keys(caseData.stub).length > 0 &&
+    isEmptyExpectation(caseData.expect)
+  );
+}
+
+/**
+ * Explain why `expect.fires: true` was not met, from what the matcher
+ * engine already found for this case's event.
+ *
+ * @remarks
+ * Checked in this order: a candidate hook the matcher rejected outranks a
+ * hook that was never even a candidate because its settings layer was
+ * excluded, which in turn outranks the case where nothing is declared under
+ * the event at all — the more specific cause is reported first.
+ */
+function deriveNonFiring(
+  event: EventName,
+  observation: CaseObservation,
+): NonFiringExplanation {
+  if (observation.rejectedByMatcher.length > 0) {
+    const hooks: RejectedMatch[] = observation.rejectedByMatcher.map((outcome) => ({
+      hook: outcome.hook,
+      reason: outcome.reason,
+    }));
+    return { kind: "matcher-did-not-match", hooks };
+  }
+  if (observation.excludedHooks.length > 0) {
+    return { kind: "excluded-settings-layer", hooks: observation.excludedHooks };
+  }
+  return { kind: "no-hook-configured", event };
+}
+
+/**
+ * Every {@link ExpectationDiff} between `expect` and a firing hook's
+ * resolved `decision` and `execOutcome`.
+ *
+ * @remarks
+ * Only called once the caller has already excluded `decision.kind ===
+ * "unknown"` — an unresolved decision produces its own `CaseResult.kind ===
+ * "unknown"` rather than a `diffs` mismatch.
+ */
+function computeFiredDiffs(
+  expect: FixtureExpectation,
+  decision: Exclude<Decision, { kind: "unknown" }>,
+  execOutcome: ExecOutcome | undefined,
+): ExpectationDiff[] {
+  const diffs: ExpectationDiff[] = [];
+
+  if (expect.fires === false) {
+    diffs.push({ field: "fires", expectedFires: false, actualFires: true });
+  }
+
+  if (expect.decision !== undefined && expect.decision !== decision.kind) {
+    diffs.push({
+      field: "decision",
+      expectedDecision: expect.decision,
+      actualDecision: decision.kind,
+    });
+  }
+
+  if (expect.exitCode !== undefined && expect.exitCode !== decision.exitCode) {
+    diffs.push({
+      field: "exitCode",
+      expectedExitCode: expect.exitCode,
+      actualExitCode: decision.exitCode,
+    });
+  }
+
+  const stdout = execOutcome?.stdout ?? "";
+  if (expect.stdoutContains !== undefined && !stdout.includes(expect.stdoutContains)) {
+    diffs.push({
+      field: "stdoutContains",
+      expectedSubstring: expect.stdoutContains,
+      actualStdout: stdout,
+    });
+  }
+
+  const stderr = execOutcome?.stderr ?? "";
+  if (expect.stderrContains !== undefined && !stderr.includes(expect.stderrContains)) {
+    diffs.push({
+      field: "stderrContains",
+      expectedSubstring: expect.stderrContains,
+      actualStderr: stderr,
+    });
+  }
+
+  if (expect.timedOut !== undefined) {
+    const actualTimedOut = execOutcome?.timedOut ?? false;
+    if (expect.timedOut !== actualTimedOut) {
+      diffs.push({
+        field: "timedOut",
+        expectedTimedOut: expect.timedOut,
+        actualTimedOut,
+      });
+    }
+  }
+
+  return diffs;
+}
+
+/**
+ * Compare `caseData`'s declared `expect` against `observation` — what
+ * actually happened — and produce the matching `CaseResult`.
+ *
+ * @remarks
+ * Checked in this order:
+ * 1. `caseData.dryRun: true` or a stub-only case with no declared
+ *    expectation → `"skipped"`, nothing to compare.
+ * 2. No hook fired at all: `expect.fires: true` → `"fail"` with
+ *    {@link NonFiringExplanation}; otherwise → `"pass"`, since nothing else
+ *    was declared to compare against a case that was not expected to fire.
+ * 3. A hook fired but its resolved `Decision` could not be asserted with
+ *    confidence (`decision.kind === "unknown"`) → `"unknown"`, carrying the
+ *    same `reasons` the `Decision` itself carries.
+ * 4. A hook fired and its `Decision` resolved with confidence → every
+ *    declared `expect` field is compared against what was observed; any
+ *    mismatch produces `"fail"` with a non-empty `diffs`, otherwise
+ *    `"pass"`.
+ */
+export function assertCase(
+  caseData: FixtureCase,
+  observation: CaseObservation,
+): CaseResult {
+  const { origin } = caseData;
+
+  if (caseData.dryRun === true) {
+    return { kind: "skipped", origin, reason: "dry-run" };
+  }
+  if (isStubOnly(caseData)) {
+    return { kind: "skipped", origin, reason: "stub-only" };
+  }
+
+  if (observation.decision === undefined) {
+    if (caseData.expect.fires === true) {
+      return {
+        kind: "fail",
+        origin,
+        diffs: [],
+        nonFiring: deriveNonFiring(caseData.event, observation),
+      };
+    }
+    return { kind: "pass", origin };
+  }
+
+  const { decision } = observation;
+  if (decision.kind === "unknown") {
+    return { kind: "unknown", origin, reasons: decision.reasons };
+  }
+
+  const diffs = computeFiredDiffs(caseData.expect, decision, observation.execOutcome);
+  if (diffs.length > 0) {
+    return { kind: "fail", origin, diffs, nonFiring: undefined };
+  }
+  return { kind: "pass", origin };
+}

--- a/src/internal/assert/index.ts
+++ b/src/internal/assert/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The assert engine's own internal surface.
+ *
+ * @remarks
+ * `CaseResult`, `Summary`, `ExpectationDiff`, and `NonFiringExplanation` —
+ * the vocabulary itself — are published straight from `src/types.ts` and
+ * `src/index.ts`; what lives here is the machinery that produces them
+ * (`assertCase.ts`, `summarize.ts`), which stays internal until a later
+ * `test`-command issue's composition root wires it in. `src/cli.ts` is that
+ * composition root — see `spec/index.ts`'s doc comment for why nothing here
+ * is re-exported from `src/index.ts` in the meantime.
+ */
+
+export { assertCase } from "./assertCase.js";
+export { summarize } from "./summarize.js";
+export type { CaseObservation } from "./types.js";

--- a/src/internal/assert/summarize.ts
+++ b/src/internal/assert/summarize.ts
@@ -1,0 +1,62 @@
+/**
+ * Folds a `CaseResult[]` into the `Summary` every reporter prints.
+ *
+ * @remarks
+ * Static layer: pure fold — no I/O, no process, no write, and no state
+ * outside this function's own local counters. This is the single place a
+ * `Summary` is built: no reporter under `src/internal/report/` may keep a
+ * tally of its own, so the numbers a reporter prints can never drift from
+ * what `summarize` actually counted.
+ */
+
+import type { CaseResult, Summary } from "../../types.js";
+
+/**
+ * Fold `results` into a `Summary`.
+ *
+ * @remarks
+ * Every `CaseResult` contributes to exactly one of `asserted` (as a
+ * `"pass"` or a `"fail"`), `unknown`, or `skipped` — never more than one,
+ * and never none. `fromRecorded` and `failed` are further breakdowns of the
+ * `asserted` set, so a `"fail"` result deliberately increments both
+ * `asserted` and `failed` together, and a recorded-origin `"pass"` or
+ * `"fail"` increments both `asserted` and `fromRecorded` together — this is
+ * the intended overlap, not double counting across the four disjoint kinds.
+ */
+export function summarize(results: readonly CaseResult[]): Summary {
+  let asserted = 0;
+  let fromRecorded = 0;
+  let failed = 0;
+  let unknown = 0;
+  let skipped = 0;
+
+  for (const result of results) {
+    switch (result.kind) {
+      case "pass": {
+        asserted++;
+        if (result.origin.kind === "recorded") {
+          fromRecorded++;
+        }
+        break;
+      }
+      case "fail": {
+        asserted++;
+        failed++;
+        if (result.origin.kind === "recorded") {
+          fromRecorded++;
+        }
+        break;
+      }
+      case "unknown": {
+        unknown++;
+        break;
+      }
+      case "skipped": {
+        skipped++;
+        break;
+      }
+    }
+  }
+
+  return { asserted, fromRecorded, failed, unknown, skipped };
+}

--- a/src/internal/assert/types.ts
+++ b/src/internal/assert/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Internal plumbing types for the assert engine.
+ *
+ * @remarks
+ * `CaseObservation` is not part of the published contract: `src/index.ts`
+ * re-exports only `src/types.ts`'s vocabulary, and ESLint's
+ * `public-api/internal-stays-private` block forbids `src/index.ts` from
+ * importing anything under `src/internal/` at all, so nothing declared here
+ * can leak into the public surface by accident. It lives next to the module
+ * that uses it rather than in `src/types.ts`, which is reserved for the
+ * vocabulary every module speaks — this one is spoken only by
+ * `src/internal/assert/**`.
+ */
+
+import type { Decision, ExecOutcome, ResolvedHook } from "../../types.js";
+import type { MatcherOutcome } from "../matcher/index.js";
+
+/**
+ * What actually happened for one fixture case, gathered from the matcher
+ * engine and the decision resolver — everything `assertCase` needs beyond
+ * the case's own declared `expect`.
+ *
+ * @remarks
+ * Static layer: plain data, no I/O. A later executor issue's composition
+ * root is what actually runs a hook and produces these values; `assertCase`
+ * only ever reads them, and never spawns anything itself.
+ */
+export interface CaseObservation {
+  /**
+   * The resolved `Decision` when a hook fired and ran; `undefined` when
+   * nothing fired for this case at all.
+   */
+  readonly decision: Decision | undefined;
+
+  /**
+   * The raw exec outcome the firing hook produced. `undefined` whenever
+   * {@link CaseObservation.decision} is `undefined` — nothing ran to
+   * produce one.
+   */
+  readonly execOutcome: ExecOutcome | undefined;
+
+  /**
+   * Every hook under this case's event that was a matcher candidate — read
+   * from a settings layer the fixture's `settings:` list included — but did
+   * not fire. Empty whenever {@link CaseObservation.decision} is defined, or
+   * when no candidate hook was rejected by the matcher.
+   */
+  readonly rejectedByMatcher: readonly MatcherOutcome[];
+
+  /**
+   * Hooks under this case's event declared in a settings layer the
+   * fixture's `settings:` list did not include, so they were never even
+   * candidates for {@link CaseObservation.rejectedByMatcher}.
+   */
+  readonly excludedHooks: readonly ResolvedHook[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,3 +348,211 @@ export type Decision =
       /** Every reason nothing more specific could be asserted. */
       readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
     };
+
+/**
+ * A structured comparison between one field of a fixture case's declared
+ * `expect` and what was actually observed, produced by `assertCase`
+ * (`src/internal/assert/`).
+ *
+ * @remarks
+ * Each member carries the expected and actual value for exactly one field of
+ * a fixture case's `expect`, in enough structured detail for a reporter to
+ * render text like "expected deny / actual pass — the hook fired but exited
+ * 0" without this type ever holding a pre-rendered string itself — rendering
+ * that text is a reporter's job (`src/internal/report/`), not this type's.
+ *
+ * @public
+ */
+export type ExpectationDiff =
+  | {
+      /** Whether any hook fired at all disagreed with `expect.fires`. */
+      readonly field: "fires";
+      /** The fixture's declared `expect.fires`. */
+      readonly expectedFires: boolean;
+      /** Whether a hook actually fired. */
+      readonly actualFires: boolean;
+    }
+  | {
+      /** The resolved `Decision.kind` disagreed with `expect.decision`. */
+      readonly field: "decision";
+      /** The fixture's declared `expect.decision`. */
+      readonly expectedDecision: Decision["kind"];
+      /** The actually resolved `Decision.kind`. */
+      readonly actualDecision: Decision["kind"];
+    }
+  | {
+      /** The resolved `Decision`'s exit code disagreed with `expect.exitCode`. */
+      readonly field: "exitCode";
+      /** The fixture's declared `expect.exitCode`. */
+      readonly expectedExitCode: number;
+      /** The actually resolved `Decision`'s exit code. */
+      readonly actualExitCode: number;
+    }
+  | {
+      /** The hook's stdout did not contain `expect.stdoutContains`. */
+      readonly field: "stdoutContains";
+      /** The fixture's declared `expect.stdoutContains`. */
+      readonly expectedSubstring: string;
+      /** The hook's actual stdout. */
+      readonly actualStdout: string;
+    }
+  | {
+      /** The hook's stderr did not contain `expect.stderrContains`. */
+      readonly field: "stderrContains";
+      /** The fixture's declared `expect.stderrContains`. */
+      readonly expectedSubstring: string;
+      /** The hook's actual stderr. */
+      readonly actualStderr: string;
+    }
+  | {
+      /** Whether the hook timed out disagreed with `expect.timedOut`. */
+      readonly field: "timedOut";
+      /** The fixture's declared `expect.timedOut`. */
+      readonly expectedTimedOut: boolean;
+      /** Whether the hook actually timed out. */
+      readonly actualTimedOut: boolean;
+    };
+
+/**
+ * One hook that was a matcher candidate for a case's event but did not fire,
+ * paired with the reason the matcher engine rejected it.
+ *
+ * @public
+ */
+export interface RejectedMatch {
+  /** The hook that did not fire. */
+  readonly hook: ResolvedHook;
+  /** Why the matcher engine did not fire it. */
+  readonly reason: string;
+}
+
+/**
+ * Why a fixture case's `expect.fires: true` was not met.
+ *
+ * @remarks
+ * `"matcher-did-not-match"` — at least one candidate hook was declared under
+ * the case's event, but every one of them was rejected by the matcher.
+ * `"no-hook-configured"` — no hook at all is declared under the case's
+ * event, in any settings layer the fixture loaded.
+ * `"excluded-settings-layer"` — a hook that would otherwise be a candidate
+ * exists, but only in a settings layer the fixture's `settings:` list did
+ * not include.
+ *
+ * These three are kept distinct rather than collapsed into one generic "did
+ * not fire" message, so a reporter can point at the actual cause: a matcher
+ * to fix, a hook to add, or a fixture's `settings:` list to extend.
+ *
+ * @public
+ */
+export type NonFiringExplanation =
+  | {
+      /** At least one candidate hook was declared under the event, but every one of them was rejected by the matcher. */
+      readonly kind: "matcher-did-not-match";
+      /** Every candidate hook the matcher rejected, and why. */
+      readonly hooks: readonly RejectedMatch[];
+    }
+  | {
+      /** No hook at all is declared under the case's event, in any settings layer the fixture loaded. */
+      readonly kind: "no-hook-configured";
+      /** The event with no hook declared under it at all. */
+      readonly event: EventName;
+    }
+  | {
+      /** A hook that would otherwise be a candidate exists only in a settings layer the fixture's `settings:` list did not include. */
+      readonly kind: "excluded-settings-layer";
+      /** Hooks that would be candidates, declared in an excluded settings layer. */
+      readonly hooks: readonly ResolvedHook[];
+    };
+
+/**
+ * The comparison between one fixture case's declared `expect` and what
+ * actually happened, produced by `assertCase` (`src/internal/assert/`).
+ *
+ * @remarks
+ * `unknown`'s `reasons` is a non-empty tuple for the same reason
+ * `Decision.unknown.reasons` is: an `unknown` `CaseResult` without at least
+ * one {@link UnknownReason} cannot be constructed, at the type level, by any
+ * call site.
+ *
+ * @public
+ */
+export type CaseResult =
+  | {
+      /** Every declared expectation was met. */
+      readonly kind: "pass";
+      /** Where the case's input payload came from. */
+      readonly origin: PayloadOrigin;
+    }
+  | {
+      /** At least one declared expectation was not met. */
+      readonly kind: "fail";
+      /** Where the case's input payload came from. */
+      readonly origin: PayloadOrigin;
+      /**
+       * Every expectation field that disagreed with what was observed.
+       * Non-empty whenever `nonFiring` (on this same result) is `undefined`.
+       */
+      readonly diffs: readonly ExpectationDiff[];
+      /**
+       * Set when the failure is that `expect.fires: true` was declared but
+       * no hook fired; `undefined` when the failure is instead a `diffs`
+       * mismatch (on this same result) on a hook that did fire.
+       */
+      readonly nonFiring: NonFiringExplanation | undefined;
+    }
+  | {
+      /**
+       * The resolved `Decision` could not be asserted with confidence;
+       * `reasons` is a non-empty tuple, so an `unknown` without at least one
+       * {@link UnknownReason} cannot be constructed, at the type level, by
+       * any call site.
+       */
+      readonly kind: "unknown";
+      /** Where the case's input payload came from. */
+      readonly origin: PayloadOrigin;
+      /** Every reason nothing more specific could be asserted. */
+      readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+    }
+  | {
+      /** The case declared nothing to compare, so it was skipped rather than asserted or left `unknown`. */
+      readonly kind: "skipped";
+      /** Where the case's input payload came from. */
+      readonly origin: PayloadOrigin;
+      /**
+       * `"dry-run"` — the case declared `dryRun: true`, so nothing was run.
+       * `"stub-only"` — the case declares only stubs and no expectation at
+       * all, so there is nothing to compare.
+       */
+      readonly reason: "dry-run" | "stub-only";
+    };
+
+/**
+ * The fold of every `CaseResult` from one or more fixture files into the
+ * counts every reporter prints, produced by `summarize`
+ * (`src/internal/assert/`).
+ *
+ * @remarks
+ * Every reporter (`pretty`, and the future `json`/`github`) renders this
+ * shape as-is; none of them re-derives or re-counts anything on its own —
+ * this is what keeps a summary line like "asserted N cases (M from recorded
+ * payloads), K unknown" honest: it interpolates {@link Summary.asserted},
+ * {@link Summary.fromRecorded} and {@link Summary.unknown} directly, rather
+ * than a value any reporter computed independently.
+ *
+ * `asserted` and `fromRecorded` count only `"pass"` and `"fail"` results —
+ * a `"unknown"` or `"skipped"` `CaseResult` never contributes to either.
+ *
+ * @public
+ */
+export interface Summary {
+  /** Count of `"pass"` plus `"fail"` results. */
+  readonly asserted: number;
+  /** Subset of {@link Summary.asserted} whose origin is `"recorded"`. */
+  readonly fromRecorded: number;
+  /** Count of `"fail"` results — a subset of {@link Summary.asserted}. */
+  readonly failed: number;
+  /** Count of `"unknown"` results. */
+  readonly unknown: number;
+  /** Count of `"skipped"` results. */
+  readonly skipped: number;
+}

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from "vitest";
+
+import { assertCase, summarize } from "../src/internal/assert/index.js";
+import type { CaseObservation } from "../src/internal/assert/index.js";
+import type { FixtureCase, FixtureExpectation } from "../src/internal/fixture/index.js";
+import type { MatcherOutcome } from "../src/internal/matcher/index.js";
+import type {
+  CaseResult,
+  EventName,
+  ExecOutcome,
+  PayloadOrigin,
+  Provenance,
+  ResolvedHook,
+  UnknownReason,
+} from "../src/types.js";
+
+// Reaching src/internal/assert/, src/internal/fixture/, and
+// src/internal/matcher/ directly (rather than through src/index.ts's
+// exports, per the writing-tests skill) is a deliberate, narrowly scoped
+// exception: none of these modules has a public runtime surface in this
+// issue and assertCase/summarize won't have one until a later `test`-command
+// issue's composition root wires them in — see eslint.config.mjs's
+// "tests/static-layer-unit-tests" block for the full reasoning. The
+// *published types* (`CaseResult`, `Summary`, `ExecOutcome`, `PayloadOrigin`,
+// `UnknownReason`, ...) are already part of the public contract, so those
+// come from "../src/types.js" like any other type test's imports.
+
+let nextOffset = 0;
+
+function makeHook(overrides: Partial<ResolvedHook> = {}): ResolvedHook {
+  const provenance: Provenance = {
+    file: "/fake/settings.json",
+    layer: "project",
+    line: 1,
+    col: 1,
+    offset: nextOffset++,
+  };
+  return {
+    event: "PreToolUse",
+    matcher: "Bash",
+    command: "./hook.sh",
+    args: undefined,
+    timeoutMs: undefined,
+    provenance,
+    dedupeKey: `PreToolUse::./hook.sh::${String(nextOffset)}`,
+    ...overrides,
+  };
+}
+
+function makeExpect(overrides: Partial<FixtureExpectation> = {}): FixtureExpectation {
+  return {
+    fires: undefined,
+    decision: undefined,
+    exitCode: undefined,
+    stdoutContains: undefined,
+    stderrContains: undefined,
+    context: undefined,
+    updatedInput: undefined,
+    timedOut: undefined,
+    ...overrides,
+  };
+}
+
+function makeCase(overrides: Partial<FixtureCase> = {}): FixtureCase {
+  return {
+    event: "PreToolUse",
+    tool: undefined,
+    input: undefined,
+    origin: { kind: "synthetic" },
+    expect: makeExpect(),
+    stub: undefined,
+    dryRun: undefined,
+    cwd: undefined,
+    ...overrides,
+  };
+}
+
+function makeObservation(overrides: Partial<CaseObservation> = {}): CaseObservation {
+  return {
+    decision: undefined,
+    execOutcome: undefined,
+    rejectedByMatcher: [],
+    excludedHooks: [],
+    ...overrides,
+  };
+}
+
+function makeExecOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
+  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
+}
+
+function expectFail(result: CaseResult): Extract<CaseResult, { kind: "fail" }> {
+  if (result.kind !== "fail") {
+    throw new Error(`expected a fail CaseResult, got ${result.kind}`);
+  }
+  return result;
+}
+
+function expectUnknown(result: CaseResult): Extract<CaseResult, { kind: "unknown" }> {
+  if (result.kind !== "unknown") {
+    throw new Error(`expected an unknown CaseResult, got ${result.kind}`);
+  }
+  return result;
+}
+
+function expectSkipped(result: CaseResult): Extract<CaseResult, { kind: "skipped" }> {
+  if (result.kind !== "skipped") {
+    throw new Error(`expected a skipped CaseResult, got ${result.kind}`);
+  }
+  return result;
+}
+
+describe("assertCase: expectation diffing", () => {
+  it("a case whose hook fired but returned a different decision than expected produces a fail CaseResult with a non-empty diffs array", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "deny" }) });
+    const observation = makeObservation({
+      decision: { kind: "pass", exitCode: 0 },
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs.length).toBeGreaterThan(0);
+    expect(result.nonFiring).toBeUndefined();
+  });
+
+  it("the diff data is sufficient to render 'expected deny / actual pass' style text", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "deny" }) });
+    const observation = makeObservation({
+      decision: { kind: "pass", exitCode: 0 },
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "decision",
+      expectedDecision: "deny",
+      actualDecision: "pass",
+    });
+  });
+
+  it.each([
+    ["exitCode", makeExpect({ exitCode: 2 }), { kind: "pass", exitCode: 0 } as const],
+    [
+      "stdoutContains",
+      makeExpect({ stdoutContains: "blocked" }),
+      { kind: "allow", exitCode: 0 } as const,
+    ],
+    [
+      "stderrContains",
+      makeExpect({ stderrContains: "oops" }),
+      { kind: "allow", exitCode: 0 } as const,
+    ],
+    [
+      "timedOut",
+      makeExpect({ timedOut: true }),
+      { kind: "allow", exitCode: 0 } as const,
+    ],
+    ["fires", makeExpect({ fires: false }), { kind: "allow", exitCode: 0 } as const],
+  ])(
+    "a mismatched %s expectation produces a diff on that field",
+    (field, expectation, decision) => {
+      const caseData = makeCase({ expect: expectation });
+      const observation = makeObservation({
+        decision,
+        execOutcome: makeExecOutcome(),
+      });
+
+      const result = expectFail(assertCase(caseData, observation));
+
+      expect(result.diffs.some((diff) => diff.field === field)).toBe(true);
+    },
+  );
+
+  it("a case whose expectation is fully met produces a pass CaseResult", () => {
+    const caseData = makeCase({
+      expect: makeExpect({
+        fires: true,
+        decision: "deny",
+        exitCode: 2,
+        stdoutContains: "blocked",
+        stderrContains: "reason",
+        timedOut: false,
+      }),
+    });
+    const observation = makeObservation({
+      decision: { kind: "deny", source: "exit-code", exitCode: 2 },
+      execOutcome: makeExecOutcome({
+        exitCode: 2,
+        stdout: "action blocked by policy",
+        stderr: "reason: not allowed",
+        timedOut: false,
+      }),
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("a case with no expectations at all, whose hook did not fire, produces a pass CaseResult", () => {
+    const caseData = makeCase();
+    const result = assertCase(caseData, makeObservation());
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("expect.timedOut defaults the actual value to false when the fired hook carries no execOutcome", () => {
+    const caseData = makeCase({ expect: makeExpect({ timedOut: true }) });
+    const observation = makeObservation({
+      decision: { kind: "allow", exitCode: 0 },
+      execOutcome: undefined,
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "timedOut",
+      expectedTimedOut: true,
+      actualTimedOut: false,
+    });
+  });
+});
+
+describe("assertCase: non-firing explanations", () => {
+  it("a case declaring expect.fires: true whose hook did not fire produces a fail CaseResult with nonFiring set", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: true }) });
+
+    const result = expectFail(assertCase(caseData, makeObservation()));
+
+    expect(result.diffs).toEqual([]);
+    expect(result.nonFiring).toBeDefined();
+  });
+
+  it("nonFiring reports matcher-did-not-match when a candidate hook was rejected by the matcher", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: true }) });
+    const outcome: MatcherOutcome = {
+      hook: makeHook(),
+      kind: "exact-list",
+      reason: "evaluated as an exact-match list and did not match Bash",
+    };
+    const observation = makeObservation({ rejectedByMatcher: [outcome] });
+
+    const result = expectFail(assertCase(caseData, observation));
+    const { nonFiring } = result;
+    if (nonFiring === undefined) {
+      throw new Error("expected nonFiring to be set");
+    }
+
+    expect(nonFiring.kind).toBe("matcher-did-not-match");
+    if (nonFiring.kind === "matcher-did-not-match") {
+      expect(nonFiring.hooks).toEqual([{ hook: outcome.hook, reason: outcome.reason }]);
+    }
+  });
+
+  it("nonFiring reports excluded-settings-layer when a hook exists only in a settings layer this fixture did not include", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: true }) });
+    const excludedHook = makeHook();
+    const observation = makeObservation({ excludedHooks: [excludedHook] });
+
+    const result = expectFail(assertCase(caseData, observation));
+    const { nonFiring } = result;
+    if (nonFiring === undefined) {
+      throw new Error("expected nonFiring to be set");
+    }
+
+    expect(nonFiring.kind).toBe("excluded-settings-layer");
+    if (nonFiring.kind === "excluded-settings-layer") {
+      expect(nonFiring.hooks).toEqual([excludedHook]);
+    }
+  });
+
+  it("nonFiring reports no-hook-configured when nothing is declared under the event at all", () => {
+    const event: EventName = "SessionStart";
+    const caseData = makeCase({ event, expect: makeExpect({ fires: true }) });
+
+    const result = expectFail(assertCase(caseData, makeObservation()));
+    const { nonFiring } = result;
+    if (nonFiring === undefined) {
+      throw new Error("expected nonFiring to be set");
+    }
+
+    expect(nonFiring).toEqual({ kind: "no-hook-configured", event });
+  });
+
+  it("nonFiring prefers matcher-did-not-match over excluded-settings-layer when both are present", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: true }) });
+    const outcome: MatcherOutcome = {
+      hook: makeHook(),
+      kind: "unanchored-regex",
+      reason: "evaluated as an unanchored regex and did not match",
+    };
+    const observation = makeObservation({
+      rejectedByMatcher: [outcome],
+      excludedHooks: [makeHook()],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+    expect(result.nonFiring?.kind).toBe("matcher-did-not-match");
+  });
+});
+
+describe("assertCase: unresolved decisions", () => {
+  it("a case whose Decision could not be resolved produces an unknown CaseResult carrying at least one UnknownReason", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: true }) });
+    const reason: UnknownReason = {
+      kind: "version-out-of-spec-range",
+      detected: "9.9.9",
+      specRange: ">=2.1.251 <2.2.0",
+    };
+    const observation = makeObservation({
+      decision: { kind: "unknown", reasons: [reason] },
+    });
+
+    const result = expectUnknown(assertCase(caseData, observation));
+
+    expect(result.reasons.length).toBeGreaterThan(0);
+    expect(result.reasons).toEqual([reason]);
+  });
+
+  it("an unknown Decision produces an unknown CaseResult even when the fixture expected fires: false", () => {
+    // The fixture's own expectation is irrelevant once nothing can be
+    // asserted with confidence at all — see assertCase's own remark.
+    const caseData = makeCase({ expect: makeExpect({ fires: false }) });
+    const reason: UnknownReason = {
+      kind: "plugin-hooks-present",
+      files: ["/etc/plugin.json"],
+    };
+    const observation = makeObservation({
+      decision: { kind: "unknown", reasons: [reason] },
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).toBe("unknown");
+  });
+});
+
+describe("assertCase: skipped cases", () => {
+  it("a dry-run case produces a skipped CaseResult with reason dry-run", () => {
+    const caseData = makeCase({ dryRun: true });
+
+    const result = expectSkipped(assertCase(caseData, makeObservation()));
+
+    expect(result.reason).toBe("dry-run");
+  });
+
+  it("a stub-only case (stub declared, no expectation) produces a skipped CaseResult with reason stub-only", () => {
+    const caseData = makeCase({ stub: { "./notify.sh": { exitCode: 0 } } });
+
+    const result = expectSkipped(assertCase(caseData, makeObservation()));
+
+    expect(result.reason).toBe("stub-only");
+  });
+
+  it("dry-run takes precedence over stub-only when both apply", () => {
+    const caseData = makeCase({
+      dryRun: true,
+      stub: { "./notify.sh": { exitCode: 0 } },
+    });
+
+    const result = expectSkipped(assertCase(caseData, makeObservation()));
+
+    expect(result.reason).toBe("dry-run");
+  });
+
+  it("a case that declares a stub but also an expectation is not treated as stub-only", () => {
+    const caseData = makeCase({
+      stub: { "./notify.sh": { exitCode: 0 } },
+      expect: makeExpect({ fires: true }),
+    });
+
+    const result = assertCase(caseData, makeObservation());
+
+    expect(result.kind).toBe("fail");
+  });
+});
+
+const recordedOrigin: PayloadOrigin = {
+  kind: "recorded",
+  capturedAt: "2026-01-01T00:00:00Z",
+  sourceFile: "/abs/envelope.json",
+  claudeVersion: undefined,
+};
+const syntheticOrigin: PayloadOrigin = { kind: "synthetic" };
+
+describe("summarize", () => {
+  it("folds pass+fail into asserted, counts recorded-origin passes/fails into fromRecorded, and counts unknown/skipped separately", () => {
+    const results: CaseResult[] = [
+      { kind: "pass", origin: syntheticOrigin },
+      { kind: "pass", origin: recordedOrigin },
+      { kind: "fail", origin: recordedOrigin, diffs: [], nonFiring: undefined },
+      { kind: "fail", origin: syntheticOrigin, diffs: [], nonFiring: undefined },
+      {
+        kind: "unknown",
+        origin: syntheticOrigin,
+        reasons: [{ kind: "plugin-hooks-present", files: [] }],
+      },
+      { kind: "skipped", origin: syntheticOrigin, reason: "dry-run" },
+      { kind: "skipped", origin: recordedOrigin, reason: "stub-only" },
+    ];
+
+    const summary = summarize(results);
+
+    expect(summary).toEqual({
+      asserted: 4,
+      fromRecorded: 2,
+      failed: 2,
+      unknown: 1,
+      skipped: 2,
+    });
+  });
+
+  it("returns every field zeroed for an empty result list", () => {
+    expect(summarize([])).toEqual({
+      asserted: 0,
+      fromRecorded: 0,
+      failed: 0,
+      unknown: 0,
+      skipped: 0,
+    });
+  });
+
+  it("never double-counts a case across two Summary fields", () => {
+    const results: CaseResult[] = [
+      { kind: "pass", origin: syntheticOrigin },
+      { kind: "pass", origin: recordedOrigin },
+      { kind: "fail", origin: syntheticOrigin, diffs: [], nonFiring: undefined },
+      {
+        kind: "unknown",
+        origin: syntheticOrigin,
+        reasons: [{ kind: "plugin-hooks-present", files: [] }],
+      },
+      { kind: "skipped", origin: syntheticOrigin, reason: "dry-run" },
+    ];
+
+    const summary = summarize(results);
+
+    // asserted, unknown, and skipped are the three disjoint buckets every
+    // result falls into exactly once; failed and fromRecorded are
+    // sub-counts of asserted, not additional buckets.
+    expect(summary.asserted + summary.unknown + summary.skipped).toBe(results.length);
+    expect(summary.failed).toBeLessThanOrEqual(summary.asserted);
+    expect(summary.fromRecorded).toBeLessThanOrEqual(summary.asserted);
+  });
+});

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type {
+  CaseResult,
   Decision,
   EventName,
   ExecOutcome,
+  ExpectationDiff,
+  NonFiringExplanation,
   PayloadOrigin,
   Provenance,
+  RejectedMatch,
   ResolvedHook,
   SettingsLayer,
+  Summary,
   UnknownReason,
   VersionSourceName,
 } from "../src/index.js";
@@ -439,6 +444,244 @@ describe("PayloadOrigin", () => {
       // @ts-expect-error a synthetic origin carries no envelope fields
       const origin: PayloadOrigin = { kind: "synthetic", capturedAt: "now" };
       void origin;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+});
+
+/** A complete `ResolvedHook`, reused by the `CaseResult` cases below. */
+const hook: ResolvedHook = {
+  event: "PreToolUse",
+  matcher: "Bash",
+  command: "./hook.sh",
+  args: undefined,
+  timeoutMs: undefined,
+  provenance,
+  dedupeKey: "PreToolUse::./hook.sh",
+};
+
+describe("CaseResult", () => {
+  it("narrows on kind to each variant's own fields", () => {
+    const narrow = (result: CaseResult): void => {
+      switch (result.kind) {
+        case "pass": {
+          expectTypeOf(result).toEqualTypeOf<{
+            readonly kind: "pass";
+            readonly origin: PayloadOrigin;
+          }>();
+          break;
+        }
+        case "fail": {
+          expectTypeOf(result).toEqualTypeOf<{
+            readonly kind: "fail";
+            readonly origin: PayloadOrigin;
+            readonly diffs: readonly ExpectationDiff[];
+            readonly nonFiring: NonFiringExplanation | undefined;
+          }>();
+          break;
+        }
+        case "unknown": {
+          expectTypeOf(result).toEqualTypeOf<{
+            readonly kind: "unknown";
+            readonly origin: PayloadOrigin;
+            readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+          }>();
+          break;
+        }
+        case "skipped": {
+          expectTypeOf(result).toEqualTypeOf<{
+            readonly kind: "skipped";
+            readonly origin: PayloadOrigin;
+            readonly reason: "dry-run" | "stub-only";
+          }>();
+          break;
+        }
+      }
+    };
+    narrow({ kind: "pass", origin: { kind: "synthetic" } });
+    narrow({
+      kind: "fail",
+      origin: { kind: "synthetic" },
+      diffs: [{ field: "exitCode", expectedExitCode: 2, actualExitCode: 0 }],
+      nonFiring: undefined,
+    });
+    narrow({
+      kind: "fail",
+      origin: { kind: "synthetic" },
+      diffs: [],
+      nonFiring: { kind: "no-hook-configured", event: "PreToolUse" },
+    });
+    narrow({
+      kind: "unknown",
+      origin: { kind: "synthetic" },
+      reasons: [{ kind: "plugin-hooks-present", files: [] }],
+    });
+    narrow({ kind: "skipped", origin: { kind: "synthetic" }, reason: "dry-run" });
+  });
+
+  it("an unknown result's reasons rejects an empty array at compile time, mirroring Decision.unknown", () => {
+    const rejected = (): void => {
+      const result: CaseResult = {
+        kind: "unknown",
+        origin: { kind: "synthetic" },
+        // @ts-expect-error reasons is a non-empty tuple, not a plain array — an empty array cannot construct it
+        reasons: [],
+      };
+      void result;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("accepts an unknown result with exactly one reason", () => {
+    const reason: UnknownReason = { kind: "plugin-hooks-present", files: [] };
+    const result: CaseResult = {
+      kind: "unknown",
+      origin: { kind: "synthetic" },
+      reasons: [reason],
+    };
+    expectTypeOf(result.reasons).toEqualTypeOf<
+      readonly [UnknownReason, ...UnknownReason[]]
+    >();
+  });
+
+  it("rejects a fail variant missing nonFiring", () => {
+    const rejected = (): void => {
+      // @ts-expect-error nonFiring must be present, even as undefined, per exactOptionalPropertyTypes
+      const result: CaseResult = {
+        kind: "fail",
+        origin: { kind: "synthetic" },
+        diffs: [],
+      };
+      void result;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+});
+
+describe("ExpectationDiff", () => {
+  it("narrows on field to each member's own expected/actual pair", () => {
+    const narrow = (diff: ExpectationDiff): void => {
+      switch (diff.field) {
+        case "fires": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "fires";
+            readonly expectedFires: boolean;
+            readonly actualFires: boolean;
+          }>();
+          break;
+        }
+        case "decision": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "decision";
+            readonly expectedDecision: Decision["kind"];
+            readonly actualDecision: Decision["kind"];
+          }>();
+          break;
+        }
+        case "exitCode": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "exitCode";
+            readonly expectedExitCode: number;
+            readonly actualExitCode: number;
+          }>();
+          break;
+        }
+        case "stdoutContains": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "stdoutContains";
+            readonly expectedSubstring: string;
+            readonly actualStdout: string;
+          }>();
+          break;
+        }
+        case "stderrContains": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "stderrContains";
+            readonly expectedSubstring: string;
+            readonly actualStderr: string;
+          }>();
+          break;
+        }
+        case "timedOut": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "timedOut";
+            readonly expectedTimedOut: boolean;
+            readonly actualTimedOut: boolean;
+          }>();
+          break;
+        }
+      }
+    };
+    narrow({ field: "fires", expectedFires: true, actualFires: false });
+    narrow({ field: "decision", expectedDecision: "deny", actualDecision: "pass" });
+    narrow({ field: "exitCode", expectedExitCode: 2, actualExitCode: 0 });
+    narrow({
+      field: "stdoutContains",
+      expectedSubstring: "blocked",
+      actualStdout: "",
+    });
+    narrow({
+      field: "stderrContains",
+      expectedSubstring: "denied",
+      actualStderr: "",
+    });
+    narrow({ field: "timedOut", expectedTimedOut: true, actualTimedOut: false });
+  });
+});
+
+describe("NonFiringExplanation", () => {
+  it("narrows on kind to each member's own fields", () => {
+    const narrow = (explanation: NonFiringExplanation): void => {
+      switch (explanation.kind) {
+        case "matcher-did-not-match": {
+          expectTypeOf(explanation).toEqualTypeOf<{
+            readonly kind: "matcher-did-not-match";
+            readonly hooks: readonly RejectedMatch[];
+          }>();
+          break;
+        }
+        case "no-hook-configured": {
+          expectTypeOf(explanation).toEqualTypeOf<{
+            readonly kind: "no-hook-configured";
+            readonly event: EventName;
+          }>();
+          break;
+        }
+        case "excluded-settings-layer": {
+          expectTypeOf(explanation).toEqualTypeOf<{
+            readonly kind: "excluded-settings-layer";
+            readonly hooks: readonly ResolvedHook[];
+          }>();
+          break;
+        }
+      }
+    };
+    narrow({
+      kind: "matcher-did-not-match",
+      hooks: [{ hook, reason: "did not match" }],
+    });
+    narrow({ kind: "no-hook-configured", event: "PreToolUse" });
+    narrow({ kind: "excluded-settings-layer", hooks: [hook] });
+  });
+});
+
+describe("Summary", () => {
+  it("requires asserted, fromRecorded, failed, unknown, skipped with no optional fields", () => {
+    expectTypeOf<Summary>().toEqualTypeOf<{
+      readonly asserted: number;
+      readonly fromRecorded: number;
+      readonly failed: number;
+      readonly unknown: number;
+      readonly skipped: number;
+    }>();
+    expectTypeOf<Required<Summary>>().toEqualTypeOf<Summary>();
+  });
+
+  it("rejects a summary missing skipped", () => {
+    const rejected = (): void => {
+      // @ts-expect-error every field is required, including skipped
+      const summary: Summary = { asserted: 0, fromRecorded: 0, failed: 0, unknown: 0 };
+      void summary;
     };
     expect(rejected).toBeTypeOf("function");
   });


### PR DESCRIPTION
## Summary

Implements `assertCase` (`src/internal/assert/assertCase.ts`), the pure comparison
between a fixture case's declared `expect` and what actually happened (the resolved
`Decision` plus the matcher engine's rejected/excluded candidates), and `summarize`
(`src/internal/assert/summarize.ts`), the single fold every reporter reads instead of
keeping its own counters.

- `assertCase` distinguishes two failure modes: an `ExpectationDiff[]` mismatch on a
  hook that fired but disagreed with `expect`, versus a `NonFiringExplanation`
  (`matcher-did-not-match` / `excluded-settings-layer` / `no-hook-configured`) when
  `expect.fires: true` was declared but nothing fired.
- New public types `CaseResult`, `Summary`, `ExpectationDiff`, `NonFiringExplanation`,
  `RejectedMatch` land in `src/types.ts` and are exported from `src/index.ts`.
  `ExpectationDiff`/`NonFiringExplanation`/`RejectedMatch` are exported even though the
  issue's own text suggested keeping them internal — they're structurally embedded in
  the public `CaseResult`'s fields, and TypeDoc's `notExported` gate (`treatWarningsAsErrors:
  true`) fails the build otherwise. Verified empirically before merging.

Closes #10

## Test plan

- `pnpm exec vitest run tests/assert.test.ts` (24 tests) — pass
- `pnpm exec vitest run tests/types.test.ts tests/assert.test.ts` (56 tests) — pass
- `pnpm check:quick` (format/lint/typecheck/full suite: 31 files, 1214 tests) — pass
- `pnpm docs:build` — pass (validates the new public types satisfy TypeDoc's
  `notExported`/`notDocumented` gates)
- `pnpm test:coverage` — pass; `src/internal/assert/` at 100% stmts/funcs/lines,
  98.41% branches (repo floor 90%)
- Reviewed with `/code-review medium --fix`; one finding (assertCase doesn't compare
  `expect.context`/`expect.updatedInput`) confirmed out of scope for this issue and
  filed as #34 rather than fixed inline.