### PR TITLE
feat: add the json and github reporters, and a shared --format selector

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -377,6 +377,7 @@ export default defineConfig([
       "tests/matcher.test.ts",
       "tests/cli.test.ts",
       "tests/report.test.ts",
+      "tests/reporters.test.ts",
       "tests/fixture.test.ts",
       "tests/assert.test.ts",
     ],

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/tomada1114/hookassert/schema/report.schema.json",
+  "title": "hookassert JSON report",
+  "description": "Schema for the `json` reporter's output (src/internal/report/json.ts): the fixed, versioned contract downstream CI tooling may parse directly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["reportVersion", "header", "event", "target", "firing", "rejected"],
+  "properties": {
+    "reportVersion": {
+      "const": "1",
+      "description": "Version of this report shape, independent of the package's own semver."
+    },
+    "header": { "$ref": "#/$defs/header" },
+    "event": { "type": "string", "minLength": 1 },
+    "target": { "type": ["string", "null"] },
+    "firing": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/firingHook" }
+    },
+    "rejected": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rejectedOutcome" }
+    }
+  },
+  "$defs": {
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claudeVersion", "specRange", "notices"],
+      "properties": {
+        "claudeVersion": { "type": "string", "minLength": 1 },
+        "specRange": { "type": "string", "minLength": 1 },
+        "notices": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "layer", "line", "col", "offset"],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "layer": {
+          "type": "string",
+          "enum": ["user", "project", "local", "explicit"]
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "col": { "type": "integer", "minimum": 1 },
+        "offset": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "hook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "matcher",
+        "command",
+        "args",
+        "timeoutMs",
+        "dedupeKey",
+        "provenance"
+      ],
+      "properties": {
+        "event": { "type": "string", "minLength": 1 },
+        "matcher": { "type": ["string", "null"] },
+        "command": { "type": "string", "minLength": 1 },
+        "args": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "timeoutMs": { "type": ["integer", "null"], "minimum": 0 },
+        "dedupeKey": { "type": "string", "minLength": 1 },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      }
+    },
+    "firingHook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "matcher",
+        "command",
+        "args",
+        "timeoutMs",
+        "dedupeKey",
+        "provenance",
+        "matcherIgnored"
+      ],
+      "properties": {
+        "event": { "type": "string", "minLength": 1 },
+        "matcher": { "type": ["string", "null"] },
+        "command": { "type": "string", "minLength": 1 },
+        "args": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "timeoutMs": { "type": ["integer", "null"], "minimum": 0 },
+        "dedupeKey": { "type": "string", "minLength": 1 },
+        "provenance": { "$ref": "#/$defs/provenance" },
+        "matcherIgnored": { "type": "boolean" }
+      }
+    },
+    "rejectedOutcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hook", "kind", "reason"],
+      "properties": {
+        "hook": { "$ref": "#/$defs/hook" },
+        "kind": {
+          "type": "string",
+          "enum": ["exact-list", "unanchored-regex", "unknown"]
+        },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -72,7 +72,7 @@
           "type": ["array", "null"],
           "items": { "type": "string" }
         },
-        "timeoutMs": { "type": ["integer", "null"], "minimum": 0 },
+        "timeoutMs": { "type": ["number", "null"] },
         "dedupeKey": { "type": "string", "minLength": 1 },
         "provenance": { "$ref": "#/$defs/provenance" }
       }
@@ -98,7 +98,7 @@
           "type": ["array", "null"],
           "items": { "type": "string" }
         },
-        "timeoutMs": { "type": ["integer", "null"], "minimum": 0 },
+        "timeoutMs": { "type": ["number", "null"] },
         "dedupeKey": { "type": "string", "minLength": 1 },
         "provenance": { "$ref": "#/$defs/provenance" },
         "matcherIgnored": { "type": "boolean" }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,9 @@ import {
 import { matchHooks, type VersionContext } from "./internal/matcher/index.js";
 import {
   buildReportHeader,
+  renderGithub,
+  renderInFormat,
+  renderJson,
   renderPretty,
   type ExplainReport,
 } from "./internal/report/index.js";
@@ -289,12 +292,6 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
     );
   }
 
-  const format = parsed.values.format ?? "pretty";
-  if (format !== "pretty") {
-    throw new UsageError(
-      `the ${JSON.stringify(format)} report format is not implemented yet; only "pretty" renders.`,
-    );
-  }
   if (parsed.values["emit-fixtures"] !== undefined) {
     throw new UsageError("the --emit-fixtures option is not implemented yet.");
   }
@@ -334,7 +331,13 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
     rejected: match.rejected,
   };
 
-  return { exitCode: 0, stdout: renderPretty(report), stderr: "" };
+  const stdout = renderInFormat(report, parsed.values.format, {
+    pretty: renderPretty,
+    json: renderJson,
+    github: renderGithub,
+  });
+
+  return { exitCode: 0, stdout, stderr: "" };
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
 import { matchHooks, type VersionContext } from "./internal/matcher/index.js";
 import {
   buildReportHeader,
+  isReportFormat,
   renderGithub,
   renderInFormat,
   renderJson,
@@ -294,6 +295,18 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
 
   if (parsed.values["emit-fixtures"] !== undefined) {
     throw new UsageError("the --emit-fixtures option is not implemented yet.");
+  }
+
+  // Validated here, before any I/O (version resolution, spec loading, the
+  // --settings existence check, loadSettings): a typo'd --format must fail
+  // as its own ERR_USAGE rather than surfacing as an unrelated I/O error
+  // once rendering is finally reached. `renderInFormat` below still owns the
+  // actual format-to-renderer selection, so that logic stays in one place.
+  if (parsed.values.format !== undefined && !isReportFormat(parsed.values.format)) {
+    throw new UsageError(
+      `unrecognized --format ${JSON.stringify(parsed.values.format)}. ` +
+        `Expected one of: pretty, json, github.`,
+    );
   }
 
   const versionContext = resolveVersionContext(

--- a/src/internal/report/format.ts
+++ b/src/internal/report/format.ts
@@ -1,0 +1,62 @@
+/**
+ * The one place a `--format` value turns into an actual rendering.
+ *
+ * @remarks
+ * Static layer: pure — no I/O, no process, no write. `explain` calls
+ * {@link renderInFormat} today; `lint` and `test` route through it unchanged
+ * once they exist, each supplying its own {@link FormatRenderers} for its own
+ * result shape, so the three subcommands can never drift on which formats
+ * exist or silently reimplement the same `switch` three times.
+ */
+
+import { UsageError } from "../errors.js";
+
+/** The report formats `--format` accepts, shared by every subcommand that renders a report. */
+export type ReportFormat = "pretty" | "json" | "github";
+
+const REPORT_FORMATS: readonly ReportFormat[] = ["pretty", "json", "github"];
+
+/** Whether `value` is one of {@link ReportFormat}'s members. */
+export function isReportFormat(value: string): value is ReportFormat {
+  return (REPORT_FORMATS as readonly string[]).includes(value);
+}
+
+/**
+ * One renderer per {@link ReportFormat}, all rendering the same report shape
+ * `T` — `ExplainReport` for `explain` today, whatever `lint`/`test` produce
+ * once they exist.
+ */
+export interface FormatRenderers<T> {
+  readonly pretty: (report: T) => string;
+  readonly json: (report: T) => string;
+  readonly github: (report: T) => string;
+}
+
+/**
+ * Render `report` in the format `--format` named, defaulting to `"pretty"`
+ * when `format` is `undefined`.
+ *
+ * @throws {UsageError} `format` is given but is not one of `"pretty" | "json"
+ * | "github"`.
+ */
+export function renderInFormat<T>(
+  report: T,
+  format: string | undefined,
+  renderers: FormatRenderers<T>,
+): string {
+  const resolved = format ?? "pretty";
+  if (!isReportFormat(resolved)) {
+    throw new UsageError(
+      `unrecognized --format ${JSON.stringify(resolved)}. ` +
+        `Expected one of: ${REPORT_FORMATS.join(", ")}.`,
+    );
+  }
+  switch (resolved) {
+    case "pretty":
+      return renderers.pretty(report);
+    case "json":
+      return renderers.json(report);
+    case "github":
+      return renderers.github(report);
+  }
+}

--- a/src/internal/report/github.ts
+++ b/src/internal/report/github.ts
@@ -1,0 +1,120 @@
+/**
+ * The `github` reporter: GitHub Actions `::error`/`::notice` workflow-command
+ * annotations, sourced from a hook's own `Provenance` rather than a
+ * re-derived text search.
+ *
+ * @remarks
+ * Static layer: pure string formatting — no I/O, no process, no write.
+ * `explain` has no failure/finding concept of its own (it is descriptive,
+ * not adversarial), so `renderGithub` emits only the leading header line for
+ * an `ExplainReport` today; a `test` failure or a `lint` `Finding` (neither
+ * landed yet) maps its own `file`/`line` into a {@link ReportFinding} and
+ * renders it with {@link renderGithubFinding} — this module never needs to
+ * know either shape.
+ */
+
+import type { ExplainReport, ReportHeader } from "./summary.js";
+
+/**
+ * One line a reporter attaches to an exact source location, decoupled from
+ * `ResolvedHook` and a future lint `Finding`.
+ *
+ * @remarks
+ * `file`/`line` are read directly off the source's own provenance (a hook's
+ * `Provenance`, or a `Finding`'s own `file`/`line`) — never re-derived by
+ * scanning the settings file's text afterward.
+ */
+export interface ReportFinding {
+  /** Absolute or workspace-relative path of the file the finding is about. */
+  readonly file: string;
+  /** 1-based line the finding points at. */
+  readonly line: number;
+  /** The rule id or case name GitHub Actions shows as the annotation title. */
+  readonly title: string;
+  /** Human-readable explanation, shown as the annotation body. */
+  readonly message: string;
+}
+
+/**
+ * Make `file` safe to pass as a GitHub Actions annotation's `file=` property.
+ *
+ * @remarks
+ * GitHub Actions resolves an annotation's `file` relative to the repository
+ * checkout root (`GITHUB_WORKSPACE`); an absolute path from `Provenance.file`
+ * does not match any path in the PR diff view, so the annotation would
+ * silently fail to attach to a line rather than erroring loudly. Forward
+ * slashes are used even off POSIX, since GitHub's own parser expects them
+ * regardless of the runner's OS.
+ */
+export function relativizeForGithub(file: string, workspaceRoot: string): string {
+  const isAbsolute = file.startsWith("/") || /^[A-Za-z]:[\\/]/.test(file);
+  if (!isAbsolute) {
+    return file.split("\\").join("/");
+  }
+  const root = workspaceRoot.endsWith("/") ? workspaceRoot : `${workspaceRoot}/`;
+  const relative = file.startsWith(root) ? file.slice(root.length) : file;
+  return relative.split("\\").join("/");
+}
+
+/**
+ * Escape the characters GitHub Actions' workflow-command parser treats
+ * specially inside a `key=value` property, per its documented escaping rules.
+ */
+function escapeProperty(value: string): string {
+  return value
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A")
+    .replaceAll(":", "%3A")
+    .replaceAll(",", "%2C");
+}
+
+/** Escape the characters GitHub Actions' workflow-command parser treats specially inside the message body. */
+function escapeData(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+/**
+ * Render one {@link ReportFinding} as a single GitHub Actions `::error`
+ * workflow command, in the form
+ * `::error file=<settings file>,line=<line>,title=<rule or case>::<message>`.
+ */
+export function renderGithubFinding(
+  finding: ReportFinding,
+  workspaceRoot: string,
+): string {
+  const file = escapeProperty(relativizeForGithub(finding.file, workspaceRoot));
+  const title = escapeProperty(finding.title);
+  return `::error file=${file},line=${String(finding.line)},title=${title}::${escapeData(finding.message)}`;
+}
+
+/**
+ * Render the one leading informational line every `github` format output
+ * carries, with the same header facts `pretty`'s free text and `json`'s
+ * structured fields print.
+ */
+export function renderGithubHeader(header: ReportHeader): string {
+  const notices =
+    header.notices.length > 0 ? `; Notices: ${header.notices.join("; ")}` : "";
+  return escapeData(
+    `::notice title=hookassert::Claude Code version: ${header.claudeVersion}; ` +
+      `Spec range: ${header.specRange}${notices}`,
+  );
+}
+
+/**
+ * Render an {@link ExplainReport} as GitHub Actions workflow commands: the
+ * leading header line, plus one `::error` per relevant finding.
+ *
+ * @remarks
+ * `explain` produces no findings of its own in this issue — it has nothing
+ * to assert pass or fail against, unlike a `test` case or a `lint` rule — so
+ * today's output is the header line alone, and takes no `workspaceRoot`
+ * because it never relativizes a path. `test`/`lint` route their own
+ * failures/findings through {@link renderGithubFinding} directly once they
+ * exist, passing their own `workspaceRoot`, rather than through this
+ * function, since neither's result shape is `ExplainReport`.
+ */
+export function renderGithub(report: ExplainReport): string {
+  return `${renderGithubHeader(report.header)}\n`;
+}

--- a/src/internal/report/github.ts
+++ b/src/internal/report/github.ts
@@ -48,12 +48,21 @@ export interface ReportFinding {
  */
 export function relativizeForGithub(file: string, workspaceRoot: string): string {
   const isAbsolute = file.startsWith("/") || /^[A-Za-z]:[\\/]/.test(file);
+  const normalizedFile = file.split("\\").join("/");
   if (!isAbsolute) {
-    return file.split("\\").join("/");
+    return normalizedFile;
   }
-  const root = workspaceRoot.endsWith("/") ? workspaceRoot : `${workspaceRoot}/`;
-  const relative = file.startsWith(root) ? file.slice(root.length) : file;
-  return relative.split("\\").join("/");
+  const isWindowsPath = /^[A-Za-z]:\//.test(normalizedFile);
+  const normalizedRoot = workspaceRoot.split("\\").join("/");
+  const root = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
+  // Normalize separators on both sides before comparing — a Windows caller may
+  // pass `file` or `workspaceRoot` (or both) with backslashes, and comparing
+  // before normalizing means a Windows absolute path never matches its root.
+  // Windows paths also compare case-insensitively, since its filesystem is.
+  const matches = isWindowsPath
+    ? normalizedFile.toLowerCase().startsWith(root.toLowerCase())
+    : normalizedFile.startsWith(root);
+  return matches ? normalizedFile.slice(root.length) : normalizedFile;
 }
 
 /**

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -10,3 +10,14 @@
 export { renderPretty } from "./pretty.js";
 export { buildReportHeader, formatClaudeVersion } from "./summary.js";
 export type { ExplainReport, ReportHeader } from "./summary.js";
+export { renderJson, toJsonReport } from "./json.js";
+export type { JsonExplainReport } from "./json.js";
+export {
+  relativizeForGithub,
+  renderGithub,
+  renderGithubFinding,
+  renderGithubHeader,
+} from "./github.js";
+export type { ReportFinding } from "./github.js";
+export { isReportFormat, renderInFormat } from "./format.js";
+export type { FormatRenderers, ReportFormat } from "./format.js";

--- a/src/internal/report/json.ts
+++ b/src/internal/report/json.ts
@@ -1,0 +1,127 @@
+/**
+ * The `json` reporter: a fixed, versioned rendering of an `ExplainReport`,
+ * checked against `schema/report.schema.json`.
+ *
+ * @remarks
+ * Static layer: pure — no I/O, no process, no write. `schema/report.schema.json`
+ * is a shipped public contract from the moment it ships: a later change to
+ * this module's output shape needs the same `release-impact` review a
+ * `src/index.ts` change would, because downstream CI tooling may parse this
+ * JSON directly.
+ */
+
+import type { EventName, Provenance, ResolvedHook } from "../../types.js";
+import type { MatcherKind } from "../matcher/index.js";
+import type { ExplainReport } from "./summary.js";
+
+/** JSON shape of a {@link Provenance}, mirroring `schema/report.schema.json`'s `$defs.provenance`. */
+interface JsonProvenance {
+  readonly file: string;
+  readonly layer: string;
+  readonly line: number;
+  readonly col: number;
+  readonly offset: number;
+}
+
+/** JSON shape of a {@link ResolvedHook}, without the `matcherIgnored` field only a firing hook carries. */
+interface JsonHook {
+  readonly event: EventName;
+  readonly matcher: string | null;
+  readonly command: string;
+  readonly args: readonly string[] | null;
+  readonly timeoutMs: number | null;
+  readonly dedupeKey: string;
+  readonly provenance: JsonProvenance;
+}
+
+/** A firing hook, plus whether its declared matcher was ignored rather than evaluated. */
+interface JsonFiringHook extends JsonHook {
+  readonly matcherIgnored: boolean;
+}
+
+/** One hook that did not fire, and why. */
+interface JsonRejectedOutcome {
+  readonly hook: JsonHook;
+  readonly kind: MatcherKind;
+  readonly reason: string;
+}
+
+/**
+ * The shape `renderJson` emits, validated by `schema/report.schema.json`.
+ *
+ * @remarks
+ * `reportVersion` is this contract's own version, independent of the
+ * package's own semver — a later issue reshaping this output bumps
+ * `reportVersion` and updates the schema in the same change, per
+ * `release-impact`.
+ */
+export interface JsonExplainReport {
+  readonly reportVersion: "1";
+  readonly header: {
+    readonly claudeVersion: string;
+    readonly specRange: string;
+    readonly notices: readonly string[];
+  };
+  readonly event: EventName;
+  readonly target: string | null;
+  readonly firing: readonly JsonFiringHook[];
+  readonly rejected: readonly JsonRejectedOutcome[];
+}
+
+function toJsonProvenance(provenance: Provenance): JsonProvenance {
+  return {
+    file: provenance.file,
+    layer: provenance.layer,
+    line: provenance.line,
+    col: provenance.col,
+    offset: provenance.offset,
+  };
+}
+
+function toJsonHook(hook: ResolvedHook): JsonHook {
+  return {
+    event: hook.event,
+    matcher: hook.matcher ?? null,
+    command: hook.command,
+    args: hook.args ?? null,
+    timeoutMs: hook.timeoutMs ?? null,
+    dedupeKey: hook.dedupeKey,
+    provenance: toJsonProvenance(hook.provenance),
+  };
+}
+
+/** Build the JSON-serializable shape `renderJson` stringifies. */
+export function toJsonReport(report: ExplainReport): JsonExplainReport {
+  const ignored = new Set(report.matcherIgnored);
+  return {
+    reportVersion: "1",
+    header: {
+      claudeVersion: report.header.claudeVersion,
+      specRange: report.header.specRange,
+      notices: report.header.notices,
+    },
+    event: report.event,
+    target: report.target ?? null,
+    firing: report.firing.map((hook) => ({
+      ...toJsonHook(hook),
+      matcherIgnored: ignored.has(hook),
+    })),
+    rejected: report.rejected.map((outcome) => ({
+      hook: toJsonHook(outcome.hook),
+      kind: outcome.kind,
+      reason: outcome.reason,
+    })),
+  };
+}
+
+/**
+ * Render an {@link ExplainReport} as JSON matching `schema/report.schema.json`.
+ *
+ * @remarks
+ * The header's `claudeVersion`, `specRange`, and `notices` are carried as
+ * data fields rather than embedded prose — the same facts `renderPretty`
+ * prints as text, here structured for a machine reader.
+ */
+export function renderJson(report: ExplainReport): string {
+  return `${JSON.stringify(toJsonReport(report), null, 2)}\n`;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -329,7 +329,7 @@ describe("runCli explain", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it.each(["json", "github"])("selects the %s reporter for --format %s", (format) => {
+  it.each(["json", "github"])("selects the %s reporter", (format) => {
     const result = runCli(
       ["explain", "PreToolUse", "Bash", "--format", format],
       "hookassert",
@@ -345,6 +345,31 @@ describe("runCli explain", () => {
       ["explain", "PreToolUse", "Bash", "--format", "xml"],
       "hookassert",
       explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("xml");
+  });
+
+  it("rejects an unrecognized --format before a failing --settings path is even checked", () => {
+    // The format must be validated before any I/O: --settings resolution,
+    // spec loading, and loadSettings all come later in runExplain, so a
+    // failing --settings path must never mask a typo'd --format behind an
+    // unrelated ERR_SETTINGS_NOT_FOUND.
+    const result = runCli(
+      [
+        "explain",
+        "PreToolUse",
+        "Bash",
+        "--format",
+        "xml",
+        "--settings",
+        "no-such-settings.json",
+      ],
+      "hookassert",
+      explainDeps({ cwd: PROJECT_WITH_HOOKS_DIR }),
     );
 
     expect(result.exitCode).toBe(4);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -329,20 +329,29 @@ describe("runCli explain", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it.each(["json", "github"])(
-    "rejects the %s report format as not implemented yet",
-    (format) => {
-      const result = runCli(
-        ["explain", "PreToolUse", "Bash", "--format", format],
-        "hookassert",
-        explainDeps(),
-      );
+  it.each(["json", "github"])("selects the %s reporter for --format %s", (format) => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", format],
+      "hookassert",
+      explainDeps(),
+    );
 
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr).toContain("ERR_USAGE");
-      expect(result.stderr).toContain("not implemented yet");
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("exits 4 with ERR_USAGE for an unrecognized --format value", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", "xml"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("xml");
+  });
 
   it("rejects --emit-fixtures as not implemented yet", () => {
     const result = runCli(

--- a/tests/fixtures/settings/with-negative-and-fractional-timeout/project.json
+++ b/tests/fixtures/settings/with-negative-and-fractional-timeout/project.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/negative-timeout.sh",
+            "timeout": -1
+          },
+          {
+            "type": "command",
+            "command": "./scripts/fractional-timeout.sh",
+            "timeout": 0.0005
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -41,6 +41,9 @@ const PROJECT_SETTINGS_FILE = path.join(
   ".claude",
   "settings.json",
 );
+const SETTINGS_FIXTURES_DIR = fileURLToPath(
+  new URL("./fixtures/settings/", import.meta.url),
+);
 
 /** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
 const SPEC_RANGE = ">=2.1.251 <2.2.0";
@@ -143,6 +146,32 @@ describe("renderJson", () => {
     expect(validate(parsed)).toBe(false);
   });
 
+  it("stays schema-valid for a negative or fractional timeoutMs, since settings/load.ts does not reject either", () => {
+    // A settings file's `timeout` is an arbitrary JSON number multiplied by
+    // 1000; nothing in the pipeline rejects a negative or fractional value.
+    // The schema must describe what the tool can actually emit, not what a
+    // well-behaved settings file would contain.
+    const settings = loadSettings([
+      {
+        path: path.join(
+          SETTINGS_FIXTURES_DIR,
+          "with-negative-and-fractional-timeout",
+          "project.json",
+        ),
+        layer: "project",
+      },
+    ]);
+    const hooks = hooksForEvent(settings, "PreToolUse");
+    expect(hooks.map((hook) => hook.timeoutMs)).toEqual([-1000, 0.5]);
+
+    const report = baseReport({ firing: hooks });
+    const parsed: unknown = JSON.parse(renderJson(report));
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(readSchema() as object);
+    expect(validate(parsed)).toBe(true);
+  });
+
   it("includes the detected version, spec range, and incompleteness notices as data fields", () => {
     const report = baseReport({
       header: {
@@ -224,6 +253,24 @@ describe("relativizeForGithub", () => {
   it("normalizes a Windows-style backslash separator to a forward slash", () => {
     expect(relativizeForGithub("nested\\settings.json", "/workspace")).toBe(
       "nested/settings.json",
+    );
+  });
+
+  it("makes a Windows absolute path relative to a Windows workspace root", () => {
+    expect(relativizeForGithub("C:\\repo\\.claude\\settings.json", "C:\\repo")).toBe(
+      ".claude/settings.json",
+    );
+  });
+
+  it("handles a Windows workspace root with a trailing separator", () => {
+    expect(relativizeForGithub("C:\\repo\\.claude\\settings.json", "C:\\repo\\")).toBe(
+      ".claude/settings.json",
+    );
+  });
+
+  it("matches a Windows path against its root case-insensitively", () => {
+    expect(relativizeForGithub("c:\\Repo\\.claude\\settings.json", "C:\\repo")).toBe(
+      ".claude/settings.json",
     );
   });
 });

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -1,0 +1,487 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Ajv } from "ajv";
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../src/cli.js";
+import { UsageError } from "../src/internal/errors.js";
+import type { MatcherOutcome } from "../src/internal/matcher/index.js";
+import {
+  isReportFormat,
+  relativizeForGithub,
+  renderGithub,
+  renderGithubFinding,
+  renderGithubHeader,
+  renderInFormat,
+  renderJson,
+  renderPretty,
+  toJsonReport,
+  type ExplainReport,
+  type FormatRenderers,
+  type ReportFinding,
+} from "../src/internal/report/index.js";
+import { hooksForEvent, loadSettings } from "../src/internal/settings/index.js";
+import type { Provenance, ResolvedHook } from "../src/types.js";
+
+// Reaching src/internal/report/, src/internal/matcher/, and
+// src/internal/settings/ directly (rather than through src/index.ts's
+// exports, per the writing-tests skill) is a deliberate, narrowly scoped
+// exception: none of these modules has a public surface in this issue and
+// never will one for its own plumbing types — see eslint.config.mjs's
+// "tests/static-layer-unit-tests" block for the full reasoning.
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SCHEMA_PATH = path.join(REPO_ROOT, "schema", "report.schema.json");
+const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/cli/", import.meta.url));
+const PROJECT_WITH_HOOKS_DIR = path.join(FIXTURES_DIR, "project-with-hooks");
+const PROJECT_SETTINGS_FILE = path.join(
+  PROJECT_WITH_HOOKS_DIR,
+  ".claude",
+  "settings.json",
+);
+
+/** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
+const SPEC_RANGE = ">=2.1.251 <2.2.0";
+
+function readSchema(): unknown {
+  return JSON.parse(readFileSync(SCHEMA_PATH, "utf8")) as unknown;
+}
+
+function makeProvenance(overrides: Partial<Provenance> = {}): Provenance {
+  return {
+    file: "/abs/project/.claude/settings.json",
+    layer: "project",
+    line: 7,
+    col: 11,
+    offset: 100,
+    ...overrides,
+  };
+}
+
+function makeHook(overrides: Partial<ResolvedHook> = {}): ResolvedHook {
+  return {
+    event: "PreToolUse",
+    matcher: "Bash",
+    command: "./scripts/guard.sh",
+    args: undefined,
+    timeoutMs: undefined,
+    provenance: makeProvenance(),
+    dedupeKey: '["PreToolUse","Bash","./scripts/guard.sh"]',
+    ...overrides,
+  };
+}
+
+function baseReport(overrides: Partial<ExplainReport> = {}): ExplainReport {
+  return {
+    header: { claudeVersion: "2.1.300", specRange: SPEC_RANGE, notices: [] },
+    event: "PreToolUse",
+    target: "Bash",
+    firing: [],
+    matcherIgnored: [],
+    rejected: [],
+    ...overrides,
+  };
+}
+
+/** Load the real hooks declared in `tests/fixtures/cli/project-with-hooks`. */
+function loadFixtureHooks(): readonly ResolvedHook[] {
+  const settings = loadSettings([{ path: PROJECT_SETTINGS_FILE, layer: "project" }]);
+  return hooksForEvent(settings, "PreToolUse");
+}
+
+/** Find a hook by its declared `matcher`, failing loudly if the fixture ever drops it. */
+function requireHookByMatcher(
+  hooks: readonly ResolvedHook[],
+  matcher: string,
+): ResolvedHook {
+  const hook = hooks.find((candidate) => candidate.matcher === matcher);
+  if (hook === undefined) {
+    throw new Error(
+      `fixture has no hook declared with matcher ${JSON.stringify(matcher)}`,
+    );
+  }
+  return hook;
+}
+
+// --- renderJson --------------------------------------------------------------
+
+describe("renderJson", () => {
+  it("validates against schema/report.schema.json for a representative report", () => {
+    const hook = makeHook();
+    const rejected: MatcherOutcome = {
+      hook: makeHook({ matcher: "Write", command: "./scripts/write-guard.sh" }),
+      kind: "exact-list",
+      reason: "evaluated as an exact-match list and did not match Bash",
+    };
+    const report = baseReport({
+      header: {
+        claudeVersion: "2.1.300",
+        specRange: SPEC_RANGE,
+        notices: ["plugin hooks detected: /abs/plugin/hooks.json"],
+      },
+      firing: [hook],
+      matcherIgnored: [hook],
+      rejected: [rejected],
+    });
+
+    const parsed: unknown = JSON.parse(renderJson(report));
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(readSchema() as object);
+    expect(validate(parsed)).toBe(true);
+  });
+
+  it("rejects a report shape ajv should reject: missing reportVersion", () => {
+    const report = baseReport();
+    const parsed = JSON.parse(renderJson(report)) as Record<string, unknown>;
+    delete parsed["reportVersion"];
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(readSchema() as object);
+    expect(validate(parsed)).toBe(false);
+  });
+
+  it("includes the detected version, spec range, and incompleteness notices as data fields", () => {
+    const report = baseReport({
+      header: {
+        claudeVersion: "2.1.300",
+        specRange: SPEC_RANGE,
+        notices: ["managed settings assumed: /etc/claude-code/managed-settings.json"],
+      },
+    });
+
+    const parsed = toJsonReport(report);
+
+    expect(parsed.header.claudeVersion).toBe("2.1.300");
+    expect(parsed.header.specRange).toBe(SPEC_RANGE);
+    expect(parsed.header.notices).toEqual([
+      "managed settings assumed: /etc/claude-code/managed-settings.json",
+    ]);
+  });
+
+  it("carries an undetermined version as the literal string, not a null", () => {
+    const report = baseReport({
+      header: { claudeVersion: "undetermined", specRange: SPEC_RANGE, notices: [] },
+    });
+
+    expect(toJsonReport(report).header.claudeVersion).toBe("undetermined");
+  });
+
+  it("marks a firing hook's matcherIgnored field true only when it was actually ignored", () => {
+    const ignoredHook = makeHook({ matcher: "anything" });
+    const plainHook = makeHook({ command: "./scripts/other.sh" });
+    const report = baseReport({
+      firing: [ignoredHook, plainHook],
+      matcherIgnored: [ignoredHook],
+    });
+
+    const parsed = toJsonReport(report);
+
+    expect(parsed.firing).toHaveLength(2);
+    expect(parsed.firing[0]?.matcherIgnored).toBe(true);
+    expect(parsed.firing[1]?.matcherIgnored).toBe(false);
+  });
+
+  it("serializes an absent matcher, args, and timeoutMs as null rather than omitting them", () => {
+    const hook = makeHook({
+      matcher: undefined,
+      args: undefined,
+      timeoutMs: undefined,
+    });
+    const report = baseReport({ firing: [hook] });
+
+    const parsed = toJsonReport(report);
+
+    expect(parsed.firing[0]?.matcher).toBeNull();
+    expect(parsed.firing[0]?.args).toBeNull();
+    expect(parsed.firing[0]?.timeoutMs).toBeNull();
+  });
+
+  it("serializes a missing matcher target as null rather than omitting it", () => {
+    const report = baseReport({ target: undefined });
+
+    expect(toJsonReport(report).target).toBeNull();
+  });
+});
+
+// --- github: relativizeForGithub ---------------------------------------------
+
+describe("relativizeForGithub", () => {
+  it("makes an absolute path relative to the workspace root", () => {
+    expect(relativizeForGithub(PROJECT_SETTINGS_FILE, PROJECT_WITH_HOOKS_DIR)).toBe(
+      ".claude/settings.json",
+    );
+  });
+
+  it("leaves an already-relative path untouched", () => {
+    expect(relativizeForGithub(".claude/settings.json", PROJECT_WITH_HOOKS_DIR)).toBe(
+      ".claude/settings.json",
+    );
+  });
+
+  it("normalizes a Windows-style backslash separator to a forward slash", () => {
+    expect(relativizeForGithub("nested\\settings.json", "/workspace")).toBe(
+      "nested/settings.json",
+    );
+  });
+});
+
+// --- github: renderGithubFinding ----------------------------------------------
+
+describe("renderGithubFinding", () => {
+  it("emits ::error file=<path>,line=<line>,title=<rule or case>::<message> using the hook's own Provenance for a known fixture", () => {
+    const bashHook = requireHookByMatcher(loadFixtureHooks(), "Bash");
+
+    const finding: ReportFinding = {
+      file: bashHook.provenance.file,
+      line: bashHook.provenance.line,
+      title: "guard-hook-missing",
+      message: "expected the guard hook to block Bash, but no hook fired",
+    };
+
+    const output = renderGithubFinding(finding, PROJECT_WITH_HOOKS_DIR);
+
+    expect(output).toBe(
+      "::error file=.claude/settings.json,line=7," +
+        "title=guard-hook-missing::expected the guard hook to block Bash, but no hook fired",
+    );
+  });
+
+  it("escapes a comma, colon, and newline the workflow-command parser treats specially", () => {
+    const output = renderGithubFinding(
+      { file: "a,b:c.json", line: 1, title: "r:1,2", message: "line one\nline two" },
+      "/repo",
+    );
+
+    expect(output).toBe(
+      "::error file=a%2Cb%3Ac.json,line=1,title=r%3A1%2C2::line one%0Aline two",
+    );
+  });
+
+  it("the emitted line number matches the settings file's actual declaration line, not an approximation", () => {
+    const hooks = loadFixtureHooks();
+    const bashHook = requireHookByMatcher(hooks, "Bash");
+    const writeHook = requireHookByMatcher(hooks, "Write");
+
+    // Independently verify against the fixture's own text, rather than
+    // trusting the loader's own computed offset math: the reported line must
+    // be the opening `{` of the hook's own object, two lines above its own
+    // `command` (the intervening line is that object's `"type": "command"`).
+    const lines = readFileSync(PROJECT_SETTINGS_FILE, "utf8").split("\n");
+    const bashLine = lines[bashHook.provenance.line - 1];
+    const bashCommandLine = lines[bashHook.provenance.line + 1];
+    expect(bashLine?.trim()).toBe("{");
+    expect(bashCommandLine).toContain('"command": "./scripts/guard.sh"');
+    expect(bashHook.provenance.line).toBe(7);
+
+    const writeLine = lines[writeHook.provenance.line - 1];
+    const writeCommandLine = lines[writeHook.provenance.line + 1];
+    expect(writeLine?.trim()).toBe("{");
+    expect(writeCommandLine).toContain('"command": "./scripts/write-guard.sh"');
+    expect(writeHook.provenance.line).toBe(16);
+
+    const output = renderGithubFinding(
+      {
+        file: writeHook.provenance.file,
+        line: writeHook.provenance.line,
+        title: "case",
+        message: "message",
+      },
+      PROJECT_WITH_HOOKS_DIR,
+    );
+    expect(output).toContain("line=16,");
+  });
+});
+
+// --- github: renderGithubHeader / renderGithub --------------------------------
+
+describe("renderGithubHeader", () => {
+  it("carries the version, spec range, and notices in one leading informational line", () => {
+    const line = renderGithubHeader({
+      claudeVersion: "2.1.300",
+      specRange: SPEC_RANGE,
+      notices: ["plugin hooks detected: /abs/plugin/hooks.json"],
+    });
+
+    expect(line).toBe(
+      `::notice title=hookassert::Claude Code version: 2.1.300; Spec range: ${SPEC_RANGE}; ` +
+        "Notices: plugin hooks detected: /abs/plugin/hooks.json",
+    );
+  });
+
+  it("omits the Notices segment entirely when there are none", () => {
+    const line = renderGithubHeader({
+      claudeVersion: "undetermined",
+      specRange: SPEC_RANGE,
+      notices: [],
+    });
+
+    expect(line).not.toContain("Notices");
+  });
+});
+
+describe("renderGithub", () => {
+  it("prints the header line even when there is nothing to flag", () => {
+    const output = renderGithub(baseReport());
+
+    expect(output).toContain("::notice title=hookassert::");
+    expect(output).toContain("Claude Code version: 2.1.300");
+    expect(output.endsWith("\n")).toBe(true);
+  });
+});
+
+// --- format selection ---------------------------------------------------------
+
+describe("isReportFormat", () => {
+  it.each(["pretty", "json", "github"])("accepts %s", (format) => {
+    expect(isReportFormat(format)).toBe(true);
+  });
+
+  it.each(["", "Pretty", "yaml", "xml"])("rejects %s", (format) => {
+    expect(isReportFormat(format)).toBe(false);
+  });
+});
+
+describe("renderInFormat", () => {
+  function renderers(): FormatRenderers<ExplainReport> {
+    return { pretty: renderPretty, json: renderJson, github: renderGithub };
+  }
+
+  it("defaults to pretty when format is undefined", () => {
+    const report = baseReport();
+    expect(renderInFormat(report, undefined, renderers())).toBe(renderPretty(report));
+  });
+
+  it.each(["pretty", "json", "github"] as const)(
+    "routes %s to its own renderer",
+    (format) => {
+      const report = baseReport();
+      const expected = { pretty: renderPretty, json: renderJson, github: renderGithub }[
+        format
+      ](report);
+
+      expect(renderInFormat(report, format, renderers())).toBe(expected);
+    },
+  );
+
+  it("throws a UsageError with the ERR_USAGE code for an unrecognized format", () => {
+    expect(() => renderInFormat(baseReport(), "yaml", renderers())).toThrow(UsageError);
+
+    let caught: unknown;
+    try {
+      renderInFormat(baseReport(), "yaml", renderers());
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    expect((caught as UsageError).code).toBe("ERR_USAGE");
+  });
+
+  it("names the rejected value in the thrown error's message", () => {
+    let caught: unknown;
+    try {
+      renderInFormat(baseReport(), "yaml", renderers());
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error).message).toContain("yaml");
+  });
+});
+
+describe("--format selects the correct reporter uniformly for explain", () => {
+  function explainDeps() {
+    return {
+      cwd: PROJECT_WITH_HOOKS_DIR,
+      home: path.join(FIXTURES_DIR, "no-such-directory"),
+      env: {},
+    };
+  }
+
+  it("--format pretty prints free-text output", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", "pretty"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Claude Code version:");
+    expect(() => {
+      JSON.parse(result.stdout);
+    }).toThrow();
+  });
+
+  it("--format json prints a schema-valid JSON document", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", "json"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const parsed: unknown = JSON.parse(result.stdout);
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(readSchema() as object);
+    expect(validate(parsed)).toBe(true);
+  });
+
+  it("--format github prints a GitHub Actions workflow-command line", () => {
+    const result = runCli(
+      ["explain", "PreToolUse", "Bash", "--format", "github"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("::notice title=hookassert::");
+  });
+
+  // FOLLOW-UPS: `lint` and `test` do not exist yet (#13, #11). Once either
+  // lands and wires --format through renderInFormat, that issue must extend
+  // this same uniform-selection assertion to its own subcommand — this issue
+  // cannot test a subcommand that does not exist.
+});
+
+// --- header parity across formats ---------------------------------------------
+
+describe("header content is substantively equivalent across pretty, json, and github", () => {
+  it("carries the same version, spec range, and notices in all three formats", () => {
+    const report = baseReport({
+      header: {
+        claudeVersion: "2.1.300",
+        specRange: SPEC_RANGE,
+        notices: ["plugin hooks detected: /abs/plugin/hooks.json"],
+      },
+    });
+
+    const pretty = renderPretty(report);
+    const json = toJsonReport(report);
+    const github = renderGithub(report);
+
+    expect(pretty).toContain("Claude Code version: 2.1.300");
+    expect(pretty).toContain(`Spec range: ${SPEC_RANGE}`);
+    expect(pretty).toContain("Notice: plugin hooks detected: /abs/plugin/hooks.json");
+
+    expect(json.header.claudeVersion).toBe("2.1.300");
+    expect(json.header.specRange).toBe(SPEC_RANGE);
+    expect(json.header.notices).toEqual([
+      "plugin hooks detected: /abs/plugin/hooks.json",
+    ]);
+
+    expect(github).toContain("Claude Code version: 2.1.300");
+    expect(github).toContain(`Spec range: ${SPEC_RANGE}`);
+    expect(github).toContain("plugin hooks detected: /abs/plugin/hooks.json");
+  });
+
+  it("carries 'undetermined' consistently when no version was resolved", () => {
+    const report = baseReport({
+      header: { claudeVersion: "undetermined", specRange: SPEC_RANGE, notices: [] },
+    });
+
+    expect(renderPretty(report)).toContain("Claude Code version: undetermined");
+    expect(toJsonReport(report).header.claudeVersion).toBe("undetermined");
+    expect(renderGithub(report)).toContain("Claude Code version: undetermined");
+  });
+});


### PR DESCRIPTION
Adds the `json` reporter (`src/internal/report/json.ts`, validated against the new shipped
`schema/report.schema.json`) and the `github` reporter (`src/internal/report/github.ts`, GitHub
Actions `::error`/`::notice` workflow commands sourced from a hook's own `Provenance`, with path
relativization to the workspace root). Centralizes `--format` selection into one generic
`renderInFormat` helper (`src/internal/report/format.ts`) and wires `explain` through it, so
`json`/`github` now render instead of erroring as not-implemented; `lint` and `test` route through
the same helper unchanged once they land.

Closes #12

Release impact: yes — MINOR. `schema/report.schema.json` is a new shipped public contract, packaged
alongside `spec.schema.json`/`fixture.schema.json` via the existing `schema/*.json` wildcard in
`package.json`; no existing published surface changed or narrowed.

## Test plan

- `pnpm exec vitest run tests/reporters.test.ts` — ajv schema validation for a representative
  report, header data fields (version / spec range / incompleteness notices), the exact `::error`
  annotation line sourced from a real fixture's `Provenance` (independently cross-checked against
  the fixture file's own text), uniform `--format` selection for `explain`, and header-content
  parity across `pretty` / `json` / `github`.
- `pnpm check:quick` — full local source gate (format, lint, typecheck, tests): pass.
- `pnpm check` — full gate including coverage thresholds, build, docs, pack, publint, attw, and the
  consumer tarball smoke test, which confirms `schema/report.schema.json` ships in the tarball: pass.

## Review findings addressed before this PR opened

A `/code-review high` pass ran against the branch first; all four findings were applied:

- `relativizeForGithub` compared paths before normalizing separators, so a Windows absolute path
  never relativized and every annotation would have silently failed to attach on a
  `windows-latest` runner. Both sides are now normalized, and compared case-insensitively for
  Windows paths.
- Moving `--format` validation to render time regressed a typo'd format into an unrelated
  `ERR_SETTINGS_NOT_FOUND` (exit 5). It is validated again before any I/O, as `ERR_USAGE`
  (exit 4), while `renderInFormat` still owns the selection itself.
- `timeoutMs` was declared `integer, minimum 0`, but `settings/load.ts` accepts any JSON number,
  so a settings file with `"timeout": -1` made the tool emit JSON failing its own shipped schema.
  The schema now describes what the tool can actually emit. Adding load-time rejection of a
  negative or fractional `timeout` is left to a follow-up rather than widened into this PR.
- A duplicated `%s` made an `it.each` test name render literally in CI output.
