### PR TITLE
feat: wire the test subcommand end to end behind a consent gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,20 @@ hookassert --help
   `HOOKASSERT_CLAUDE_VERSION` environment variable, falling back to `"undetermined"`.
 - `hookassert lint` checks hook declarations for matcher and command mistakes.
 - `hookassert record` captures real hook payloads from a Claude Code session.
-- `hookassert test` replays recorded events and asserts on what the hooks did.
+- `hookassert test <fixture>...` replays one or more fixture files against your merged
+  settings, runs the hooks that actually fire, and asserts what happened against each
+  case's declared `expect`. It is the one command that spawns processes, so it asks for
+  consent first: on a terminal it prints the exact commands about to run and waits for
+  confirmation; `--yes` and `--ci` both skip the prompt, and a non-interactive run given
+  neither exits `6` with `ERR_CONSENT_REQUIRED` instead of running anything. `--dry-run`
+  excludes every case from the spawn plan; `--claude-version`, `--settings`,
+  `--timeout`, `--env`, and `--format` (`pretty`/`json`/`github`) all work the same way
+  they do for `explain`. Exits `0` when every case passes (and, with `--ci`, none is
+  `unknown` either), `1` when at least one fails, and `3` when there are no failures but
+  `--ci` was given and at least one case is `unknown`.
 
-`lint`, `record`, and `test` have no behavior yet: each currently exits `4` with
-`ERR_USAGE`, so a script that wires one up fails loudly instead of silently reporting
-success.
+`lint` and `record` have no behavior yet: each currently exits `4` with `ERR_USAGE`, so
+a script that wires one up fails loudly instead of silently reporting success.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ hookassert --help
   consent first: on a terminal it prints the exact commands about to run and waits for
   confirmation; `--yes` and `--ci` both skip the prompt, and a non-interactive run given
   neither exits `6` with `ERR_CONSENT_REQUIRED` instead of running anything. `--dry-run`
-  excludes every case from the spawn plan; `--claude-version`, `--settings`,
-  `--timeout`, `--env`, and `--format` (`pretty`/`json`/`github`) all work the same way
-  they do for `explain`. Exits `0` when every case passes (and, with `--ci`, none is
+  excludes every case from the spawn plan; `--claude-version`, `--settings` and
+  `--format` (`pretty`/`json`/`github`) mean exactly what they do for `explain`, and two
+  options are `test`'s own: `--timeout <ms>` sets the default hook timeout in
+  milliseconds for hooks that declare none (a fixture file's own `defaults.timeoutMs`
+  still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
+  variable into every spawned hook's environment by name — a value is never accepted
+  here, only a name. Exits `0` when every case passes (and, with `--ci`, none is
   `unknown` either), `1` when at least one fails, and `3` when there are no failures but
   `--ci` was given and at least one case is `unknown`.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -381,6 +381,7 @@ export default defineConfig([
       "tests/reporters.test.ts",
       "tests/fixture.test.ts",
       "tests/assert.test.ts",
+      "tests/test-cmd.test.ts",
     ],
     rules: {
       "no-restricted-imports": "off",

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -5,11 +5,23 @@
   "description": "Schema for the `json` reporter's output (src/internal/report/json.ts): the fixed, versioned contract downstream CI tooling may parse directly.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["reportVersion", "header", "event", "target", "firing", "rejected"],
+  "required": [
+    "reportVersion",
+    "reportType",
+    "header",
+    "event",
+    "target",
+    "firing",
+    "rejected"
+  ],
   "properties": {
     "reportVersion": {
       "const": "1",
       "description": "Version of this report shape, independent of the package's own semver."
+    },
+    "reportType": {
+      "const": "explain",
+      "description": "Discriminates this shape from other hookassert JSON report shapes (for example `test`'s), which reuse `reportVersion: \"1\"` for their own, independently versioned shape."
     },
     "header": { "$ref": "#/$defs/header" },
     "event": { "type": "string", "minLength": 1 },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import {
   loadFixtures,
   type FixtureCase,
   type FixtureFile,
+  type FixtureSet,
 } from "./internal/fixture/index.js";
 import {
   matchHooks,
@@ -562,6 +563,32 @@ function isPreSkipped(caseData: FixtureCase): boolean {
   return caseData.dryRun === true || isStubOnly(caseData);
 }
 
+/**
+ * Whether any case across `fixtureSet` could possibly enter the spawn plan —
+ * decided from the fixtures alone, before settings are discovered, hooks are
+ * matched, or the version is resolved.
+ *
+ * @remarks
+ * A conservative (never a false negative) approximation of "will `spawnWorthy`
+ * end up non-empty": it is exactly {@link isPreSkipped}'s own verdict, which
+ * is unaffected by which hooks actually end up matched, so a case this
+ * returns `true` for may still resolve to zero real steps later (no hook
+ * configured for its event, every firing hook individually stubbed). It can
+ * never return `false` for a case that does end up spawning, which is what
+ * lets `runTest` use it to gate consent before anything downstream of the
+ * fixtures has run at all.
+ */
+function hasSpawnableCase(fixtureSet: FixtureSet, dryRunFlag: boolean): boolean {
+  if (dryRunFlag) {
+    // Folded into every case's own `dryRun` before `isPreSkipped` is asked
+    // (see the per-case fold in `runTest`'s loop) — so none of them can spawn.
+    return false;
+  }
+  return fixtureSet.files.some(({ file }) =>
+    file.cases.some((caseData) => !isPreSkipped(caseData)),
+  );
+}
+
 /** Resolve one case's working-directory override to an absolute path, or `undefined` to use the run's own project root. */
 function resolveStepCwd(
   caseData: FixtureCase,
@@ -585,6 +612,13 @@ function resolveStepCwd(
  * precedence over `--timeout` for that file's own hooks — a fixture's own
  * explicit default is more specific than a run-wide override — which in turn
  * takes precedence over `HOOKASSERT_DEFAULT_TIMEOUT_MS`.
+ *
+ * `explicitDefaultTimeoutMs` is set from `cliTimeoutOverrideMs` only when no
+ * `file.defaults.timeoutMs` applies: `--timeout` is what the design calls "an
+ * override for the whole run", so it must actually win over
+ * `resolveDefaultTimeoutMs`'s ceiling rather than being silently clamped by
+ * it — see `executor.ts`'s own remark on `ExecDeps.explicitDefaultTimeoutMs`.
+ * A file's own declared default stays subject to that ceiling, unchanged.
  */
 function buildExecDepsForFile(
   deps: CliDeps,
@@ -594,6 +628,7 @@ function buildExecDepsForFile(
   cliEnvNames: readonly string[],
 ): ExecDeps {
   const fileEnv = file.defaults?.env ?? {};
+  const fileTimeoutMs = file.defaults?.timeoutMs;
   return {
     spawner: deps.spawner,
     projectRoot: deps.cwd,
@@ -601,8 +636,11 @@ function buildExecDepsForFile(
     providedEnvKeys: spec.hookEnv.provided,
     allowedEnvKeys: [...cliEnvNames, ...Object.keys(fileEnv)],
     hookassertDefaultTimeoutMs:
-      file.defaults?.timeoutMs ?? cliTimeoutOverrideMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
+      fileTimeoutMs ?? cliTimeoutOverrideMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
     specDefaultTimeoutMs: spec.defaults.hookTimeoutMs,
+    ...(fileTimeoutMs === undefined && cliTimeoutOverrideMs !== undefined
+      ? { explicitDefaultTimeoutMs: cliTimeoutOverrideMs }
+      : {}),
   };
 }
 
@@ -625,39 +663,65 @@ function quoteForConsent(word: string): string {
 }
 
 /**
- * Obtain consent to spawn `spawnWorthy` before `test` runs a single one of
- * them.
+ * Whether `test`'s consent gate is answerable at all for this invocation —
+ * checked before anything downstream of the fixtures runs, so a run that
+ * cannot possibly obtain consent fails before it spawns even the version
+ * probe.
+ *
+ * @remarks
+ * This is the "is there anyone to ask, or was consent already given" half of
+ * the gate: it takes only `isTTY`, `yes`, and `ci` — never the firing set,
+ * the spec, or the resolved `ClaudeVersion`, none of which is known yet this
+ * early in `runTest`. The other half — "does this human approve this
+ * specific command list" — is {@link gateConsent}, which runs later, once
+ * the firing set is known, and only for a TTY (this function has already
+ * ruled out every non-interactive, non-consenting case by the time that
+ * runs).
+ *
+ * `runTest` calls this only when {@link hasSpawnableCase} says the run could
+ * spawn something at all — a fixture that is entirely `--dry-run` or
+ * stub-only never needs consent, interactive or not.
+ *
+ * @throws {ConsentRequiredError} the invocation is non-interactive and
+ * neither `--yes` nor `--ci` was given.
+ */
+function assertConsentReachable(isTTY: boolean, yes: boolean, ci: boolean): void {
+  if (isTTY || yes || ci) {
+    return;
+  }
+  throw new ConsentRequiredError(
+    "test needs consent to spawn the hooks its fixtures would run, but is " +
+      "running non-interactively without --yes or --ci. Pass --yes to consent, " +
+      "--ci for a non-interactive CI run, or run in a terminal to confirm interactively.",
+  );
+}
+
+/**
+ * Obtain a human's approval of `spawnWorthy`'s exact command list before
+ * `test` runs a single one of them.
  *
  * @remarks
  * A step whose own `stub` bypasses the spawner never reaches `spawnWorthy` in
  * the first place — see `runTest`'s own filter — so an empty `spawnWorthy`
  * means nothing will actually run, and nothing needs consenting to: this
- * function returns immediately, without checking `yes`, `ci`, or `isTTY` at
- * all. `--yes` and `--ci` both bypass the prompt outright, in that order of
- * appearance below (either is sufficient). Otherwise, a non-TTY invocation
- * fails immediately — there is no one to ask — and a TTY invocation prints
- * the full command list and awaits {@link CliDeps.confirm}'s answer.
+ * function returns immediately, without checking `yes` or `ci` at all.
+ * `--yes` and `--ci` both bypass the prompt outright, in that order of
+ * appearance below (either is sufficient). Otherwise this prints the full
+ * command list and awaits {@link CliDeps.confirm}'s answer — by the time this
+ * runs, {@link assertConsentReachable} has already rejected every
+ * non-interactive invocation that lacked `--yes`/`--ci`, so a non-empty
+ * `spawnWorthy` reaching here is always on a TTY.
  *
- * @throws {ConsentRequiredError} consent was not obtained, either because the
- * invocation was non-interactive without `--yes`/`--ci`, or because the
- * interactive prompt was declined.
+ * @throws {ConsentRequiredError} the interactive prompt was declined.
  */
 async function gateConsent(
-  deps: Pick<CliDeps, "confirm" | "isTTY">,
+  deps: Pick<CliDeps, "confirm">,
   yes: boolean,
   ci: boolean,
   spawnWorthy: readonly ExecutionStep[],
 ): Promise<void> {
   if (spawnWorthy.length === 0 || yes || ci) {
     return;
-  }
-
-  if (!deps.isTTY) {
-    throw new ConsentRequiredError(
-      `test needs consent to spawn ${String(spawnWorthy.length)} command(s) but is ` +
-        "running non-interactively without --yes or --ci. Pass --yes to consent, " +
-        "--ci for a non-interactive CI run, or run in a terminal to confirm interactively.",
-    );
   }
 
   const commandList = spawnWorthy.map(describeStepForConsent).join("\n");
@@ -761,12 +825,27 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     }
   }
 
+  const dryRunFlag = parsed.values["dry-run"] === true;
+
   const spec = loadSpecFile(deps.specPath);
 
   const fixturePaths = parsed.positionals.map((fixture) =>
     path.resolve(deps.cwd, fixture),
   );
   const fixtureSet = loadFixtures(fixturePaths, spec);
+
+  // Before the probe, not after: a non-interactive invocation without
+  // `--yes`/`--ci` must fail without spawning anything at all, including
+  // `NodeVersionProbe`'s own `claude --version` — issue #11's own acceptance
+  // criterion. `hasSpawnableCase` is decided from the fixtures alone, so a
+  // fixture that is entirely `--dry-run` or stub-only never needs consent.
+  if (hasSpawnableCase(fixtureSet, dryRunFlag)) {
+    assertConsentReachable(
+      deps.isTTY,
+      parsed.values.yes === true,
+      parsed.values.ci === true,
+    );
+  }
 
   const probe = new NodeVersionProbe(deps.spawner, deps.cwd, deps.env);
   const versionContext = await resolveVersionContextForTest(
@@ -782,7 +861,6 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
   });
   const discoveredSettings = loadSettings(discoveredSources);
   const cliEnvNames = parsed.values.env ?? [];
-  const dryRunFlag = parsed.values["dry-run"] === true;
 
   const prepared: PreparedCase[] = [];
   const filePlans: FilePlan[] = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { parseArgs } from "node:util";
 
 import {
   assertCase,
+  isStubOnly,
   summarize,
   type CaseObservation,
 } from "./internal/assert/index.js";
@@ -28,7 +29,7 @@ import {
   type ExecutionPlan,
   type ExecutionStep,
 } from "./internal/exec/index.js";
-import { createUnimplementedSpawner, type Spawner } from "./internal/exec/spawner.js";
+import { NodeSpawner, type Spawner } from "./internal/exec/spawner.js";
 import type { VersionProbe } from "./internal/exec/version.js";
 import {
   loadFixtures,
@@ -242,11 +243,13 @@ export interface CliDeps {
    * Whether `test`'s consent gate treats this run as interactive.
    *
    * @remarks
-   * Defaults to `process.stdout.isTTY === true` — never `process.env.CI`,
-   * which answers a different question ("is a CI runner driving this
-   * process") than "can a human see and answer a prompt right now."
-   * Overridable so a test can exercise both branches of the consent gate
-   * without an actual terminal attached.
+   * Defaults to `process.stdout.isTTY === true && process.stdin.isTTY ===
+   * true` — never `process.env.CI`, which answers a different question ("is a
+   * CI runner driving this process") than "can a human see and answer a
+   * prompt right now." Both streams have to be terminals, because the prompt
+   * is printed on one and read from the other. Overridable so a test can
+   * exercise both branches of the consent gate without an actual terminal
+   * attached.
    */
   readonly isTTY: boolean;
 
@@ -279,9 +282,13 @@ function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
     cwd: overrides.cwd ?? process.cwd(),
     home: overrides.home ?? homedir(),
     env: overrides.env ?? process.env,
-    spawner: overrides.spawner ?? createUnimplementedSpawner(),
+    spawner: overrides.spawner ?? new NodeSpawner(),
     specPath: overrides.specPath ?? SPEC_PATH,
-    isTTY: overrides.isTTY ?? process.stdout.isTTY,
+    // Both streams, not stdout alone: `realConfirm` reads the answer from
+    // stdin, and a `question()` on a stdin already at EOF (`hookassert test
+    // … < /dev/null`) never settles, hanging the run at the prompt. `=== true`
+    // because `isTTY` is `undefined`, not `false`, on a non-terminal stream.
+    isTTY: overrides.isTTY ?? (process.stdout.isTTY && process.stdin.isTTY),
     confirm: overrides.confirm ?? realConfirm,
   };
 }
@@ -537,35 +544,22 @@ function includedHooksForCase(
   return { candidates, excludedHooks };
 }
 
-/** Whether `expect` declares no assertion at all — mirrors `assertCase.ts`'s own private predicate. */
-function isEmptyExpectation(caseData: FixtureCase): boolean {
-  const { expect } = caseData;
-  return (
-    expect.fires === undefined &&
-    expect.decision === undefined &&
-    expect.exitCode === undefined &&
-    expect.stdoutContains === undefined &&
-    expect.stderrContains === undefined &&
-    expect.context === undefined &&
-    expect.updatedInput === undefined &&
-    expect.timedOut === undefined
-  );
-}
-
 /**
- * Whether `caseData` should never enter the spawn plan at all: an explicit
- * `dryRun`, `--dry-run` applied to the whole run, or a case that declares
- * only stubs and nothing to assert (`assertCase`'s own `"stub-only"` case).
+ * Whether `caseData` should never enter the spawn plan at all: a `dryRun`
+ * case (`--dry-run` is already folded into every case's own `dryRun` by the
+ * time this is asked), or a case that declares only stubs and nothing to
+ * assert.
+ *
+ * @remarks
+ * Both halves are `assertCase`'s own verdict, borrowed rather than restated:
+ * a case this returns `true` for is exactly one `assertCase` reports as
+ * `"skipped"`. Reimplementing the stub-only test here — it reads every field
+ * of `FixtureExpectation` — is what would let the two drift the next time a
+ * field is added to that interface, leaving a case the plan spawns for and
+ * the assert engine then skips.
  */
-function isPreSkipped(caseData: FixtureCase, dryRunFlag: boolean): boolean {
-  if (caseData.dryRun === true || dryRunFlag) {
-    return true;
-  }
-  return (
-    caseData.stub !== undefined &&
-    Object.keys(caseData.stub).length > 0 &&
-    isEmptyExpectation(caseData)
-  );
+function isPreSkipped(caseData: FixtureCase): boolean {
+  return caseData.dryRun === true || isStubOnly(caseData);
 }
 
 /** Resolve one case's working-directory override to an absolute path, or `undefined` to use the run's own project root. */
@@ -615,8 +609,19 @@ function buildExecDepsForFile(
 /** One command a step would actually spawn, described for a human at the consent prompt. */
 function describeStepForConsent(step: ExecutionStep): string {
   const form = step.hook.args === undefined ? "shell" : "exec";
-  const args = step.hook.args === undefined ? "" : ` ${step.hook.args.join(" ")}`;
-  return `  [${form}] ${step.hook.command}${args}`;
+  // Quoted, not bare-joined: this line is the whole basis for the answer the
+  // user gives, so an argument containing a space, a quote or a newline must
+  // not read as two arguments, or as an early end to the command list.
+  const args =
+    step.hook.args === undefined
+      ? ""
+      : ` ${step.hook.args.map(quoteForConsent).join(" ")}`;
+  return `  [${form}] ${quoteForConsent(step.hook.command)}${args}`;
+}
+
+/** Render one command word for the consent prompt, quoting it when it is not a single plain word. */
+function quoteForConsent(word: string): string {
+  return /^[\w@%+=:,./-]+$/.test(word) ? word : JSON.stringify(word);
 }
 
 /**
@@ -763,7 +768,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
   );
   const fixtureSet = loadFixtures(fixturePaths, spec);
 
-  const probe = new NodeVersionProbe(deps.spawner);
+  const probe = new NodeVersionProbe(deps.spawner, deps.cwd, deps.env);
   const versionContext = await resolveVersionContextForTest(
     parsed.values["claude-version"],
     deps.env,
@@ -823,7 +828,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
           : rawCaseData;
 
       let firstStep: ExecutionStep | undefined;
-      if (!isPreSkipped(caseData, dryRunFlag)) {
+      if (!isPreSkipped(caseData)) {
         match.firing.forEach((hook, hookIndex) => {
           const step: ExecutionStep = {
             event: caseData.event,
@@ -936,8 +941,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
  * @param executable Name or path shown in the usage line.
  * @param deps Dependencies to override; anything omitted falls back to the
  * live process (`process.cwd()`, `os.homedir()`, `process.env`) or, for
- * `spawner`, a placeholder that rejects every call — see
- * `src/internal/exec/spawner.ts`.
+ * `spawner`, the real `NodeSpawner` — see `src/internal/exec/spawner.ts`.
  * @returns The process result a caller should observe.
  */
 export async function runCli(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,15 +4,42 @@ import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
 import {
+  assertCase,
+  summarize,
+  type CaseObservation,
+} from "./internal/assert/index.js";
+import { resolveDecision } from "./internal/decision/index.js";
+import {
+  ConsentRequiredError,
   HookassertError,
   SettingsNotFoundError,
   UsageError,
 } from "./internal/errors.js";
-import { matchHooks, type VersionContext } from "./internal/matcher/index.js";
+import {
+  executeHooks,
+  HOOKASSERT_DEFAULT_TIMEOUT_MS,
+  NodeVersionProbe,
+  type ExecDeps,
+  type ExecutionPlan,
+  type ExecutionStep,
+} from "./internal/exec/index.js";
+import { createUnimplementedSpawner, type Spawner } from "./internal/exec/spawner.js";
+import type { VersionProbe } from "./internal/exec/version.js";
+import {
+  loadFixtures,
+  type FixtureCase,
+  type FixtureFile,
+} from "./internal/fixture/index.js";
+import {
+  matchHooks,
+  type MatcherOutcome,
+  type VersionContext,
+} from "./internal/matcher/index.js";
 import {
   buildReportHeader,
   isReportFormat,
@@ -20,16 +47,20 @@ import {
   renderInFormat,
   renderJson,
   renderPretty,
+  renderTestGithub,
+  renderTestJson,
+  renderTestPretty,
   type ExplainReport,
+  type TestCaseReport,
+  type TestReport,
 } from "./internal/report/index.js";
 import {
   discoverSources,
   hooksForEvent,
   loadSettings,
 } from "./internal/settings/index.js";
-import { loadSpecFile, parseClaudeVersion } from "./internal/spec/index.js";
-import { createUnimplementedSpawner, type Spawner } from "./internal/exec/spawner.js";
-import type { EventName } from "./types.js";
+import { loadSpecFile, parseClaudeVersion, type Spec } from "./internal/spec/index.js";
+import type { CaseResult, EventName, ExecOutcome, ResolvedHook } from "./types.js";
 
 export interface CliResult {
   exitCode: number;
@@ -62,11 +93,10 @@ const SPEC_PATH = fileURLToPath(
  * usage text.
  *
  * @remarks
- * `explain` is the first of the four with real behavior, wired in by this
- * issue. `lint`, `record`, and `test` are still stubs: naming all four here
- * anyway is what makes the usage text and the "unknown command" message
- * agree with each other, and with the routing that replaces each stub once
- * its own issue lands.
+ * `explain` and `test` have real behavior; `lint` and `record` are still
+ * stubs. Naming all four here anyway is what makes the usage text and the
+ * "unknown command" message agree with each other, and with the routing that
+ * replaces each stub once its own issue lands.
  */
 const COMMANDS = [
   ["explain", "Show which hooks a tool event fires, and why."],
@@ -170,7 +200,7 @@ function failureResult(error: HookassertError, executable: string): CliResult {
   };
 }
 
-/** The dependencies `explain` and `lint` are threaded through, for injection in tests. */
+/** The dependencies `explain`, `lint`, and `test` are threaded through, for injection in tests. */
 export interface CliDeps {
   /** Directory `project` and `local` settings, and a relative `--settings <file>`, resolve against. */
   readonly cwd: string;
@@ -178,16 +208,70 @@ export interface CliDeps {
   /** Directory `user` settings resolve against. */
   readonly home: string;
 
-  /** Environment variables, read only for {@link CLAUDE_VERSION_ENV_VAR}. */
+  /**
+   * Environment variables. `explain` and `lint` read only
+   * {@link CLAUDE_VERSION_ENV_VAR} from it; `test` additionally uses it as
+   * the base a spawned hook's own environment is built from (see
+   * `buildHookEnv` in `src/internal/exec/executor.ts`) — never forwarded
+   * wholesale, only the variables that end up allowlisted.
+   */
   readonly env: Readonly<Record<string, string | undefined>>;
 
   /**
    * The command-execution seam. `explain` and `lint` accept it but never
    * call it — see `src/internal/exec/spawner.ts`'s own remark — so a
    * `CountingSpawner` injected here is how `tests/cli.test.ts` proves the
-   * zero-spawn guarantee mechanically rather than by inspection.
+   * zero-spawn guarantee mechanically rather than by inspection. `test` is
+   * the first command that actually calls it, both to run a fixture's hooks
+   * and, through `NodeVersionProbe`, to run `claude --version`.
    */
   readonly spawner: Spawner;
+
+  /**
+   * Absolute path of the shipped hooks spec to load.
+   *
+   * @remarks
+   * Defaults to the one spec file this package ships. Overridable so a test
+   * can exercise a code path the real spec cannot reach on its own — for
+   * example, `resolveDecision`'s `"event-not-in-spec"` `unknown` outcome,
+   * which the real spec's complete `events` map never produces.
+   */
+  readonly specPath: string;
+
+  /**
+   * Whether `test`'s consent gate treats this run as interactive.
+   *
+   * @remarks
+   * Defaults to `process.stdout.isTTY === true` — never `process.env.CI`,
+   * which answers a different question ("is a CI runner driving this
+   * process") than "can a human see and answer a prompt right now."
+   * Overridable so a test can exercise both branches of the consent gate
+   * without an actual terminal attached.
+   */
+  readonly isTTY: boolean;
+
+  /**
+   * Prints `prompt` and asks the user to confirm, for `test`'s interactive
+   * consent gate.
+   *
+   * @remarks
+   * Only ever called when {@link CliDeps.isTTY} is `true` and neither
+   * `--yes` nor `--ci` was given. Defaults to a real `node:readline/promises`
+   * prompt reading from `process.stdin`; overridable so a test can approve or
+   * decline deterministically without a real terminal.
+   */
+  readonly confirm: (prompt: string) => Promise<boolean>;
+}
+
+/** {@link CliDeps.confirm}'s real implementation: an interactive y/N prompt on the real terminal. */
+async function realConfirm(prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`${prompt}\nProceed? [y/N] `);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
 }
 
 function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
@@ -196,19 +280,24 @@ function resolveDeps(overrides: Partial<CliDeps>): CliDeps {
     home: overrides.home ?? homedir(),
     env: overrides.env ?? process.env,
     spawner: overrides.spawner ?? createUnimplementedSpawner(),
+    specPath: overrides.specPath ?? SPEC_PATH,
+    isTTY: overrides.isTTY ?? process.stdout.isTTY,
+    confirm: overrides.confirm ?? realConfirm,
   };
 }
 
 /**
  * Resolve the Claude Code version `explain` and `lint` run against, from the
- * two-step order this issue implements.
+ * first two steps of the full resolution order.
  *
  * @remarks
  * `--claude-version` beats {@link CLAUDE_VERSION_ENV_VAR}, which beats
- * `"undetermined"`. Deliberately no third step: a `VersionProbe` spawning
- * `claude --version`, and a fallback to the last `record` session's
- * recorded version, are both `#11`'s work, and adding either here would spawn
- * a process from a command whose whole point is guaranteeing it never does.
+ * `"undetermined"`. Deliberately no third step here: a `VersionProbe`
+ * spawning `claude --version` would violate `explain`/`lint`'s own zero-spawn
+ * guarantee. `resolveVersionContextForTest`, below, is `test`'s own wrapper
+ * that adds the probe (and, once `record`'s own session bookkeeping ships, a
+ * last-recorded-session fallback) as the two further steps only `test` is
+ * allowed to take.
  *
  * An environment variable that is set but empty counts as absent, not as a
  * malformed version: `HOOKASSERT_CLAUDE_VERSION=` in a CI job, or an
@@ -313,7 +402,7 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
     parsed.values["claude-version"],
     deps.env,
   );
-  const spec = loadSpecFile(SPEC_PATH);
+  const spec = loadSpecFile(deps.specPath);
 
   const explicitSettings = parsed.values.settings;
   // The loader maps a missing settings file to zero hooks, which is right for
@@ -353,8 +442,495 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   return { exitCode: 0, stdout, stderr: "" };
 }
 
+/** `test`'s own option table: `common` plus consent, timing, and execution controls. */
+const TEST_OPTIONS = {
+  settings: { type: "string", multiple: true },
+  "claude-version": { type: "string" },
+  format: { type: "string" },
+  yes: { type: "boolean" },
+  ci: { type: "boolean" },
+  "dry-run": { type: "boolean" },
+  timeout: { type: "string" },
+  env: { type: "string", multiple: true },
+  help: { type: "boolean", short: "h" },
+} as const;
+
+/**
+ * Resolve the Claude Code version a `test` run should assume, from this
+ * issue's full four-step order.
+ *
+ * @remarks
+ * `--claude-version` and {@link CLAUDE_VERSION_ENV_VAR} are resolved exactly
+ * as {@link resolveVersionContext} already does for `explain`/`lint`
+ * (including its `UsageError` on an invalid value); `probe.detect()` is
+ * tried only when both of those came back empty, and "last recorded
+ * session's version" — the step between the probe and `"undetermined"` — is
+ * a documented no-op until `record`'s own session bookkeeping (`#15`) ships:
+ * there is nothing to read yet, so this always falls through past it.
+ *
+ * @throws {UsageError} `claudeVersionFlag` (or the environment variable, when
+ * the flag is absent) is not a `major.minor.patch` string.
+ */
+async function resolveVersionContextForTest(
+  claudeVersionFlag: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+  probe: VersionProbe,
+): Promise<VersionContext> {
+  const direct = resolveVersionContext(claudeVersionFlag, env);
+  if (direct.kind === "known") {
+    return direct;
+  }
+  const probed = await probe.detect();
+  if (probed !== undefined) {
+    return { kind: "known", version: probed };
+  }
+  return { kind: "undetermined" };
+}
+
+/**
+ * Parse `--timeout`'s value into a positive millisecond count.
+ *
+ * @throws {UsageError} `value` is defined but not a positive finite number.
+ */
+function parseTimeoutOption(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new UsageError(
+      `--timeout must be a positive number of milliseconds, got ${JSON.stringify(value)}.`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * The candidate hooks a fixture case's matcher request considers, and every
+ * hook this issue's `settings:` filter excluded before the matcher ever saw
+ * them.
+ *
+ * @remarks
+ * `fileSettings.length === 0` (the fixture declares no `settings:` list, the
+ * common case) means "no restriction": every hook `hooksForEvent` returns is
+ * a candidate, and nothing is excluded. A non-empty list restricts candidates
+ * to hooks declared in one of the named files — resolved against `cwd`, the
+ * same base `--settings` itself resolves against — and reports every other
+ * hook under this event as {@link CaseObservation.excludedHooks}.
+ */
+function includedHooksForCase(
+  discovered: readonly ResolvedHook[],
+  fileSettings: readonly string[],
+  cwd: string,
+): {
+  readonly candidates: readonly ResolvedHook[];
+  readonly excludedHooks: readonly ResolvedHook[];
+} {
+  if (fileSettings.length === 0) {
+    return { candidates: discovered, excludedHooks: [] };
+  }
+  const included = new Set(fileSettings.map((entry) => path.resolve(cwd, entry)));
+  const candidates = discovered.filter((hook) => included.has(hook.provenance.file));
+  const excludedHooks = discovered.filter(
+    (hook) => !included.has(hook.provenance.file),
+  );
+  return { candidates, excludedHooks };
+}
+
+/** Whether `expect` declares no assertion at all — mirrors `assertCase.ts`'s own private predicate. */
+function isEmptyExpectation(caseData: FixtureCase): boolean {
+  const { expect } = caseData;
+  return (
+    expect.fires === undefined &&
+    expect.decision === undefined &&
+    expect.exitCode === undefined &&
+    expect.stdoutContains === undefined &&
+    expect.stderrContains === undefined &&
+    expect.context === undefined &&
+    expect.updatedInput === undefined &&
+    expect.timedOut === undefined
+  );
+}
+
+/**
+ * Whether `caseData` should never enter the spawn plan at all: an explicit
+ * `dryRun`, `--dry-run` applied to the whole run, or a case that declares
+ * only stubs and nothing to assert (`assertCase`'s own `"stub-only"` case).
+ */
+function isPreSkipped(caseData: FixtureCase, dryRunFlag: boolean): boolean {
+  if (caseData.dryRun === true || dryRunFlag) {
+    return true;
+  }
+  return (
+    caseData.stub !== undefined &&
+    Object.keys(caseData.stub).length > 0 &&
+    isEmptyExpectation(caseData)
+  );
+}
+
+/** Resolve one case's working-directory override to an absolute path, or `undefined` to use the run's own project root. */
+function resolveStepCwd(
+  caseData: FixtureCase,
+  file: FixtureFile,
+  cwd: string,
+): string | undefined {
+  const raw = caseData.cwd ?? file.defaults?.cwd;
+  return raw === undefined ? undefined : path.resolve(cwd, raw);
+}
+
+/**
+ * Build the `ExecDeps` one fixture file's steps run against.
+ *
+ * @remarks
+ * `file.defaults.env`'s declared values are merged into the effective
+ * process environment and their own keys added to the allowlist: unlike
+ * `--env <NAME>`, which opts an *ambient* variable in by name, a fixture's
+ * own `defaults.env` supplies its values directly, so declaring one there is
+ * itself "explicitly requesting it" for `buildHookEnv`'s credential-shape
+ * exception. `file.defaults.timeoutMs`, when the file declares one, takes
+ * precedence over `--timeout` for that file's own hooks — a fixture's own
+ * explicit default is more specific than a run-wide override — which in turn
+ * takes precedence over `HOOKASSERT_DEFAULT_TIMEOUT_MS`.
+ */
+function buildExecDepsForFile(
+  deps: CliDeps,
+  file: FixtureFile,
+  spec: Spec,
+  cliTimeoutOverrideMs: number | undefined,
+  cliEnvNames: readonly string[],
+): ExecDeps {
+  const fileEnv = file.defaults?.env ?? {};
+  return {
+    spawner: deps.spawner,
+    projectRoot: deps.cwd,
+    processEnv: { ...deps.env, ...fileEnv },
+    providedEnvKeys: spec.hookEnv.provided,
+    allowedEnvKeys: [...cliEnvNames, ...Object.keys(fileEnv)],
+    hookassertDefaultTimeoutMs:
+      file.defaults?.timeoutMs ?? cliTimeoutOverrideMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
+    specDefaultTimeoutMs: spec.defaults.hookTimeoutMs,
+  };
+}
+
+/** One command a step would actually spawn, described for a human at the consent prompt. */
+function describeStepForConsent(step: ExecutionStep): string {
+  const form = step.hook.args === undefined ? "shell" : "exec";
+  const args = step.hook.args === undefined ? "" : ` ${step.hook.args.join(" ")}`;
+  return `  [${form}] ${step.hook.command}${args}`;
+}
+
+/**
+ * Obtain consent to spawn `spawnWorthy` before `test` runs a single one of
+ * them.
+ *
+ * @remarks
+ * A step whose own `stub` bypasses the spawner never reaches `spawnWorthy` in
+ * the first place — see `runTest`'s own filter — so an empty `spawnWorthy`
+ * means nothing will actually run, and nothing needs consenting to: this
+ * function returns immediately, without checking `yes`, `ci`, or `isTTY` at
+ * all. `--yes` and `--ci` both bypass the prompt outright, in that order of
+ * appearance below (either is sufficient). Otherwise, a non-TTY invocation
+ * fails immediately — there is no one to ask — and a TTY invocation prints
+ * the full command list and awaits {@link CliDeps.confirm}'s answer.
+ *
+ * @throws {ConsentRequiredError} consent was not obtained, either because the
+ * invocation was non-interactive without `--yes`/`--ci`, or because the
+ * interactive prompt was declined.
+ */
+async function gateConsent(
+  deps: Pick<CliDeps, "confirm" | "isTTY">,
+  yes: boolean,
+  ci: boolean,
+  spawnWorthy: readonly ExecutionStep[],
+): Promise<void> {
+  if (spawnWorthy.length === 0 || yes || ci) {
+    return;
+  }
+
+  if (!deps.isTTY) {
+    throw new ConsentRequiredError(
+      `test needs consent to spawn ${String(spawnWorthy.length)} command(s) but is ` +
+        "running non-interactively without --yes or --ci. Pass --yes to consent, " +
+        "--ci for a non-interactive CI run, or run in a terminal to confirm interactively.",
+    );
+  }
+
+  const commandList = spawnWorthy.map(describeStepForConsent).join("\n");
+  const prompt = `About to run ${String(spawnWorthy.length)} command(s):\n${commandList}`;
+  const approved = await deps.confirm(prompt);
+  if (!approved) {
+    throw new ConsentRequiredError(
+      "test needs consent to spawn the hooks its fixtures would run, and consent " +
+        "was declined at the interactive prompt.",
+    );
+  }
+}
+
+/** Exit-code precedence for `test`, computed once from `Summary`'s counts. */
+function resolveTestExitCode(
+  summary: { readonly failed: number; readonly unknown: number },
+  ci: boolean,
+): number {
+  if (summary.failed > 0) {
+    return 1;
+  }
+  if (ci && summary.unknown > 0) {
+    return 3;
+  }
+  return 0;
+}
+
+/** One fixture case, prepared for execution: its matcher result and (once assigned) its authoritative step. */
+interface PreparedCase {
+  readonly fixturePath: string;
+  readonly index: number;
+  readonly caseData: FixtureCase;
+  /**
+   * The step whose outcome this case's `Decision` is built from — the first
+   * hook the matcher resolved as firing, in `ResolvedHook` order — or
+   * `undefined` when the case was pre-skipped or nothing fired for it.
+   *
+   * @remarks
+   * When more than one hook fires for the same case, every one of them is
+   * still spawned (a real Claude Code session would run them all), but only
+   * this first one is read back for the case's own pass/fail/unknown
+   * verdict — `CaseObservation` carries a single `decision`, not one per
+   * firing hook.
+   */
+  readonly firstStep: ExecutionStep | undefined;
+  readonly rejectedByMatcher: readonly MatcherOutcome[];
+  readonly excludedHooks: readonly ResolvedHook[];
+}
+
+/** One fixture file's execution plan, kept alongside the `ExecDeps` it runs against. */
+interface FilePlan {
+  readonly fixturePath: string;
+  readonly execDeps: ExecDeps;
+  readonly steps: ExecutionStep[];
+  readonly assertedEvents: Set<EventName>;
+}
+
+/**
+ * `test`'s own option table's positionals require at least one `<fixture>`
+ * path; parses and validates every other option, then wires the full
+ * pipeline this issue's design section names end to end.
+ *
+ * @throws {UsageError} an option was malformed, no `<fixture>` was given, or
+ * `--format`/`--timeout` was given an invalid value.
+ * @throws {ConsentRequiredError} consent to spawn was not obtained.
+ * (Also propagates every load-time error `loadSpecFile`/`loadFixtures` can
+ * throw — see those modules' own documentation.)
+ */
+async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResult> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args,
+      strict: true,
+      allowPositionals: true,
+      options: TEST_OPTIONS,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new UsageError(`invalid options for test: ${reason}`);
+  }
+
+  if (parsed.positionals.length === 0) {
+    throw new UsageError("test requires at least one <fixture> argument.");
+  }
+
+  // Validated before any I/O, per the same rule runExplain follows.
+  if (parsed.values.format !== undefined && !isReportFormat(parsed.values.format)) {
+    throw new UsageError(
+      `unrecognized --format ${JSON.stringify(parsed.values.format)}. ` +
+        `Expected one of: pretty, json, github.`,
+    );
+  }
+  const timeoutOverrideMs = parseTimeoutOption(parsed.values.timeout);
+
+  const explicitSettings = parsed.values.settings;
+  for (const file of explicitSettings ?? []) {
+    const resolved = path.resolve(deps.cwd, file);
+    if (!existsSync(resolved)) {
+      throw new SettingsNotFoundError(resolved);
+    }
+  }
+
+  const spec = loadSpecFile(deps.specPath);
+
+  const fixturePaths = parsed.positionals.map((fixture) =>
+    path.resolve(deps.cwd, fixture),
+  );
+  const fixtureSet = loadFixtures(fixturePaths, spec);
+
+  const probe = new NodeVersionProbe(deps.spawner);
+  const versionContext = await resolveVersionContextForTest(
+    parsed.values["claude-version"],
+    deps.env,
+    probe,
+  );
+
+  const discoveredSources = discoverSources({
+    cwd: deps.cwd,
+    home: deps.home,
+    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
+  });
+  const discoveredSettings = loadSettings(discoveredSources);
+  const cliEnvNames = parsed.values.env ?? [];
+  const dryRunFlag = parsed.values["dry-run"] === true;
+
+  const prepared: PreparedCase[] = [];
+  const filePlans: FilePlan[] = [];
+
+  for (const { path: fixturePath, file } of fixtureSet.files) {
+    const execDeps = buildExecDepsForFile(
+      deps,
+      file,
+      spec,
+      timeoutOverrideMs,
+      cliEnvNames,
+    );
+    const filePlan: FilePlan = {
+      fixturePath,
+      execDeps,
+      steps: [],
+      assertedEvents: new Set<EventName>(),
+    };
+    filePlans.push(filePlan);
+
+    file.cases.forEach((rawCaseData, index) => {
+      filePlan.assertedEvents.add(rawCaseData.event);
+
+      const { candidates, excludedHooks } = includedHooksForCase(
+        hooksForEvent(discoveredSettings, rawCaseData.event),
+        file.settings,
+        deps.cwd,
+      );
+      const match = matchHooks(spec, versionContext, {
+        event: rawCaseData.event,
+        hooks: candidates,
+        target: rawCaseData.tool,
+      });
+
+      // `--dry-run` applies to the whole run, but `assertCase` only ever
+      // reads a case's own `dryRun` field — folding the flag into a copy
+      // here is what makes its "skipped"/"dry-run" verdict (not merely the
+      // absence of spawned steps below) hold for every case when the flag
+      // is set, without assertCase needing to know about a CLI flag at all.
+      const caseData: FixtureCase =
+        dryRunFlag && rawCaseData.dryRun !== true
+          ? { ...rawCaseData, dryRun: true }
+          : rawCaseData;
+
+      let firstStep: ExecutionStep | undefined;
+      if (!isPreSkipped(caseData, dryRunFlag)) {
+        match.firing.forEach((hook, hookIndex) => {
+          const step: ExecutionStep = {
+            event: caseData.event,
+            hook,
+            stdin: JSON.stringify(caseData.input ?? null),
+            cwd: resolveStepCwd(caseData, file, deps.cwd),
+            stub: caseData.stub?.[hook.command],
+          };
+          filePlan.steps.push(step);
+          if (hookIndex === 0) {
+            firstStep = step;
+          }
+        });
+      }
+
+      prepared.push({
+        fixturePath,
+        index,
+        caseData,
+        firstStep,
+        rejectedByMatcher: match.rejected,
+        excludedHooks,
+      });
+    });
+  }
+
+  const spawnWorthy = filePlans.flatMap((plan) =>
+    plan.steps.filter((step) => step.stub === undefined),
+  );
+  await gateConsent(
+    deps,
+    parsed.values.yes === true,
+    parsed.values.ci === true,
+    spawnWorthy,
+  );
+
+  const executed = await Promise.all(
+    filePlans.map((plan) => {
+      const executionPlan: ExecutionPlan = {
+        steps: plan.steps,
+        assertedEvents: plan.assertedEvents,
+      };
+      return executeHooks(plan.execDeps, executionPlan);
+    }),
+  );
+
+  const outcomesByStep = new Map<ExecutionStep, ExecOutcome>();
+  for (const results of executed) {
+    for (const { step, outcome } of results) {
+      outcomesByStep.set(step, outcome);
+    }
+  }
+
+  const caseReports: TestCaseReport[] = [];
+  const caseResults: CaseResult[] = [];
+  for (const p of prepared) {
+    const outcome =
+      p.firstStep === undefined ? undefined : outcomesByStep.get(p.firstStep);
+    const decision =
+      outcome === undefined
+        ? undefined
+        : resolveDecision(spec, p.caseData.event, outcome);
+    const observation: CaseObservation = {
+      decision,
+      execOutcome: outcome,
+      rejectedByMatcher: p.rejectedByMatcher,
+      excludedHooks: p.excludedHooks,
+    };
+    const result = assertCase(p.caseData, observation);
+    caseResults.push(result);
+    caseReports.push({
+      file: p.fixturePath,
+      index: p.index,
+      event: p.caseData.event,
+      tool: p.caseData.tool,
+      result,
+    });
+  }
+
+  const summary = summarize(caseResults);
+  const report: TestReport = {
+    header: buildReportHeader(versionContext, spec.claudeCodeRange),
+    cases: caseReports,
+    summary,
+  };
+
+  const stdout = renderInFormat(report, parsed.values.format, {
+    pretty: renderTestPretty,
+    json: renderTestJson,
+    github: (r: TestReport) => renderTestGithub(r, deps.cwd),
+  });
+
+  return {
+    exitCode: resolveTestExitCode(summary, parsed.values.ci === true),
+    stdout,
+    stderr: "",
+  };
+}
+
 /**
  * Run the package command without coupling its behavior to process globals.
+ *
+ * @remarks
+ * Async because `test` — unlike `explain` — genuinely spawns processes
+ * (fixture hooks, and `NodeVersionProbe`'s own `claude --version`) and awaits
+ * their results; `explain`'s own branch stays a plain synchronous call,
+ * simply returned from this `async` function like any other value.
  *
  * @param argv Arguments after the executable name.
  * @param executable Name or path shown in the usage line.
@@ -364,11 +940,11 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
  * `src/internal/exec/spawner.ts`.
  * @returns The process result a caller should observe.
  */
-export function runCli(
+export async function runCli(
   argv: readonly string[],
   executable = "hookassert",
   deps: Partial<CliDeps> = {},
-): CliResult {
+): Promise<CliResult> {
   const [subcommand] = argv;
   if (subcommand === undefined || argv.includes("--help") || argv.includes("-h")) {
     return { exitCode: 0, stdout: usage(executable), stderr: "" };
@@ -390,9 +966,10 @@ export function runCli(
     switch (subcommand) {
       case "explain":
         return runExplain(rest, resolveDeps(deps));
+      case "test":
+        return await runTest(rest, resolveDeps(deps));
       case "lint":
       case "record":
-      case "test":
         // A recognised command with no implementation behind it is still a
         // usage error: fabricating partial behavior would make the gap
         // invisible to the issue that is supposed to close it.
@@ -449,13 +1026,13 @@ export function isMain(moduleUrl: string): boolean {
  * @param argv Arguments after the executable name.
  * @returns The exit code the caller should set on the process.
  */
-export function main(argv: readonly string[]): number {
-  const result = runCli(argv);
+export async function main(argv: readonly string[]): Promise<number> {
+  const result = await runCli(argv);
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
   return result.exitCode;
 }
 
 if (isMain(import.meta.url)) {
-  process.exitCode = main(process.argv.slice(2));
+  process.exitCode = await main(process.argv.slice(2));
 }

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -38,8 +38,14 @@ function isEmptyExpectation(expect: FixtureExpectation): boolean {
 /**
  * Whether `caseData` exists only to configure a stub, with nothing declared
  * to assert against.
+ *
+ * @remarks
+ * Exported so `src/cli.ts` can keep such a case out of the spawn plan in the
+ * first place, using this exact predicate rather than a copy of it: a case
+ * this returns `true` for is one {@link assertCase} reports as `"skipped"`,
+ * and the two must never disagree about which those are.
  */
-function isStubOnly(caseData: FixtureCase): boolean {
+export function isStubOnly(caseData: FixtureCase): boolean {
   return (
     caseData.stub !== undefined &&
     Object.keys(caseData.stub).length > 0 &&

--- a/src/internal/assert/index.ts
+++ b/src/internal/assert/index.ts
@@ -11,6 +11,6 @@
  * is re-exported from `src/index.ts` in the meantime.
  */
 
-export { assertCase } from "./assertCase.js";
+export { assertCase, isStubOnly } from "./assertCase.js";
 export { summarize } from "./summarize.js";
 export type { CaseObservation } from "./types.js";

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -258,6 +258,35 @@ export class FixtureNotFoundError extends HookassertError {
 }
 
 /**
+ * Thrown when `test` did not obtain consent to spawn the hooks its fixtures
+ * would run.
+ *
+ * @remarks
+ * Raised in exactly two situations, per this issue's consent-gate design: a
+ * TTY invocation where the user declined the confirmation prompt, or a
+ * non-TTY invocation (`!process.stdout.isTTY`) that passed neither `--yes`
+ * nor `--ci`. This is deliberately a load-time-adjacent failure (exit `6`),
+ * not a plain assertion failure (`1`): nothing was actually run, so it would
+ * be misleading to report it the same way as a fixture case that ran and
+ * disagreed with its own `expect`.
+ */
+export class ConsentRequiredError extends HookassertError {
+  /** Stable discriminator, unchanged across non-breaking releases. */
+  readonly code = "ERR_CONSENT_REQUIRED" as const;
+
+  /** Consent failures always exit 6. */
+  readonly exitCode = 6;
+
+  /**
+   * @param message - Human-readable explanation of why consent was not obtained.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "ConsentRequiredError";
+  }
+}
+
+/**
  * Thrown when a fixture case expects a decision the event it targets can
  * never produce.
  *

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -234,6 +234,25 @@ export interface ExecDeps {
 
   /** The loaded spec's own `defaults.hookTimeoutMs`. */
   readonly specDefaultTimeoutMs: number;
+
+  /**
+   * A default timeout the caller declared explicitly (`test`'s own
+   * `--timeout <ms>`), rather than one hookassert computed on its own.
+   *
+   * @remarks
+   * When present, this is the default {@link buildSpawnRequest} uses for a
+   * hook that declares no `timeoutMs` of its own — bypassing
+   * {@link resolveDefaultTimeoutMs}'s ceiling against `specDefaultTimeoutMs`
+   * entirely, the same exemption a hook's own declared `timeoutMs` already
+   * gets (see `buildSpawnRequest`'s own remark). A value the user typed on
+   * the command line is at least as explicit as one written into a hook's
+   * `settings.json` entry: hookassert's ceiling exists to bound the case
+   * where nobody said how long is acceptable, not to second-guess a duration
+   * the user actually asked for. `undefined` when `--timeout` was not given,
+   * in which case the computed default is still `min(hookassert's default,
+   * spec.defaults.hookTimeoutMs)`, unchanged.
+   */
+  readonly explicitDefaultTimeoutMs?: number;
 }
 
 /**
@@ -280,10 +299,9 @@ function buildSpawnRequest(
 ): SpawnRequest {
   const { hook } = step;
   const form: SpawnRequest["form"] = hook.args === undefined ? "shell" : "exec";
-  const defaultTimeoutMs = resolveDefaultTimeoutMs(
-    deps.hookassertDefaultTimeoutMs,
-    deps.specDefaultTimeoutMs,
-  );
+  const defaultTimeoutMs =
+    deps.explicitDefaultTimeoutMs ??
+    resolveDefaultTimeoutMs(deps.hookassertDefaultTimeoutMs, deps.specDefaultTimeoutMs);
 
   return {
     form,

--- a/src/internal/exec/index.ts
+++ b/src/internal/exec/index.ts
@@ -25,4 +25,5 @@ export type {
 } from "./executor.js";
 export { createUnimplementedSpawner, NodeSpawner } from "./spawner.js";
 export type { SpawnRequest, Spawner } from "./spawner.js";
+export { NodeVersionProbe } from "./version.js";
 export type { VersionProbe } from "./version.js";

--- a/src/internal/exec/spawner.ts
+++ b/src/internal/exec/spawner.ts
@@ -71,10 +71,10 @@ export interface Spawner {
  * requires a value but nothing has implemented the seam yet.
  *
  * @remarks
- * `src/cli.ts` wires this in as its default `Spawner` so `main()` has a
- * complete dependency graph to run against until `test`'s own composition
- * wires in a real `NodeSpawner`. Never reached by `explain` or `lint`, which
- * never call `spawn` at all.
+ * `src/cli.ts` used to wire this in as its default `Spawner`, before `test`
+ * had a composition of its own; the default is `NodeSpawner` now, and this
+ * survives for a caller that wants a `Spawner`-shaped value it can prove is
+ * never called — `tests/reporters.test.ts` injects it for exactly that.
  */
 export function createUnimplementedSpawner(): Spawner {
   return {

--- a/src/internal/exec/version.ts
+++ b/src/internal/exec/version.ts
@@ -1,19 +1,35 @@
 /**
- * The seam a later issue's real Claude Code version detection implements.
+ * The seam `test`'s real Claude Code version detection implements, and its
+ * real implementation.
  *
  * @remarks
- * Declared here, as a type only, because {@link UnknownReason}'s
- * `"version-undetermined"` member (`src/types.ts`) already needs a closed
- * `VersionSourceName` vocabulary to report which sources a probe tried, and
- * the `executor` issue's design section names this interface explicitly.
- * `detect()`'s actual body — spawning `claude --version`, reading an
- * environment variable, falling back to a `record`ed session's own recorded
- * version — is the `test-cmd` issue's work, which is also what wires a real
- * `VersionProbe` into version resolution. Nothing in this package constructs
- * one yet.
+ * `VersionProbe` was originally declared here, as a type only, because
+ * {@link UnknownReason}'s `"version-undetermined"` member (`src/types.ts`)
+ * already needed a closed `VersionSourceName` vocabulary to report which
+ * sources a probe tried, and the `executor` issue's design section named this
+ * interface explicitly. `NodeVersionProbe`'s body — spawning `claude
+ * --version` through the same {@link Spawner} seam every hook invocation
+ * runs through — is this issue's own work: reusing `Spawner` rather than
+ * shelling out independently is what lets `tests/cli.test.ts`'s and
+ * `tests/test-cmd.test.ts`'s `CountingSpawner` observe (or assert the
+ * absence of) this one real, intentional spawn the same way they already
+ * observe every hook invocation. `src/cli.ts`'s `runTest` is the only code
+ * that ever constructs one — `explain` and `lint` must stay at zero spawns,
+ * so neither may import this class, only the `VersionProbe` type.
+ *
+ * "Last recorded session's version" — the step between this probe and
+ * `"undetermined"` in the resolution order — reads whatever `record`'s own
+ * session bookkeeping (`#15`, not yet shipped) most recently wrote. Until
+ * that lands, there is nothing to read, so `src/cli.ts` simply falls through
+ * to `"undetermined"` after this probe reports nothing; no placeholder
+ * session-file format is invented here to fill that gap early.
  */
 
+import process from "node:process";
+
+import { parseClaudeVersion } from "../spec/index.js";
 import type { ClaudeVersion } from "../spec/index.js";
+import type { Spawner } from "./spawner.js";
 
 /**
  * Detects the Claude Code version a `test` run should assume, or reports
@@ -25,4 +41,70 @@ export interface VersionProbe {
    * tried could determine one.
    */
   detect(): Promise<ClaudeVersion | undefined>;
+}
+
+/** Matches the first `major.minor.patch` substring in `claude --version`'s output. */
+const VERSION_IN_OUTPUT = /(\d+\.\d+\.\d+)/;
+
+/** How long `NodeVersionProbe` waits for `claude --version` before giving up. */
+const PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * The real {@link VersionProbe}: spawns `claude --version` and parses its
+ * output for a `major.minor.patch` version.
+ *
+ * @remarks
+ * Runs through the injected {@link Spawner} rather than `node:child_process`
+ * directly, so the exact same seam that makes hook execution injectable and
+ * countable in tests also covers this probe — see this module's own doc
+ * comment. A non-zero exit, a spawn failure (`claude` not on `PATH`), a
+ * timeout, or output with no parseable version all resolve to `undefined`
+ * rather than throwing: a probe that cannot determine a version is an
+ * ordinary, expected outcome (feeding version resolution's own fallback to
+ * `"undetermined"`), not a failure of the run itself.
+ */
+export class NodeVersionProbe implements VersionProbe {
+  readonly #spawner: Spawner;
+
+  constructor(spawner: Spawner) {
+    this.#spawner = spawner;
+  }
+
+  async detect(): Promise<ClaudeVersion | undefined> {
+    let outcome;
+    try {
+      outcome = await this.#spawner.spawn({
+        form: "exec",
+        command: "claude",
+        args: ["--version"],
+        cwd: process.cwd(),
+        // No allowlisted variables beyond PATH: this probe only needs to
+        // resolve `claude` itself, never a hook's own configured environment.
+        env: { PATH: process.env["PATH"] ?? "" },
+        stdin: "",
+        timeoutMs: PROBE_TIMEOUT_MS,
+      });
+    } catch {
+      return undefined;
+    }
+
+    if (outcome.timedOut || outcome.exitCode !== 0) {
+      return undefined;
+    }
+
+    const match = VERSION_IN_OUTPUT.exec(outcome.stdout);
+    if (match?.[1] === undefined) {
+      return undefined;
+    }
+
+    try {
+      // `VERSION_IN_OUTPUT`'s own capture group already guarantees the
+      // `\d+\.\d+\.\d+` shape `parseClaudeVersion` requires, so this never
+      // actually throws in practice; the `try`/`catch` is defense in depth
+      // against a future change to either pattern drifting out of sync.
+      return parseClaudeVersion(match[1]);
+    } catch {
+      return undefined;
+    }
+  }
 }

--- a/src/internal/exec/version.ts
+++ b/src/internal/exec/version.ts
@@ -25,8 +25,6 @@
  * session-file format is invented here to fill that gap early.
  */
 
-import process from "node:process";
-
 import { parseClaudeVersion } from "../spec/index.js";
 import type { ClaudeVersion } from "../spec/index.js";
 import type { Spawner } from "./spawner.js";
@@ -62,12 +60,27 @@ const PROBE_TIMEOUT_MS = 5_000;
  * rather than throwing: a probe that cannot determine a version is an
  * ordinary, expected outcome (feeding version resolution's own fallback to
  * `"undetermined"`), not a failure of the run itself.
+ *
+ * `cwd` and the `PATH` value both come from the composition root's own
+ * `CliDeps`, never from `process` directly: a programmatic `runCli(argv, exe,
+ * { cwd, env })` caller has already said which directory and which
+ * environment this run speaks for, and reading the ambient process instead
+ * would probe a different machine state than the one every other stage of the
+ * run uses.
  */
 export class NodeVersionProbe implements VersionProbe {
   readonly #spawner: Spawner;
+  readonly #cwd: string;
+  readonly #env: Readonly<Record<string, string | undefined>>;
 
-  constructor(spawner: Spawner) {
+  constructor(
+    spawner: Spawner,
+    cwd: string,
+    env: Readonly<Record<string, string | undefined>>,
+  ) {
     this.#spawner = spawner;
+    this.#cwd = cwd;
+    this.#env = env;
   }
 
   async detect(): Promise<ClaudeVersion | undefined> {
@@ -77,10 +90,10 @@ export class NodeVersionProbe implements VersionProbe {
         form: "exec",
         command: "claude",
         args: ["--version"],
-        cwd: process.cwd(),
+        cwd: this.#cwd,
         // No allowlisted variables beyond PATH: this probe only needs to
         // resolve `claude` itself, never a hook's own configured environment.
-        env: { PATH: process.env["PATH"] ?? "" },
+        env: { PATH: this.#env["PATH"] ?? "" },
         stdin: "",
         timeoutMs: PROBE_TIMEOUT_MS,
       });

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -21,3 +21,10 @@ export {
 export type { ReportFinding } from "./github.js";
 export { isReportFormat, renderInFormat } from "./format.js";
 export type { FormatRenderers, ReportFormat } from "./format.js";
+export {
+  renderTestGithub,
+  renderTestJson,
+  renderTestPretty,
+  toJsonTestReport,
+} from "./testReport.js";
+export type { JsonTestReport, TestCaseReport, TestReport } from "./testReport.js";

--- a/src/internal/report/json.ts
+++ b/src/internal/report/json.ts
@@ -53,10 +53,16 @@ interface JsonRejectedOutcome {
  * `reportVersion` is this contract's own version, independent of the
  * package's own semver — a later issue reshaping this output bumps
  * `reportVersion` and updates the schema in the same change, per
- * `release-impact`.
+ * `release-impact`. `reportType` is a separate, narrower discriminator: both
+ * this shape and `test`'s own `JsonTestReport` (`testReport.ts`) currently
+ * claim `reportVersion: "1"`, since each versions its own shape independently,
+ * so `reportType` is what lets a consumer — or `schema/report.schema.json`,
+ * which pins `"explain"` — tell the two apart before trusting `reportVersion`
+ * to mean this document's shape rather than the other one's.
  */
 export interface JsonExplainReport {
   readonly reportVersion: "1";
+  readonly reportType: "explain";
   readonly header: {
     readonly claudeVersion: string;
     readonly specRange: string;
@@ -95,6 +101,7 @@ export function toJsonReport(report: ExplainReport): JsonExplainReport {
   const ignored = new Set(report.matcherIgnored);
   return {
     reportVersion: "1",
+    reportType: "explain",
     header: {
       claudeVersion: report.header.claudeVersion,
       specRange: report.header.specRange,

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -1,0 +1,246 @@
+/**
+ * The result shape `test` renders, and its `pretty`/`json`/`github`
+ * renderers.
+ *
+ * @remarks
+ * Static layer: pure string formatting — no I/O, no process, no write.
+ * Mirrors `summary.ts`'s `ExplainReport`/`pretty.ts`/`json.ts`/`github.ts`
+ * split for `explain`, but for `CaseResult[]`/`Summary` (`src/internal/assert/`)
+ * rather than a `MatchResult`. `src/cli.ts`'s `runTest` is this module's only
+ * caller: it builds one {@link TestReport} from every fixture file's cases and
+ * routes it through the same `renderInFormat` helper `explain` already uses,
+ * rather than a second `--format` switch.
+ */
+
+import type {
+  CaseResult,
+  EventName,
+  ExpectationDiff,
+  NonFiringExplanation,
+  Summary,
+  UnknownReason,
+} from "../../types.js";
+import { renderGithubFinding, renderGithubHeader } from "./github.js";
+import type { ReportHeader } from "./summary.js";
+
+/** One fixture case's result, identified by which file and position it came from. */
+export interface TestCaseReport {
+  /** Absolute path of the fixture file this case was declared in. */
+  readonly file: string;
+
+  /** 0-based position of this case within {@link TestCaseReport.file}'s `cases` array. */
+  readonly index: number;
+
+  /** The event this case declared. */
+  readonly event: EventName;
+
+  /** The matcher target this case declared, or `undefined` when it declared none. */
+  readonly tool: string | undefined;
+
+  /** What `assertCase` produced for this case. */
+  readonly result: CaseResult;
+}
+
+/** The full result `test <fixture>...` renders. */
+export interface TestReport {
+  /** Printed first by every reporter format. */
+  readonly header: ReportHeader;
+
+  /** Every case run, across every fixture file given, in the order they were declared. */
+  readonly cases: readonly TestCaseReport[];
+
+  /** The fold of every {@link TestReport.cases}' `result` into the counts every reporter prints. */
+  readonly summary: Summary;
+}
+
+/** One line naming the case a reporter is about to describe. */
+function caseLabel(report: TestCaseReport): string {
+  const target =
+    report.tool === undefined ? report.event : `${report.event} ${report.tool}`;
+  return `${report.file}#${String(report.index)} (${target})`;
+}
+
+function describeUnknownReason(reason: UnknownReason): string {
+  switch (reason.kind) {
+    case "version-out-of-spec-range":
+      return `the detected Claude Code version ${reason.detected} falls outside the loaded spec's range ${reason.specRange}`;
+    case "version-undetermined":
+      return `no Claude Code version could be determined (tried: ${reason.triedSources.join(", ")})`;
+    case "payload-shape-unverified":
+      return `${reason.event}'s payload shape has never been confirmed against a live Claude Code instance (spec ${reason.specVersion})`;
+    case "plugin-hooks-present":
+      return `unread plugin hook files: ${reason.files.join(", ")}`;
+    case "managed-settings-assumed":
+      return `a managed settings file was assumed present without being able to confirm it: ${reason.path}`;
+    case "event-not-in-spec":
+      return `${reason.event} has no entry in the loaded spec (spec ${reason.specVersion})`;
+    case "contradictory-exit-code-effect":
+      return `the loaded spec contradicts itself for ${reason.event}'s exit code ${String(reason.exitCode)}`;
+  }
+}
+
+function describeNonFiring(nonFiring: NonFiringExplanation): string {
+  switch (nonFiring.kind) {
+    case "matcher-did-not-match":
+      return nonFiring.hooks
+        .map((rejected) => `${rejected.hook.command} — ${rejected.reason}`)
+        .join("; ");
+    case "no-hook-configured":
+      return `no hook is declared under ${nonFiring.event} in any loaded settings layer`;
+    case "excluded-settings-layer":
+      return `only declared in a settings layer this fixture's "settings" list did not include: ${nonFiring.hooks
+        .map((hook) => hook.command)
+        .join(", ")}`;
+  }
+}
+
+function describeDiff(diff: ExpectationDiff): string {
+  switch (diff.field) {
+    case "fires":
+      return `fires: expected ${String(diff.expectedFires)}, got ${String(diff.actualFires)}`;
+    case "decision":
+      return `decision: expected "${diff.expectedDecision}", got "${diff.actualDecision}"`;
+    case "exitCode":
+      return `exitCode: expected ${String(diff.expectedExitCode)}, got ${String(diff.actualExitCode)}`;
+    case "stdoutContains":
+      return `stdoutContains: expected stdout to contain ${JSON.stringify(diff.expectedSubstring)}, got ${JSON.stringify(diff.actualStdout)}`;
+    case "stderrContains":
+      return `stderrContains: expected stderr to contain ${JSON.stringify(diff.expectedSubstring)}, got ${JSON.stringify(diff.actualStderr)}`;
+    case "timedOut":
+      return `timedOut: expected ${String(diff.expectedTimedOut)}, got ${String(diff.actualTimedOut)}`;
+  }
+}
+
+/** One human-readable line per {@link TestCaseReport}, for `renderTestPretty`. */
+function renderCaseLine(report: TestCaseReport): string {
+  const label = caseLabel(report);
+  const { result } = report;
+  switch (result.kind) {
+    case "pass":
+      return `PASS  ${label}`;
+    case "skipped":
+      return `SKIP  ${label} (${result.reason})`;
+    case "unknown":
+      return `UNKNOWN ${label} — ${result.reasons.map(describeUnknownReason).join("; ")}`;
+    case "fail": {
+      const detail =
+        result.nonFiring === undefined
+          ? result.diffs.map(describeDiff).join("; ")
+          : describeNonFiring(result.nonFiring);
+      return `FAIL  ${label} — ${detail}`;
+    }
+  }
+}
+
+/** Render a {@link TestReport} for a terminal. */
+export function renderTestPretty(report: TestReport): string {
+  const lines: string[] = [];
+
+  lines.push(`Claude Code version: ${report.header.claudeVersion}`);
+  lines.push(`Spec range: ${report.header.specRange}`);
+  for (const notice of report.header.notices) {
+    lines.push(`Notice: ${notice}`);
+  }
+
+  lines.push("");
+  if (report.cases.length === 0) {
+    lines.push("No cases.");
+  } else {
+    for (const caseReport of report.cases) {
+      lines.push(renderCaseLine(caseReport));
+    }
+  }
+
+  const { summary } = report;
+  lines.push("");
+  lines.push(
+    `asserted ${String(summary.asserted)} (${String(summary.fromRecorded)} from recorded), ` +
+      `${String(summary.failed)} failed, ${String(summary.unknown)} unknown, ` +
+      `${String(summary.skipped)} skipped`,
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+/** JSON-serializable shape one {@link TestCaseReport} renders to. */
+interface JsonTestCaseReport {
+  readonly file: string;
+  readonly index: number;
+  readonly event: EventName;
+  readonly tool: string | null;
+  readonly result: CaseResult;
+}
+
+/** The shape `renderTestJson` emits. */
+export interface JsonTestReport {
+  readonly reportVersion: "1";
+  readonly header: {
+    readonly claudeVersion: string;
+    readonly specRange: string;
+    readonly notices: readonly string[];
+  };
+  readonly cases: readonly JsonTestCaseReport[];
+  readonly summary: Summary;
+}
+
+/** Build the JSON-serializable shape {@link renderTestJson} stringifies. */
+export function toJsonTestReport(report: TestReport): JsonTestReport {
+  return {
+    reportVersion: "1",
+    header: {
+      claudeVersion: report.header.claudeVersion,
+      specRange: report.header.specRange,
+      notices: report.header.notices,
+    },
+    cases: report.cases.map((caseReport) => ({
+      file: caseReport.file,
+      index: caseReport.index,
+      event: caseReport.event,
+      tool: caseReport.tool ?? null,
+      result: caseReport.result,
+    })),
+    summary: report.summary,
+  };
+}
+
+/** Render a {@link TestReport} as JSON. */
+export function renderTestJson(report: TestReport): string {
+  return `${JSON.stringify(toJsonTestReport(report), null, 2)}\n`;
+}
+
+/**
+ * Render a {@link TestReport} as GitHub Actions workflow commands: the
+ * leading header line, then one `::error` per `"fail"` case.
+ *
+ * @remarks
+ * A fixture case carries no line number of its own the way a `ResolvedHook`
+ * does through `Provenance` — `fixture/load.ts` never records one — so every
+ * annotation points at line 1 of its fixture file, identified instead by the
+ * case's own 0-based index and event/target in the annotation's title.
+ */
+export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
+  const lines: string[] = [renderGithubHeader(report.header)];
+
+  for (const caseReport of report.cases) {
+    if (caseReport.result.kind !== "fail") {
+      continue;
+    }
+    const detail =
+      caseReport.result.nonFiring === undefined
+        ? caseReport.result.diffs.map(describeDiff).join("; ")
+        : describeNonFiring(caseReport.result.nonFiring);
+    lines.push(
+      renderGithubFinding(
+        {
+          file: caseReport.file,
+          line: 1,
+          title: `test case #${String(caseReport.index)}: ${caseLabel(caseReport)}`,
+          message: detail,
+        },
+        workspaceRoot,
+      ),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -171,9 +171,20 @@ interface JsonTestCaseReport {
   readonly result: CaseResult;
 }
 
-/** The shape `renderTestJson` emits. */
+/**
+ * The shape `renderTestJson` emits.
+ *
+ * @remarks
+ * `reportVersion` is versioned independently of `explain`'s own
+ * `JsonExplainReport` (`report/json.ts`) — both currently claim
+ * `reportVersion: "1"` for their own, different shapes. `reportType`
+ * disambiguates the two: `schema/report.schema.json`, the one shipped schema
+ * so far, pins its `reportType` to `"explain"` and would reject this shape,
+ * which is deliberate — this shape has no schema of its own yet.
+ */
 export interface JsonTestReport {
   readonly reportVersion: "1";
+  readonly reportType: "test";
   readonly header: {
     readonly claudeVersion: string;
     readonly specRange: string;
@@ -187,6 +198,7 @@ export interface JsonTestReport {
 export function toJsonTestReport(report: TestReport): JsonTestReport {
   return {
     reportVersion: "1",
+    reportType: "test",
     header: {
       claudeVersion: report.header.claudeVersion,
       specRange: report.header.specRange,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -47,14 +47,24 @@ function explainDeps(overrides: Partial<CliDeps> = {}): CliDeps {
     home: overrides.home ?? NO_SUCH_DIR,
     env: overrides.env ?? {},
     spawner: overrides.spawner ?? new CountingSpawner(),
+    specPath: overrides.specPath ?? explainDefaultSpecPath(),
+    isTTY: overrides.isTTY ?? false,
+    confirm: overrides.confirm ?? (() => Promise.resolve(false)),
   };
+}
+
+/** The shipped spec path, resolved the same way `src/cli.ts` resolves its own default. */
+function explainDefaultSpecPath(): string {
+  return fileURLToPath(
+    new URL("../spec/claude-code-2.1.251-2.2.0.json", import.meta.url),
+  );
 }
 
 /** The commands hookassert will ship, in the order the usage text lists them. */
 const SUBCOMMANDS = ["explain", "lint", "record", "test"] as const;
 
-/** The commands with no behavior yet — `explain` is this issue's own subject. */
-const STUB_SUBCOMMANDS = ["lint", "record", "test"] as const;
+/** The commands with no behavior yet — `explain` and `test` are both real now. */
+const STUB_SUBCOMMANDS = ["lint", "record"] as const;
 
 /** The `ERR_` shape AGENTS.md fixes for every published error code. */
 const ERROR_CODE = /^ERR_[A-Z0-9_]+$/;
@@ -65,37 +75,40 @@ function firstLine(stderr: string): string {
 }
 
 describe("runCli help", () => {
-  it("--help still exits 0 and prints the usage line", () => {
-    const result = runCli(["--help"], "my-tool");
+  it("--help still exits 0 and prints the usage line", async () => {
+    const result = await runCli(["--help"], "my-tool");
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Usage: my-tool <command> [options]");
   });
 
-  it.each(SUBCOMMANDS)("--help lists the %s command in the usage text", (name) => {
-    expect(runCli(["--help"]).stdout).toContain(`  ${name}`);
-  });
+  it.each(SUBCOMMANDS)(
+    "--help lists the %s command in the usage text",
+    async (name) => {
+      expect((await runCli(["--help"])).stdout).toContain(`  ${name}`);
+    },
+  );
 
-  it("returns help on the short help flag", () => {
-    const result = runCli(["-h"]);
+  it("returns help on the short help flag", async () => {
+    const result = await runCli(["-h"]);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Usage: hookassert <command> [options]");
     expect(result.stderr).toBe("");
   });
 
-  it("prefers help over dispatch when a command is also given", () => {
+  it("prefers help over dispatch when a command is also given", async () => {
     // `hookassert explain --help` asks about `explain`; until explain exists,
     // the general usage text is the honest answer, and it must not be an error.
-    const result = runCli(["explain", "--help"]);
+    const result = await runCli(["explain", "--help"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
   });
 
-  it("exits 0 with the usage text when given no arguments", () => {
+  it("exits 0 with the usage text when given no arguments", async () => {
     // Deliberate: a bare invocation stays exit 0, as it was before subcommand
     // dispatch existed. Only the empty stdout changes — printing the commands
     // is what a reader of a bare `hookassert` actually needs.
-    const result = runCli([], "my-tool");
+    const result = await runCli([], "my-tool");
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Usage: my-tool <command> [options]");
@@ -103,8 +116,8 @@ describe("runCli help", () => {
 });
 
 describe("runCli dispatch", () => {
-  it("exits 4 with ERR_USAGE when the subcommand is unrecognized", () => {
-    const result = runCli(["frobnicate"], "my-tool");
+  it("exits 4 with ERR_USAGE when the subcommand is unrecognized", async () => {
+    const result = await runCli(["frobnicate"], "my-tool");
     expect(result.exitCode).toBe(4);
     expect(result.stdout).toBe("");
     expect(firstLine(result.stderr)).toBe(
@@ -113,18 +126,18 @@ describe("runCli dispatch", () => {
     );
   });
 
-  it("treats a leading option as an unknown command rather than ignoring it", () => {
+  it("treats a leading option as an unknown command rather than ignoring it", async () => {
     // Nothing parses options yet, so `--json` reaching dispatch must fail
     // loudly instead of silently selecting no command.
-    const result = runCli(["--json"]);
+    const result = await runCli(["--json"]);
     expect(result.exitCode).toBe(4);
     expect(result.stderr).toContain('unknown command "--json"');
   });
 
   it.each(STUB_SUBCOMMANDS)(
     "exits 4 with a not-yet-implemented message for %s",
-    (name) => {
-      const result = runCli([name], "my-tool");
+    async (name) => {
+      const result = await runCli([name], "my-tool");
       expect(result.exitCode).toBe(4);
       expect(result.stdout).toBe("");
       expect(firstLine(result.stderr)).toBe(
@@ -133,27 +146,29 @@ describe("runCli dispatch", () => {
     },
   );
 
-  it("points at the help flag on every usage error", () => {
-    expect(runCli(["frobnicate"], "my-tool").stderr).toContain(
+  it("points at the help flag on every usage error", async () => {
+    expect((await runCli(["frobnicate"], "my-tool")).stderr).toContain(
       "Run `my-tool --help` for usage.",
     );
   });
 
-  it("reports a usage error with an ERR_-prefixed code", () => {
+  it("reports a usage error with an ERR_-prefixed code", async () => {
     // The code is the contract a CI log or a wrapper script branches on; the
     // prose after it is not. See the `designing-errors` skill.
-    const code = /^[^:]+: (\S+):/.exec(firstLine(runCli(["frobnicate"]).stderr))?.[1];
+    const code = /^[^:]+: (\S+):/.exec(
+      firstLine((await runCli(["frobnicate"])).stderr),
+    )?.[1];
     expect(code).toMatch(ERROR_CODE);
   });
 
-  it("ends stderr with a newline so a terminal does not glue on the next line", () => {
-    expect(runCli(["frobnicate"]).stderr.endsWith("\n")).toBe(true);
+  it("ends stderr with a newline so a terminal does not glue on the next line", async () => {
+    expect((await runCli(["frobnicate"])).stderr.endsWith("\n")).toBe(true);
   });
 });
 
 describe("runCli explain", () => {
-  it("wires settings + spec + matcher and prints the firing set with layer, file, and line", () => {
-    const result = runCli(
+  it("wires settings + spec + matcher and prints the firing set with layer, file, and line", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps(),
@@ -166,8 +181,8 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("./scripts/guard.sh");
   });
 
-  it("prints a non-firing matcher's MatcherOutcome reason", () => {
-    const result = runCli(
+  it("prints a non-firing matcher's MatcherOutcome reason", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps(),
@@ -180,8 +195,8 @@ describe("runCli explain", () => {
     );
   });
 
-  it("prints 'undetermined' when no Claude Code version can be resolved", () => {
-    const result = runCli(
+  it("prints 'undetermined' when no Claude Code version can be resolved", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps(),
@@ -190,8 +205,8 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("Claude Code version: undetermined");
   });
 
-  it("prints the resolved Claude Code version when one is known", () => {
-    const result = runCli(
+  it("prints the resolved Claude Code version when one is known", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--claude-version", "2.1.300"],
       "hookassert",
       explainDeps(),
@@ -200,8 +215,8 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("Claude Code version: 2.1.300");
   });
 
-  it("always prints the spec's declared claudeCodeRange", () => {
-    const result = runCli(
+  it("always prints the spec's declared claudeCodeRange", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps(),
@@ -210,8 +225,8 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain(`Spec range: ${SPEC_RANGE}`);
   });
 
-  it("--claude-version overrides HOOKASSERT_CLAUDE_VERSION", () => {
-    const result = runCli(
+  it("--claude-version overrides HOOKASSERT_CLAUDE_VERSION", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--claude-version", "2.1.300"],
       "hookassert",
       explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "2.1.260" } }),
@@ -221,8 +236,8 @@ describe("runCli explain", () => {
     expect(result.stdout).not.toContain("2.1.260");
   });
 
-  it("uses HOOKASSERT_CLAUDE_VERSION when --claude-version is absent", () => {
-    const result = runCli(
+  it("uses HOOKASSERT_CLAUDE_VERSION when --claude-version is absent", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "2.1.280" } }),
@@ -231,35 +246,39 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("Claude Code version: 2.1.280");
   });
 
-  it("exits 4 with ERR_USAGE when explain is given an unrecognized option", () => {
-    const result = runCli(["explain", "--bogus"], "hookassert", explainDeps());
+  it("exits 4 with ERR_USAGE when explain is given an unrecognized option", async () => {
+    const result = await runCli(["explain", "--bogus"], "hookassert", explainDeps());
 
     expect(result.exitCode).toBe(4);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("ERR_USAGE");
   });
 
-  it("exits 4 with ERR_USAGE when <event> is missing", () => {
-    const result = runCli(["explain"], "hookassert", explainDeps());
+  it("exits 4 with ERR_USAGE when <event> is missing", async () => {
+    const result = await runCli(["explain"], "hookassert", explainDeps());
 
     expect(result.exitCode).toBe(4);
     expect(result.stderr).toContain("ERR_USAGE");
     expect(result.stderr).toContain("<event>");
   });
 
-  it("exits 4 with ERR_USAGE when <event> is not a documented Claude Code event", () => {
-    const result = runCli(["explain", "NotARealEvent"], "hookassert", explainDeps());
+  it("exits 4 with ERR_USAGE when <event> is not a documented Claude Code event", async () => {
+    const result = await runCli(
+      ["explain", "NotARealEvent"],
+      "hookassert",
+      explainDeps(),
+    );
 
     expect(result.exitCode).toBe(4);
     expect(result.stderr).toContain("ERR_USAGE");
     expect(result.stderr).toContain("NotARealEvent");
   });
 
-  it("treats a set-but-empty HOOKASSERT_CLAUDE_VERSION as no version at all", () => {
+  it("treats a set-but-empty HOOKASSERT_CLAUDE_VERSION as no version at all", async () => {
     // A CI job that declares the variable without a value, or an
     // `export HOOKASSERT_CLAUDE_VERSION="$(… || true)"` that produced
     // nothing, must fall back to "undetermined" rather than failing the run.
-    const result = runCli(
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "" } }),
@@ -269,8 +288,8 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("Claude Code version: undetermined");
   });
 
-  it("names HOOKASSERT_CLAUDE_VERSION when the invalid version came from it", () => {
-    const result = runCli(
+  it("names HOOKASSERT_CLAUDE_VERSION when the invalid version came from it", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps({ env: { HOOKASSERT_CLAUDE_VERSION: "not-a-version" } }),
@@ -280,11 +299,11 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("HOOKASSERT_CLAUDE_VERSION");
   });
 
-  it("exits 4 with ERR_USAGE on an unexpected extra positional argument", () => {
+  it("exits 4 with ERR_USAGE on an unexpected extra positional argument", async () => {
     // `--settings a.json b.json` parses as one settings file plus a stray
     // positional; accepting it silently would make `b.json` the matcher
     // target and report a wrong firing set at exit 0.
-    const result = runCli(
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "Write"],
       "hookassert",
       explainDeps(),
@@ -296,8 +315,8 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("Write");
   });
 
-  it("exits 4 with ERR_USAGE when --claude-version is not major.minor.patch", () => {
-    const result = runCli(
+  it("exits 4 with ERR_USAGE when --claude-version is not major.minor.patch", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--claude-version", "not-a-version"],
       "hookassert",
       explainDeps(),
@@ -307,9 +326,9 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("ERR_USAGE");
   });
 
-  it("performs exactly zero spawns", () => {
+  it("performs exactly zero spawns", async () => {
     const spawner = new CountingSpawner();
-    const result = runCli(
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps({ spawner }),
@@ -319,8 +338,8 @@ describe("runCli explain", () => {
     expect(spawner.calls).toHaveLength(0);
   });
 
-  it("accepts --format pretty explicitly", () => {
-    const result = runCli(
+  it("accepts --format pretty explicitly", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", "pretty"],
       "hookassert",
       explainDeps(),
@@ -329,8 +348,8 @@ describe("runCli explain", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it.each(["json", "github"])("selects the %s reporter", (format) => {
-    const result = runCli(
+  it.each(["json", "github"])("selects the %s reporter", async (format) => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", format],
       "hookassert",
       explainDeps(),
@@ -340,8 +359,8 @@ describe("runCli explain", () => {
     expect(result.stderr).toBe("");
   });
 
-  it("exits 4 with ERR_USAGE for an unrecognized --format value", () => {
-    const result = runCli(
+  it("exits 4 with ERR_USAGE for an unrecognized --format value", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", "xml"],
       "hookassert",
       explainDeps(),
@@ -353,12 +372,12 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("xml");
   });
 
-  it("rejects an unrecognized --format before a failing --settings path is even checked", () => {
+  it("rejects an unrecognized --format before a failing --settings path is even checked", async () => {
     // The format must be validated before any I/O: --settings resolution,
     // spec loading, and loadSettings all come later in runExplain, so a
     // failing --settings path must never mask a typo'd --format behind an
     // unrelated ERR_SETTINGS_NOT_FOUND.
-    const result = runCli(
+    const result = await runCli(
       [
         "explain",
         "PreToolUse",
@@ -378,8 +397,8 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("xml");
   });
 
-  it("rejects --emit-fixtures as not implemented yet", () => {
-    const result = runCli(
+  it("rejects --emit-fixtures as not implemented yet", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--emit-fixtures", "/tmp/hookassert-out"],
       "hookassert",
       explainDeps(),
@@ -390,8 +409,8 @@ describe("runCli explain", () => {
     expect(result.stderr).toContain("--emit-fixtures");
   });
 
-  it("adds an explicit-layer settings file with --settings", () => {
-    const result = runCli(
+  it("adds an explicit-layer settings file with --settings", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--settings", EXPLICIT_SETTINGS_FILE],
       "hookassert",
       explainDeps({ cwd: NO_SUCH_DIR }),
@@ -402,12 +421,12 @@ describe("runCli explain", () => {
     expect(result.stdout).toContain("./scripts/explicit-guard.sh");
   });
 
-  it("fails with ERR_SETTINGS_NOT_FOUND when a --settings file does not exist", () => {
+  it("fails with ERR_SETTINGS_NOT_FOUND when a --settings file does not exist", async () => {
     // A missing *discovered* layer is not an error, but a file the caller
     // named is: without this, a typo prints "Firing hooks: none" at exit 0 —
     // a confident wrong answer from the command whose whole job is saying
     // which hooks fire.
-    const result = runCli(
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--settings", "no-such-settings.json"],
       "hookassert",
       explainDeps({ cwd: PROJECT_WITH_HOOKS_DIR }),
@@ -418,11 +437,11 @@ describe("runCli explain", () => {
     expect(result.stdout).toBe("");
   });
 
-  it("keeps a missing discovered settings layer lenient", () => {
+  it("keeps a missing discovered settings layer lenient", async () => {
     // The mirror of the case above: discovery naming a file that does not
     // exist stays a zero-hook contribution, so the strictness added for
     // --settings must not leak into the three well-known layers.
-    const result = runCli(
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash"],
       "hookassert",
       explainDeps({ cwd: NO_SUCH_DIR }),
@@ -431,18 +450,18 @@ describe("runCli explain", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("rethrows a non-HookassertError rather than reporting it as a usage failure", () => {
+  it("rethrows a non-HookassertError rather than reporting it as a usage failure", async () => {
     // Passing a directory as --settings makes readFileSync fail with a plain
     // EISDIR Error, not one of loadSourceHooks' own recognized cases — this
     // proves runCli only turns a HookassertError into a graceful CliResult
     // and lets anything else propagate rather than mislabeling it.
-    expect(() =>
+    await expect(
       runCli(
         ["explain", "PreToolUse", "Bash", "--settings", PROJECT_WITH_HOOKS_DIR],
         "hookassert",
         explainDeps(),
       ),
-    ).toThrow(/EISDIR/);
+    ).rejects.toThrow(/EISDIR/);
   });
 });
 
@@ -480,16 +499,16 @@ describe("main", () => {
     return { stdout, stderr };
   }
 
-  it("writes the usage text to stdout and returns 0 for --help", () => {
+  it("writes the usage text to stdout and returns 0 for --help", async () => {
     const streams = captureStreams();
-    expect(main(["--help"])).toBe(0);
+    expect(await main(["--help"])).toBe(0);
     expect(streams.stdout.join("")).toContain("Usage: hookassert <command> [options]");
     expect(streams.stderr.join("")).toBe("");
   });
 
-  it("writes a usage error to stderr and returns its exit code", () => {
+  it("writes a usage error to stderr and returns its exit code", async () => {
     const streams = captureStreams();
-    expect(main(["frobnicate"])).toBe(4);
+    expect(await main(["frobnicate"])).toBe(4);
     expect(streams.stdout.join("")).toBe("");
     expect(streams.stderr.join("")).toContain("ERR_USAGE");
   });

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -196,21 +196,27 @@ describe("documented examples compile against the public API", () => {
   );
 });
 
-describe("README's command list", () => {
-  // The suite above type-checks the documented *types*; the commands are the
-  // other half of what a reader is promised, and nothing type-checks prose.
-  // The usage text is the source of truth — the README is a copy of it that
-  // Prettier will happily keep formatting long after it stopped being true.
-  const usage = runCli(["--help"], packageName).stdout;
-  const commands = [...usage.matchAll(/^ {2}([a-z]+) {2,}\S/gm)].map(
-    (match) => match[1] ?? "",
-  );
+// The suite above type-checks the documented *types*; the commands are the
+// other half of what a reader is promised, and nothing type-checks prose.
+// The usage text is the source of truth — the README is a copy of it that
+// Prettier will happily keep formatting long after it stopped being true.
+//
+// Hoisted to a real module-level top-level `await`, rather than computed
+// inside the `describe` callback below: `it.each(commands)` needs `commands`
+// synchronously at collection time to generate one named test per command,
+// and a `describe` callback itself cannot be `async` — vitest calls it
+// synchronously to collect the suite.
+const USAGE_TEXT = (await runCli(["--help"], packageName)).stdout;
+const README_COMMANDS = [...USAGE_TEXT.matchAll(/^ {2}([a-z]+) {2,}\S/gm)].map(
+  (match) => match[1] ?? "",
+);
 
+describe("README's command list", () => {
   it("found the command list in the usage text", () => {
-    expect(commands).not.toEqual([]);
+    expect(README_COMMANDS).not.toEqual([]);
   });
 
-  it.each(commands)("documents the %s command", (name) => {
+  it.each(README_COMMANDS)("documents the %s command", (name) => {
     const readme = readFileSync(path.join(repoRoot, "README.md"), "utf8");
     expect(readme).toContain(`${packageName} ${name}`);
   });

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -117,6 +117,9 @@ function makeDeps(overrides: Partial<ExecDeps> = {}): ExecDeps {
       overrides.hookassertDefaultTimeoutMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
     specDefaultTimeoutMs:
       overrides.specDefaultTimeoutMs ?? REAL_SPEC.defaults.hookTimeoutMs,
+    ...(overrides.explicitDefaultTimeoutMs === undefined
+      ? {}
+      : { explicitDefaultTimeoutMs: overrides.explicitDefaultTimeoutMs }),
   };
 }
 
@@ -361,6 +364,26 @@ describe("timeout", () => {
     });
     await executeHooks(deps, makePlan([makeStep(hook)]));
     expect(spawner.calls[0]?.timeoutMs).toBe(10_000);
+  });
+
+  it("explicitDefaultTimeoutMs overrides the computed default and is not clamped by specDefaultTimeoutMs", async () => {
+    const spawner = new CountingSpawner();
+    const hook = makeHook({
+      command: "echo hi",
+      args: undefined,
+      timeoutMs: undefined,
+    });
+    const deps = makeDeps({
+      spawner,
+      hookassertDefaultTimeoutMs: HOOKASSERT_DEFAULT_TIMEOUT_MS,
+      specDefaultTimeoutMs: 600_000,
+      explicitDefaultTimeoutMs: 900_000,
+    });
+    await executeHooks(deps, makePlan([makeStep(hook)]));
+    // Above both HOOKASSERT_DEFAULT_TIMEOUT_MS and specDefaultTimeoutMs:
+    // resolveDefaultTimeoutMs's Math.min would have clamped it to 600_000,
+    // which is exactly what an explicit override must not be subject to.
+    expect(spawner.calls[0]?.timeoutMs).toBe(900_000);
   });
 
   it("a hook's own declared timeoutMs overrides the effective default", async () => {

--- a/tests/fixtures/cli/test-no-op.yaml
+++ b/tests/fixtures/cli/test-no-op.yaml
@@ -1,0 +1,8 @@
+# A single case whose event has no hook configured in PROJECT_WITH_HOOKS_DIR's
+# settings.json at all — nothing fires, nothing is spawned, and the case
+# passes trivially, since no expectation is declared. Used only to prove
+# --format selects the right reporter for `test`, without needing a real
+# subprocess or the consent gate.
+cases:
+  - event: SessionEnd
+    expect: {}

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -446,8 +446,8 @@ describe("--format selects the correct reporter uniformly for explain", () => {
     };
   }
 
-  it("--format pretty prints free-text output", () => {
-    const result = runCli(
+  it("--format pretty prints free-text output", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", "pretty"],
       "hookassert",
       explainDeps(),
@@ -460,8 +460,8 @@ describe("--format selects the correct reporter uniformly for explain", () => {
     }).toThrow();
   });
 
-  it("--format json prints a schema-valid JSON document", () => {
-    const result = runCli(
+  it("--format json prints a schema-valid JSON document", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", "json"],
       "hookassert",
       explainDeps(),
@@ -474,8 +474,8 @@ describe("--format selects the correct reporter uniformly for explain", () => {
     expect(validate(parsed)).toBe(true);
   });
 
-  it("--format github prints a GitHub Actions workflow-command line", () => {
-    const result = runCli(
+  it("--format github prints a GitHub Actions workflow-command line", async () => {
+    const result = await runCli(
       ["explain", "PreToolUse", "Bash", "--format", "github"],
       "hookassert",
       explainDeps(),
@@ -485,10 +485,63 @@ describe("--format selects the correct reporter uniformly for explain", () => {
     expect(result.stdout).toContain("::notice title=hookassert::");
   });
 
-  // FOLLOW-UPS: `lint` and `test` do not exist yet (#13, #11). Once either
-  // lands and wires --format through renderInFormat, that issue must extend
-  // this same uniform-selection assertion to its own subcommand — this issue
-  // cannot test a subcommand that does not exist.
+  // FOLLOW-UPS: `lint` does not exist yet (#13). Once it lands and wires
+  // --format through renderInFormat, that issue must extend this same
+  // uniform-selection assertion to its own subcommand.
+});
+
+describe("--format selects the correct reporter uniformly for test", () => {
+  const NO_OP_FIXTURE = path.join(FIXTURES_DIR, "test-no-op.yaml");
+
+  function testDeps() {
+    return {
+      cwd: PROJECT_WITH_HOOKS_DIR,
+      home: path.join(FIXTURES_DIR, "no-such-directory"),
+      env: {},
+    };
+  }
+
+  // The fixture case here declares an event with no configured hook at all
+  // (`SessionEnd`, absent from `PROJECT_WITH_HOOKS_DIR`'s settings) and no
+  // `expect`, so the run spawns nothing and needs no consent — keeping this
+  // suite in the fast unit project rather than `automationTests`.
+
+  it("--format pretty prints free-text output", async () => {
+    const result = await runCli(
+      ["test", NO_OP_FIXTURE, "--ci", "--format", "pretty"],
+      "hookassert",
+      testDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Claude Code version:");
+    expect(() => {
+      JSON.parse(result.stdout);
+    }).toThrow();
+  });
+
+  it("--format json prints a JSON document", async () => {
+    const result = await runCli(
+      ["test", NO_OP_FIXTURE, "--ci", "--format", "json"],
+      "hookassert",
+      testDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { reportVersion: string };
+    expect(parsed.reportVersion).toBe("1");
+  });
+
+  it("--format github prints a GitHub Actions workflow-command line", async () => {
+    const result = await runCli(
+      ["test", NO_OP_FIXTURE, "--ci", "--format", "github"],
+      "hookassert",
+      testDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("::notice title=hookassert::");
+  });
 });
 
 // --- header parity across formats ---------------------------------------------

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import { runCli } from "../src/cli.js";
 import { UsageError } from "../src/internal/errors.js";
+import { createUnimplementedSpawner } from "../src/internal/exec/spawner.js";
 import type { MatcherOutcome } from "../src/internal/matcher/index.js";
 import {
   isReportFormat,
@@ -25,9 +26,10 @@ import {
 import { hooksForEvent, loadSettings } from "../src/internal/settings/index.js";
 import type { Provenance, ResolvedHook } from "../src/types.js";
 
-// Reaching src/internal/report/, src/internal/matcher/, and
-// src/internal/settings/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
+// Reaching src/internal/report/, src/internal/matcher/,
+// src/internal/settings/ and src/internal/exec/ directly (rather than through
+// src/index.ts's exports, per the writing-tests skill) is a deliberate,
+// narrowly scoped
 // exception: none of these modules has a public surface in this issue and
 // never will one for its own plumbing types — see eslint.config.mjs's
 // "tests/static-layer-unit-tests" block for the full reasoning.
@@ -498,6 +500,11 @@ describe("--format selects the correct reporter uniformly for test", () => {
       cwd: PROJECT_WITH_HOOKS_DIR,
       home: path.join(FIXTURES_DIR, "no-such-directory"),
       env: {},
+      // `runCli`'s own default is the real `NodeSpawner`. This suite lives in
+      // the fast unit project and must never launch a process — including
+      // `NodeVersionProbe`'s `claude --version`, which would otherwise really
+      // run on a machine that has Claude Code installed.
+      spawner: createUnimplementedSpawner(),
     };
   }
 

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -1,0 +1,651 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { runCli, type CliDeps } from "../src/cli.js";
+import { NodeSpawner } from "../src/internal/exec/spawner.js";
+import type { Spawner, SpawnRequest } from "../src/internal/exec/spawner.js";
+import type { ExecOutcome } from "../src/types.js";
+
+// Reaching src/internal/exec/spawner.ts directly (rather than through
+// src/index.ts's exports, per the writing-tests skill) is a deliberate,
+// narrowly scoped exception, the same one tests/cli.test.ts and
+// tests/executor.test.ts already take: `Spawner` has no public surface, and
+// this file's whole point is proving `test`'s consent gate and spawn plan
+// mechanically through an injected one — see eslint.config.mjs's
+// "tests/static-layer-unit-tests" block for the full reasoning.
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const HOOKS_DIR = fileURLToPath(new URL("./fixtures/hooks/", import.meta.url));
+const MINIMAL_SPEC_PATH = path.join(
+  REPO_ROOT,
+  "tests",
+  "fixtures",
+  "spec",
+  "valid-minimal.json",
+);
+
+const EXIT0_SILENT = path.join(HOOKS_DIR, "exit0-silent.mjs");
+const EXIT2_STDERR = path.join(HOOKS_DIR, "exit2-stderr.mjs");
+const EMIT_ALLOW_JSON = path.join(HOOKS_DIR, "emit-allow-json.mjs");
+const PRINT_ARGV = path.join(HOOKS_DIR, "print-argv.mjs");
+const PRINT_CWD = path.join(HOOKS_DIR, "print-cwd.mjs");
+
+/**
+ * Records every spawn request and actually runs it, through a real
+ * `NodeSpawner` — used only by the one test that needs genuine end-to-end
+ * spawning of the side-effect-free scripts under `tests/fixtures/hooks/`.
+ */
+class RecordingSpawner implements Spawner {
+  readonly calls: SpawnRequest[] = [];
+  readonly #inner = new NodeSpawner();
+
+  spawn(req: SpawnRequest): Promise<ExecOutcome> {
+    this.calls.push(req);
+    return this.#inner.spawn(req);
+  }
+}
+
+/** A canned outcome `FakeSpawner` resolves to for a request whose args name a given script. */
+interface FakeOutcome {
+  readonly exitCode: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}
+
+/**
+ * Records every spawn request and resolves it from a canned lookup, without
+ * ever actually spawning a process.
+ *
+ * @remarks
+ * Used by every test in this file except the one dedicated "full pipeline"
+ * test: real spawning is this file's whole subject for that one case, but
+ * every other test only needs to observe *whether* a spawn happened and
+ * *what* it would have produced — including `NodeVersionProbe`'s `claude
+ * --version`, which must never really run here, since a real `claude`
+ * binary may exist on the machine running this suite.
+ */
+class FakeSpawner implements Spawner {
+  readonly calls: SpawnRequest[] = [];
+  readonly #byScript: ReadonlyMap<string, FakeOutcome>;
+  readonly #fallback: FakeOutcome;
+
+  constructor(
+    byScript: ReadonlyMap<string, FakeOutcome> = new Map(),
+    fallback: FakeOutcome = { exitCode: 0 },
+  ) {
+    this.#byScript = byScript;
+    this.#fallback = fallback;
+  }
+
+  spawn(req: SpawnRequest): Promise<ExecOutcome> {
+    this.calls.push(req);
+    const scriptArg = req.args.find((arg) => this.#byScript.has(arg));
+    const outcome =
+      (scriptArg === undefined ? undefined : this.#byScript.get(scriptArg)) ??
+      this.#fallback;
+    return Promise.resolve({
+      exitCode: outcome.exitCode,
+      stdout: outcome.stdout ?? "",
+      stderr: outcome.stderr ?? "",
+      timedOut: false,
+    });
+  }
+}
+
+let projectDir: string;
+let fixtureCounter = 0;
+
+beforeAll(() => {
+  projectDir = mkdtempSync(path.join(tmpdir(), "hookassert-test-cmd-"));
+  mkdirSync(path.join(projectDir, ".claude"), { recursive: true });
+
+  function commandGroup(matcher: string | undefined, script: string): unknown {
+    return {
+      ...(matcher === undefined ? {} : { matcher }),
+      hooks: [{ type: "command", command: process.execPath, args: [script] }],
+    };
+  }
+
+  const settings = {
+    hooks: {
+      PreToolUse: [
+        commandGroup("Bash", EXIT0_SILENT),
+        commandGroup("Write", EXIT2_STDERR),
+        commandGroup("Edit", EMIT_ALLOW_JSON),
+      ],
+      // Declared but never referenced by any case in these fixtures: proves
+      // hooks of events no case asserts on are never spawned.
+      Notification: [commandGroup(undefined, PRINT_ARGV)],
+      Stop: [commandGroup(undefined, PRINT_CWD)],
+    },
+  };
+  writeFileSync(
+    path.join(projectDir, ".claude", "settings.json"),
+    JSON.stringify(settings, null, 2),
+  );
+});
+
+afterAll(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+/** Write a fixture object (plain JSON is valid YAML) into the shared project dir. */
+function writeFixture(fixture: unknown): string {
+  fixtureCounter += 1;
+  const filePath = path.join(projectDir, `fixture-${String(fixtureCounter)}.yaml`);
+  writeFileSync(filePath, JSON.stringify(fixture, null, 2));
+  return filePath;
+}
+
+function testDeps(overrides: Partial<CliDeps> = {}): Partial<CliDeps> {
+  return {
+    cwd: projectDir,
+    home: path.join(projectDir, "no-such-home"),
+    env: {},
+    specPath: MINIMAL_SPEC_PATH,
+    isTTY: false,
+    confirm: () => Promise.resolve(false),
+    spawner: new FakeSpawner(),
+    ...overrides,
+  };
+}
+
+interface JsonTestSummary {
+  readonly asserted: number;
+  readonly fromRecorded: number;
+  readonly failed: number;
+  readonly unknown: number;
+  readonly skipped: number;
+}
+
+interface JsonTestCase {
+  readonly event: string;
+  readonly tool: string | null;
+  readonly result: { readonly kind: string; readonly reason?: string };
+}
+
+interface JsonTestReportShape {
+  readonly reportVersion: string;
+  readonly header: { readonly claudeVersion: string };
+  readonly cases: readonly JsonTestCase[];
+  readonly summary: JsonTestSummary;
+}
+
+function parseJsonReport(stdout: string): JsonTestReportShape {
+  return JSON.parse(stdout) as JsonTestReportShape;
+}
+
+describe("the full pipeline", () => {
+  it("runs a fixture end to end and produces the expected pass/fail/unknown/skipped mix", async () => {
+    const spawner = new RecordingSpawner();
+    const fixturePath = writeFixture({
+      cases: [
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          expect: { decision: "pass", exitCode: 0 },
+        },
+        // Deliberately wrong expectation — the hook actually denies.
+        { event: "PreToolUse", tool: "Write", expect: { decision: "allow" } },
+        { event: "PreToolUse", tool: "Edit", expect: { decision: "allow" } },
+        // Notification has no entry in valid-minimal.json's spec, so the
+        // fired hook's decision resolves to "unknown" (event-not-in-spec).
+        { event: "Notification", expect: {} },
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          dryRun: true,
+          expect: { decision: "pass" },
+        },
+        {
+          event: "PreToolUse",
+          tool: "Write",
+          stub: { [process.execPath]: { exitCode: 0 } },
+          expect: {},
+        },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    const report = parseJsonReport(result.stdout);
+    expect(report.summary).toEqual({
+      asserted: 3,
+      fromRecorded: 0,
+      failed: 1,
+      unknown: 1,
+      skipped: 2,
+    });
+    // Every real (non-dry-run, non-stub-only) case actually spawned; the
+    // dry-run and stub-only cases never entered the spawn plan at all.
+    expect(spawner.calls).toHaveLength(4);
+  });
+
+  it("the pretty and github reporters render a fail's diffs and its no-hook-configured reason", async () => {
+    const OUTCOMES = new Map<string, FakeOutcome>([[EXIT2_STDERR, { exitCode: 2 }]]);
+    const fixturePath = writeFixture({
+      cases: [
+        // Wrong on purpose: fires and denies, but expected "allow" — a diff-shaped fail.
+        { event: "PreToolUse", tool: "Write", expect: { decision: "allow" } },
+        // No hook is configured for SessionStart at all — a nonFiring-shaped fail.
+        { event: "SessionStart", expect: { fires: true } },
+      ],
+    });
+
+    const pretty = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner: new FakeSpawner(OUTCOMES) }),
+    );
+    expect(pretty.stdout).toContain('decision: expected "allow", got "deny"');
+    expect(pretty.stdout).toContain("no hook is declared under SessionStart");
+
+    const github = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "github",
+      ],
+      "hookassert",
+      testDeps({ spawner: new FakeSpawner(OUTCOMES) }),
+    );
+    expect(github.stdout).toContain("::error file=");
+    expect(github.stdout).toContain("test case #0");
+    expect(github.stdout).toContain("test case #1");
+  });
+});
+
+describe("the consent gate", () => {
+  function singlePassingCaseFixture(): string {
+    return writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+  }
+
+  it("on a non-TTY without --yes or --ci, exits 6 with ERR_CONSENT_REQUIRED and spawns nothing", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(6);
+    expect(result.stderr).toContain("ERR_CONSENT_REQUIRED");
+    expect(spawner.calls).toHaveLength(0);
+  });
+
+  it("--yes bypasses the prompt and proceeds", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(1);
+  });
+
+  it("--ci bypasses the prompt and proceeds", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--ci"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(1);
+  });
+
+  it("an interactive TTY that declines the prompt is treated the same as a refusal", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300"],
+      "hookassert",
+      testDeps({ spawner, isTTY: true, confirm: () => Promise.resolve(false) }),
+    );
+
+    expect(result.exitCode).toBe(6);
+    expect(result.stderr).toContain("ERR_CONSENT_REQUIRED");
+    expect(spawner.calls).toHaveLength(0);
+  });
+
+  it("an interactive TTY that approves the prompt proceeds", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+    let promptSeen = "";
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300"],
+      "hookassert",
+      testDeps({
+        spawner,
+        isTTY: true,
+        confirm: (prompt) => {
+          promptSeen = prompt;
+          return Promise.resolve(true);
+        },
+      }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(1);
+    expect(promptSeen).toContain(process.execPath);
+  });
+});
+
+describe("--dry-run and stub-only exclusion from the spawn plan", () => {
+  it("--dry-run excludes its cases from the spawn plan and marks them skipped", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--dry-run",
+        "--format",
+        "json",
+      ],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result).toEqual({
+      kind: "skipped",
+      reason: "dry-run",
+      origin: { kind: "synthetic" },
+    });
+  });
+
+  it("a fully stub-covered case is excluded from the spawn plan and marks skipped", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          stub: { [process.execPath]: { exitCode: 0 } },
+          expect: {},
+        },
+      ],
+    });
+
+    // No --yes/--ci/isTTY needed: nothing in the plan is spawn-worthy.
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--format", "json"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result).toEqual({
+      kind: "skipped",
+      reason: "stub-only",
+      origin: { kind: "synthetic" },
+    });
+  });
+});
+
+describe("ClaudeVersion resolution order", () => {
+  function noOpFixture(): string {
+    // SessionStart is in valid-minimal.json's spec but has no configured
+    // hook in this project's settings.json, so nothing fires or spawns.
+    return writeFixture({ cases: [{ event: "SessionStart", expect: {} }] });
+  }
+
+  it("--claude-version overrides the probe and the recorded-session fallback", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = noOpFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--ci"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls.some((call) => call.command === "claude")).toBe(false);
+  });
+
+  it("HOOKASSERT_CLAUDE_VERSION overrides the probe when --claude-version is absent", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = noOpFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--ci"],
+      "hookassert",
+      testDeps({ spawner, env: { HOOKASSERT_CLAUDE_VERSION: "2.1.280" } }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls.some((call) => call.command === "claude")).toBe(false);
+  });
+
+  it("the probe (VersionProbe) is used only when --claude-version and the env var are both absent", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = noOpFixture();
+
+    const result = await runCli(
+      ["test", fixturePath, "--ci"],
+      "hookassert",
+      testDeps({ spawner, env: {} }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const probeCall = spawner.calls.find((call) => call.command === "claude");
+    expect(probeCall?.args).toEqual(["--version"]);
+  });
+});
+
+describe("exit-code semantics", () => {
+  const OUTCOMES = new Map<string, FakeOutcome>([
+    [EXIT0_SILENT, { exitCode: 0 }],
+    [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+    [
+      EMIT_ALLOW_JSON,
+      {
+        exitCode: 0,
+        stdout: JSON.stringify({ hookSpecificOutput: { permissionDecision: "allow" } }),
+      },
+    ],
+  ]);
+
+  function fakeSpawnerWithRealOutcomes(): FakeSpawner {
+    return new FakeSpawner(OUTCOMES);
+  }
+
+  it("all cases pass -> exit 0", async () => {
+    const fixturePath = writeFixture({
+      cases: [
+        { event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } },
+        { event: "PreToolUse", tool: "Edit", expect: { decision: "allow" } },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner: fakeSpawnerWithRealOutcomes() }),
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("one failure among passes -> exit 1", async () => {
+    const fixturePath = writeFixture({
+      cases: [
+        { event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } },
+        // Wrong on purpose: the hook actually denies.
+        { event: "PreToolUse", tool: "Write", expect: { decision: "allow" } },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner: fakeSpawnerWithRealOutcomes() }),
+    );
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("zero failures, one unknown, no --ci -> exit 0", async () => {
+    const fixturePath = writeFixture({
+      cases: [
+        { event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } },
+        { event: "Notification", expect: {} },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner: fakeSpawnerWithRealOutcomes() }),
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("zero failures, one unknown, --ci -> exit 3", async () => {
+    const fixturePath = writeFixture({
+      cases: [
+        { event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } },
+        { event: "Notification", expect: {} },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--ci"],
+      "hookassert",
+      testDeps({ spawner: fakeSpawnerWithRealOutcomes() }),
+    );
+
+    expect(result.exitCode).toBe(3);
+  });
+
+  it("one failure and one unknown together, --ci -> exit 1 (failure wins over unknown)", async () => {
+    const fixturePath = writeFixture({
+      cases: [
+        // Wrong on purpose: the hook actually denies.
+        { event: "PreToolUse", tool: "Write", expect: { decision: "allow" } },
+        { event: "Notification", expect: {} },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--ci"],
+      "hookassert",
+      testDeps({ spawner: fakeSpawnerWithRealOutcomes() }),
+    );
+
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("machine guarantees", () => {
+  it("hooks of events no case in the fixture asserts are never spawned", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(1);
+    expect(spawner.calls.some((call) => call.args.includes(PRINT_CWD))).toBe(false);
+    expect(spawner.calls.some((call) => call.args.includes(PRINT_ARGV))).toBe(false);
+  });
+
+  it("stubbed commands are never spawned", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [
+        {
+          event: "PreToolUse",
+          tool: "Write",
+          stub: { [process.execPath]: { exitCode: 0 } },
+          // A real (non-empty) expectation: this case is NOT stub-only, so
+          // it does enter the plan, but its one firing hook is still never
+          // spawned — its Decision comes from the stub's declared exitCode.
+          expect: { decision: "pass", exitCode: 0 },
+        },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result.kind).toBe("pass");
+  });
+
+  it("explain and lint (already covered by earlier issues) remain at 0 spawns when run alongside test in the same CLI process", async () => {
+    const spawner = new FakeSpawner();
+    const deps = testDeps({ spawner });
+
+    const explainResult = await runCli(
+      ["explain", "PreToolUse", "Bash"],
+      "hookassert",
+      deps,
+    );
+    expect(explainResult.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+
+    const lintResult = await runCli(["lint"], "hookassert", deps);
+    expect(lintResult.exitCode).toBe(4);
+    expect(spawner.calls).toHaveLength(0);
+
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+    const testResult = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      deps,
+    );
+    expect(testResult.exitCode).toBe(0);
+    expect(spawner.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -290,6 +290,26 @@ describe("the consent gate", () => {
     expect(spawner.calls).toHaveLength(0);
   });
 
+  it("on a non-TTY without --yes, --ci, --claude-version, or HOOKASSERT_CLAUDE_VERSION, exits 6 and never spawns the version probe either", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+
+    // No --claude-version and no env var: resolveVersionContextForTest would
+    // otherwise have to call NodeVersionProbe.detect(), which spawns `claude
+    // --version`. This is the regression case for the bug where the probe
+    // ran before the consent gate did — the assertion that matters here is
+    // the spawn count, not just the exit code.
+    const result = await runCli(
+      ["test", fixturePath],
+      "hookassert",
+      testDeps({ spawner, env: {} }),
+    );
+
+    expect(result.exitCode).toBe(6);
+    expect(result.stderr).toContain("ERR_CONSENT_REQUIRED");
+    expect(spawner.calls).toHaveLength(0);
+  });
+
   it("--yes bypasses the prompt and proceeds", async () => {
     const spawner = new FakeSpawner();
     const fixturePath = singlePassingCaseFixture();
@@ -467,6 +487,36 @@ describe("ClaudeVersion resolution order", () => {
     expect(result.exitCode).toBe(0);
     const probeCall = spawner.calls.find((call) => call.command === "claude");
     expect(probeCall?.args).toEqual(["--version"]);
+  });
+});
+
+describe("--timeout", () => {
+  it("an explicit --timeout above the spec's own ceiling is honored, not clamped", async () => {
+    const spawner = new FakeSpawner();
+    // valid-minimal.json's own defaults.hookTimeoutMs is 600000; the point of
+    // this test is that a --timeout above that ceiling still wins, mirroring
+    // the exemption a hook's own declared timeoutMs already gets.
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--timeout",
+        "900000",
+      ],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const hookCall = spawner.calls.find((call) => call.command !== "claude");
+    expect(hookCall?.timeoutMs).toBe(900_000);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ const automationTests = [
   "tests/sync-agents.test.ts",
   "tests/sync-labels.test.ts",
   "tests/tarball.test.ts",
+  "tests/test-cmd.test.ts",
   "tests/tooling-ignores.test.ts",
   "tests/verify-bootstrap.test.ts",
   "tests/verify-package.test.ts",


### PR DESCRIPTION
Wires `hookassert test <fixture>...` end to end: the full pipeline (fixture → settings → spec →
matcher → consent gate → exec → decision → assert → report), a TTY / `--yes` / `--ci` consent gate
raising `ERR_CONSENT_REQUIRED` (exit 6), the extended `ClaudeVersion` resolution order via a real
`NodeVersionProbe`, and the exit-code precedence (`1` beats `3` beats `0`) computed once from
`Summary`'s counts. `runCli`/`main` become `async`, because `test` is the first subcommand that
genuinely spawns; `explain` is otherwise unchanged and stays at zero spawns.

Closes #11

Release impact: yes — MAJOR. `schema/report.schema.json` — a public contract shipped by #12 —
gains a `required` `reportType` discriminator, so an `explain --format json` document produced
before this change no longer validates against the current schema.

**Migration (required, per `release-impact`, while the package is below `1.0.0` and this ships as
a minor bump):** a consumer validating hookassert's JSON against `schema/report.schema.json` must
re-fetch the schema alongside the package; documents from an older hookassert lack `reportType`
and will now fail validation. A consumer discriminating between report shapes by hand should
switch to reading `reportType` (`"explain"` | `"test"`) rather than inferring the shape from which
fields are present. In practice the blast radius is nil — the package is at `0.0.0` and has never
been published, and the schema this amends landed earlier the same day — but the level is stated
from the table rather than from the blast radius, so the breaking change is visible.

## Test plan

- `pnpm exec vitest run tests/test-cmd.test.ts` — the full pipeline mix; the consent gate
  (non-TTY reject, `--yes`, `--ci`, TTY accept and decline); `--dry-run` and stub-only exclusion;
  the four-step `ClaudeVersion` resolution order; all five exit-code combinations; and the machine
  guarantees — hooks of unasserted events and stubbed commands are never spawned, and
  `explain`/`lint` stay at zero spawns alongside `test`.
- `pnpm check:quick` — format, lint, typecheck, and the full suite (1304 tests, 34 files): pass.
- `pnpm check` — the full gate including coverage (95.43% statements / 91.2% branches, both above
  floor), build, docs, pack, publint, attw, and the consumer smoke test: pass.

`tests/test-cmd.test.ts` joins `vitest.config.ts`'s `automationTests` (it spawns real processes)
and `eslint.config.mjs`'s existing `tests/static-layer-unit-tests` allowlist, added by name the way
that list documents. No coverage floor was moved and no rule was relaxed.

## Review findings addressed before this PR opened

A `/code-review high --fix` pass ran against the branch first. Nine findings, all resolved — six by
the fix pass, three after triage here:

- **The shipped `test` command could not run a single hook.** `resolveDeps` still defaulted
  `spawner` to `createUnimplementedSpawner()`, and `NodeSpawner` was never constructed anywhere in
  `src/`. Every test injects its own spawner, so nothing caught it; reproduced against the built
  `dist/cli.js`, where it died with an unhandled rejection because the placeholder throws a plain
  `Error` that `runCli`'s `HookassertError`-only catch rethrows.
- **The version probe spawned `claude --version` before the consent gate**, so a non-TTY run
  without `--yes`/`--ci` spawned a process and only then exited 6 — violating this issue's own
  acceptance criterion that such a run "spawns nothing". The gate is now split into its two real
  questions: "is consent obtainable at all" (needs only `isTTY`/`--yes`/`--ci`) runs before the
  probe; "does this human approve this command list" still runs after the firing set is known. The
  regression test asserts zero spawner calls, not just the exit code.
- **The consent gate keyed off `process.stdout.isTTY` alone** while the prompt reads `stdin`, so
  `hookassert test fx.yaml < /dev/null` hung forever at a prompt that could never be answered. Both
  streams must now be terminals.
- **`test`'s JSON claimed `reportVersion: "1"`**, colliding with the shape `schema/report.schema.json`
  pins to that version. Both documents now carry a `reportType` discriminator. A dedicated
  `schema/test-report.schema.json` is deliberately left to a follow-up rather than invented here.
- **`--timeout` was silently clamped** by the spec's 600000 ms ceiling despite the design saying it
  "overrides" the computed default. An explicit `--timeout` now wins, mirroring the exemption #9
  already documented for a hook's own declared timeout; a fixture file's own default stays clamped.
- The consent prompt joined `args` with bare spaces, so an argument containing a space or newline
  rendered as two arguments in the one line a user bases a security decision on. Words are now
  quoted.
- `NodeVersionProbe` read `process.cwd()`/`process.env` directly, bypassing the `CliDeps` seam its
  own doc comment claims; both are now supplied by the composition root.
- A dead parameter on `isPreSkipped`, plus a verbatim copy of `assertCase`'s private stub-only
  predicate that would have drifted the next time a field was added to `FixtureExpectation`.
  `isStubOnly` is exported and reused instead.
- README prose claimed `--timeout`/`--env` work "the same way they do for `explain`", which accepts
  neither.
