### PR TITLE
fix: bound executeHooks' concurrency instead of spawning every step at once

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import {
   NodeVersionProbe,
   type ExecDeps,
   type ExecutionPlan,
+  type ExecutionResult,
   type ExecutionStep,
 } from "./internal/exec/index.js";
 import { NodeSpawner, type Spawner } from "./internal/exec/spawner.js";
@@ -943,15 +944,21 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     spawnWorthy,
   );
 
-  const executed = await Promise.all(
-    filePlans.map((plan) => {
-      const executionPlan: ExecutionPlan = {
-        steps: plan.steps,
-        assertedEvents: plan.assertedEvents,
-      };
-      return executeHooks(plan.execDeps, executionPlan);
-    }),
-  );
+  // Sequential, not `Promise.all`: each `executeHooks` call runs its own
+  // concurrency-capped worker pool (see `executor.ts`'s
+  // `HOOKASSERT_DEFAULT_CONCURRENCY`), so running the files in parallel here
+  // would let N fixture files spawn N independent pools at once — the exact
+  // fan-out issue #40 caps against. A `for…of` with `await` keeps at most one
+  // pool in flight per run while preserving the per-file result order the
+  // rest of `runTest` relies on.
+  const executed: (readonly ExecutionResult[])[] = [];
+  for (const plan of filePlans) {
+    const executionPlan: ExecutionPlan = {
+      steps: plan.steps,
+      assertedEvents: plan.assertedEvents,
+    };
+    executed.push(await executeHooks(plan.execDeps, executionPlan));
+  }
 
   const outcomesByStep = new Map<ExecutionStep, ExecOutcome>();
   for (const results of executed) {

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -37,6 +37,46 @@ import type { Spawner, SpawnRequest } from "./spawner.js";
 export const HOOKASSERT_DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
+ * The default cap on how many steps {@link executeHooks} spawns at once.
+ *
+ * @remarks
+ * `test` runs the user's own hooks on the user's own machine; the concrete
+ * failure this bounds is `Promise.all`-ing every step of a real
+ * `ExecutionPlan` at once, which for a fixture set with many cases against a
+ * settings tree with several hooks per event reaches a few hundred
+ * simultaneous `detached` children, each holding three pipes — enough to hit
+ * `EAGAIN`/`EMFILE` on the spawner itself (reported by `NodeSpawner` as
+ * `exitCode: -1`, indistinguishable from a real hook failure) well before a
+ * few hundred processes is unusual.
+ *
+ * `8` was chosen from two measurements taken on the machine this issue was
+ * fixed on (`os.availableParallelism()` also reports `8` there), spawning
+ * real child processes through `/bin/sh -c` and `node -e` at caps
+ * `1/4/8/16/32/unbounded`:
+ *
+ * - **I/O-bound** (200 steps, each `sh -c "sleep 0.02"`): cap `1` took
+ *   ~7044ms; cap `8` took ~939ms (a 7.5x speedup over serial); caps `16`/`32`
+ *   kept improving but only to ~601ms/~569ms — real but sharply diminishing
+ *   returns past `8`.
+ * - **CPU-bound** (64 steps, each a fresh `node -e` doing real work): cap `8`
+ *   was the fastest point measured (~1576ms); caps `16`/`32` were *slower*
+ *   (~1826ms/~1791ms) than `8`, from context-switching more processes than
+ *   the machine has cores for.
+ *
+ * `8` sits at the CPU-bound optimum and already captures the large majority
+ * of the I/O-bound benefit, without the unbounded case's fd/process-table
+ * exposure. It is a fixed constant rather than a dynamic
+ * `os.availableParallelism()` read: hook processes are typically
+ * I/O-bound rather than CPU-bound (per the CPU-bound measurement above,
+ * `availableParallelism()` would actually be the *worse* choice for that
+ * workload), and a fixed default keeps a run's behavior independent of the
+ * machine it happens to run on. {@link ExecDeps.concurrency} overrides this
+ * per run; wiring a `--concurrency` flag to it is a CLI-surface addition left
+ * for a future change.
+ */
+export const HOOKASSERT_DEFAULT_CONCURRENCY = 8;
+
+/**
  * The effective default timeout for a run: the shorter of hookassert's own
  * default and the loaded spec's `defaults.hookTimeoutMs`.
  *
@@ -253,6 +293,14 @@ export interface ExecDeps {
    * spec.defaults.hookTimeoutMs)`, unchanged.
    */
   readonly explicitDefaultTimeoutMs?: number;
+
+  /**
+   * Maximum number of steps {@link executeHooks} runs at once. Omit to use
+   * {@link HOOKASSERT_DEFAULT_CONCURRENCY}; see its remark for how that
+   * default was chosen. A value below `1` is treated as `1` rather than
+   * deadlocking a plan that has steps to run.
+   */
+  readonly concurrency?: number;
 }
 
 /**
@@ -340,6 +388,43 @@ async function runStep(
 }
 
 /**
+ * Run `fn` over every item of `items`, at most `limit` invocations in flight
+ * at once, and return the results in `items`' own order.
+ *
+ * @remarks
+ * A small worker pool rather than chunking `items` into `Math.ceil(items.length
+ * / limit)` batches and `Promise.all`-ing each batch in turn: batching would
+ * let one slow item stall every other item in its batch even while other
+ * workers sit idle, whereas each worker here pulls the next item the instant
+ * it finishes its current one. `items.entries()` — rather than an indexed
+ * `items[i]` loop — is what lets multiple workers share one iterator safely:
+ * each `for...of` step calls the shared iterator's `next()` synchronously, so
+ * two workers can never race onto the same index, and `noUncheckedIndexedAccess`
+ * never comes into play since nothing here indexes the array directly.
+ * `results` is written through a local `(R | undefined)[]`, then asserted to
+ * `R[]` only after every worker has returned — at that point every index in
+ * `[0, items.length)` was visited exactly once by exactly one worker.
+ */
+async function runWithConcurrencyLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: (R | undefined)[] = new Array<R | undefined>(items.length);
+  const iterator = items.entries();
+
+  async function worker(): Promise<void> {
+    for (const [index, item] of iterator) {
+      results[index] = await fn(item);
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results as R[];
+}
+
+/**
  * Run every step of `plan` whose event `plan.assertedEvents` actually
  * references, and report each one's `ExecOutcome` paired with the step it
  * belongs to.
@@ -349,14 +434,25 @@ async function runStep(
  * anything about it is inspected further — not spawned, and not even
  * checked for a `stub` — so it contributes nothing to the returned array
  * rather than a placeholder entry. Order among the steps that do run follows
- * `plan.steps`'s own order, but all of them run concurrently
- * (`Promise.all`): nothing about one step's outcome depends on another's.
+ * `plan.steps`'s own order.
+ *
+ * At most `deps.concurrency` (default {@link HOOKASSERT_DEFAULT_CONCURRENCY})
+ * steps are ever in flight at once — see that constant's remark for why a
+ * plan built from a real `FixtureSet` cannot be trusted to stay small enough
+ * to `Promise.all` outright. The cap applies to every step this function
+ * considers running, `stub`-declared or not: a stubbed step never reaches
+ * `deps.spawner` regardless (see `runStep`), so it occupies a worker only for
+ * the negligible time {@link stubbedOutcome} takes, never competing with a
+ * real spawn for the resources the cap protects.
  *
  * Each result carries its own `step` rather than being returned as a bare
  * positional `ExecOutcome[]`: the array here is already filtered down from
  * `plan.steps`, so a caller that only sees `plan.steps` (never the filtered
  * list) cannot reliably index back from a returned outcome to the hook that
- * produced it without re-deriving the identical filter.
+ * produced it without re-deriving the identical filter. `runWithConcurrencyLimit`
+ * preserves `relevant`'s order in its result regardless of which worker
+ * happened to finish which item first, so this pairing survives the cap the
+ * same way it survived the previous unbounded `Promise.all`.
  */
 export async function executeHooks(
   deps: ExecDeps,
@@ -364,7 +460,9 @@ export async function executeHooks(
 ): Promise<readonly ExecutionResult[]> {
   const env = envForDeps(deps);
   const relevant = plan.steps.filter((step) => plan.assertedEvents.has(step.event));
-  return Promise.all(
-    relevant.map(async (step) => ({ step, outcome: await runStep(deps, step, env) })),
-  );
+  const concurrency = deps.concurrency ?? HOOKASSERT_DEFAULT_CONCURRENCY;
+  return runWithConcurrencyLimit(relevant, concurrency, async (step) => ({
+    step,
+    outcome: await runStep(deps, step, env),
+  }));
 }

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -43,36 +43,18 @@ export const HOOKASSERT_DEFAULT_TIMEOUT_MS = 10_000;
  * `test` runs the user's own hooks on the user's own machine; the concrete
  * failure this bounds is `Promise.all`-ing every step of a real
  * `ExecutionPlan` at once, which for a fixture set with many cases against a
- * settings tree with several hooks per event reaches a few hundred
- * simultaneous `detached` children, each holding three pipes — enough to hit
- * `EAGAIN`/`EMFILE` on the spawner itself (reported by `NodeSpawner` as
- * `exitCode: -1`, indistinguishable from a real hook failure) well before a
- * few hundred processes is unusual.
+ * settings tree with several hooks per event can reach hundreds of
+ * simultaneous children, enough to hit `EAGAIN`/`EMFILE` on the spawner
+ * itself.
  *
- * `8` was chosen from two measurements taken on the machine this issue was
- * fixed on (`os.availableParallelism()` also reports `8` there), spawning
- * real child processes through `/bin/sh -c` and `node -e` at caps
- * `1/4/8/16/32/unbounded`:
- *
- * - **I/O-bound** (200 steps, each `sh -c "sleep 0.02"`): cap `1` took
- *   ~7044ms; cap `8` took ~939ms (a 7.5x speedup over serial); caps `16`/`32`
- *   kept improving but only to ~601ms/~569ms — real but sharply diminishing
- *   returns past `8`.
- * - **CPU-bound** (64 steps, each a fresh `node -e` doing real work): cap `8`
- *   was the fastest point measured (~1576ms); caps `16`/`32` were *slower*
- *   (~1826ms/~1791ms) than `8`, from context-switching more processes than
- *   the machine has cores for.
- *
- * `8` sits at the CPU-bound optimum and already captures the large majority
- * of the I/O-bound benefit, without the unbounded case's fd/process-table
- * exposure. It is a fixed constant rather than a dynamic
- * `os.availableParallelism()` read: hook processes are typically
- * I/O-bound rather than CPU-bound (per the CPU-bound measurement above,
- * `availableParallelism()` would actually be the *worse* choice for that
- * workload), and a fixed default keeps a run's behavior independent of the
- * machine it happens to run on. {@link ExecDeps.concurrency} overrides this
- * per run; wiring a `--concurrency` flag to it is a CLI-surface addition left
- * for a future change.
+ * `8` is a fixed constant rather than a dynamic `os.availableParallelism()`
+ * read, measured with real child processes: it is the CPU-bound optimum
+ * (more workers than cores slows a CPU-bound run down from context
+ * switching), and I/O-bound throughput keeps improving past `8` only with
+ * sharply diminishing returns. A fixed default also keeps a run's behavior
+ * independent of the machine it happens to run on. {@link ExecDeps.concurrency}
+ * overrides this per run; wiring a `--concurrency` flag to it is a
+ * CLI-surface addition left for a future change.
  */
 export const HOOKASSERT_DEFAULT_CONCURRENCY = 8;
 
@@ -297,8 +279,8 @@ export interface ExecDeps {
   /**
    * Maximum number of steps {@link executeHooks} runs at once. Omit to use
    * {@link HOOKASSERT_DEFAULT_CONCURRENCY}; see its remark for how that
-   * default was chosen. A value below `1` is treated as `1` rather than
-   * deadlocking a plan that has steps to run.
+   * default was chosen. When given, must be an integer `>= 1`; `executeHooks`
+   * throws a `RangeError` otherwise rather than silently coercing it.
    */
   readonly concurrency?: number;
 }
@@ -399,11 +381,7 @@ async function runStep(
  * it finishes its current one. `items.entries()` — rather than an indexed
  * `items[i]` loop — is what lets multiple workers share one iterator safely:
  * each `for...of` step calls the shared iterator's `next()` synchronously, so
- * two workers can never race onto the same index, and `noUncheckedIndexedAccess`
- * never comes into play since nothing here indexes the array directly.
- * `results` is written through a local `(R | undefined)[]`, then asserted to
- * `R[]` only after every worker has returned — at that point every index in
- * `[0, items.length)` was visited exactly once by exactly one worker.
+ * two workers can never race onto the same index.
  */
 async function runWithConcurrencyLimit<T, R>(
   items: readonly T[],
@@ -453,11 +431,24 @@ async function runWithConcurrencyLimit<T, R>(
  * preserves `relevant`'s order in its result regardless of which worker
  * happened to finish which item first, so this pairing survives the cap the
  * same way it survived the previous unbounded `Promise.all`.
+ *
+ * @throws {RangeError} `deps.concurrency` is given but is not an integer
+ * `>= 1` — a value such as `0`, a fraction, or `NaN` is rejected here rather
+ * than silently clamped, since a clamp that turns `NaN` into `0` workers
+ * would resolve with no hook ever spawned.
  */
 export async function executeHooks(
   deps: ExecDeps,
   plan: ExecutionPlan,
 ): Promise<readonly ExecutionResult[]> {
+  if (
+    deps.concurrency !== undefined &&
+    !(Number.isInteger(deps.concurrency) && deps.concurrency >= 1)
+  ) {
+    throw new RangeError(
+      `ExecDeps.concurrency must be an integer >= 1, got ${String(deps.concurrency)}.`,
+    );
+  }
   const env = envForDeps(deps);
   const relevant = plan.steps.filter((step) => plan.assertedEvents.has(step.event));
   const concurrency = deps.concurrency ?? HOOKASSERT_DEFAULT_CONCURRENCY;

--- a/src/internal/exec/index.ts
+++ b/src/internal/exec/index.ts
@@ -12,6 +12,7 @@
 export {
   buildHookEnv,
   executeHooks,
+  HOOKASSERT_DEFAULT_CONCURRENCY,
   HOOKASSERT_DEFAULT_ENV_KEYS,
   HOOKASSERT_DEFAULT_TIMEOUT_MS,
   isCredentialShapedEnvKey,

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildHookEnv,
   executeHooks,
+  HOOKASSERT_DEFAULT_CONCURRENCY,
   HOOKASSERT_DEFAULT_TIMEOUT_MS,
   isCredentialShapedEnvKey,
   NodeSpawner,
@@ -120,6 +121,9 @@ function makeDeps(overrides: Partial<ExecDeps> = {}): ExecDeps {
     ...(overrides.explicitDefaultTimeoutMs === undefined
       ? {}
       : { explicitDefaultTimeoutMs: overrides.explicitDefaultTimeoutMs }),
+    ...(overrides.concurrency === undefined
+      ? {}
+      : { concurrency: overrides.concurrency }),
   };
 }
 
@@ -465,6 +469,147 @@ describe("stub bypass", () => {
     expect(spawner.calls.every((call) => call.command !== "stubbed-command")).toBe(
       true,
     );
+  });
+});
+
+describe("concurrency cap", () => {
+  /**
+   * A `Spawner` whose calls stay pending until manually released, and which
+   * records the maximum number of calls in flight at once — the fact this
+   * describe block relies on to prove `executeHooks`' cap actually holds
+   * during the run, not only trusting the implementation to enforce it.
+   */
+  class GatedSpawner implements Spawner {
+    readonly calls: SpawnRequest[] = [];
+    readonly #pending: (() => void)[] = [];
+    #current = 0;
+    maxObserved = 0;
+
+    spawn(req: SpawnRequest): Promise<ExecOutcome> {
+      this.calls.push(req);
+      this.#current += 1;
+      this.maxObserved = Math.max(this.maxObserved, this.#current);
+      return new Promise((resolve) => {
+        this.#pending.push(() => {
+          this.#current -= 1;
+          resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+        });
+      });
+    }
+
+    get current(): number {
+      return this.#current;
+    }
+
+    /** Resolves every call currently pending, letting its worker move on. */
+    releasePending(): void {
+      const toRelease = this.#pending.splice(0, this.#pending.length);
+      for (const resolveOne of toRelease) {
+        resolveOne();
+      }
+    }
+  }
+
+  /**
+   * Yields the microtask queue enough times for one released spawn's
+   * continuation chain (the spawn's own promise, then `runStep`'s adopted
+   * promise, then the per-step callback's `await`, then the worker's
+   * `await`) to reach the next synchronous dispatch — no real timer
+   * involved, since nothing here is waiting on wall-clock time.
+   */
+  async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  it("never runs more than `concurrency` steps at once, still runs every step, and preserves each result's step pairing", async () => {
+    const spawner = new GatedSpawner();
+    const hooks = Array.from({ length: 7 }, (_, index) =>
+      makeHook({ command: `step-${String(index)}` }),
+    );
+    const steps = hooks.map((hook) => makeStep(hook));
+    const deps = makeDeps({ spawner, concurrency: 3 });
+
+    const resultPromise = executeHooks(deps, makePlan(steps));
+
+    // executeHooks' worker pool dispatches its first round synchronously:
+    // each of the 3 workers runs up to its own first await (the pending
+    // spawn call) before control returns here, so exactly `concurrency`
+    // calls have already started — no microtask flush needed yet.
+    expect(spawner.calls).toHaveLength(3);
+    expect(spawner.current).toBe(3);
+
+    while (spawner.calls.length < steps.length) {
+      spawner.releasePending();
+      await flushMicrotasks();
+    }
+    spawner.releasePending();
+    await flushMicrotasks();
+
+    const results = await resultPromise;
+
+    expect(spawner.calls).toHaveLength(7);
+    expect(spawner.current).toBe(0);
+    // The cap held for the whole run, not only at the start: this is the
+    // assertion the fix's completion checklist asks for.
+    expect(spawner.maxObserved).toBe(3);
+    expect(results).toHaveLength(7);
+    // Each ExecutionResult still carries its own step, in plan order.
+    expect(results.map((result) => result.step)).toEqual(steps);
+  });
+
+  it("a concurrency below 1 is treated as 1 rather than deadlocking", async () => {
+    const spawner = new CountingSpawner();
+    const hook = makeHook({ command: "echo hi" });
+    const deps = makeDeps({ spawner, concurrency: 0 });
+
+    const outcomes = await executeHooks(deps, makePlan([makeStep(hook)]));
+
+    expect(outcomes).toHaveLength(1);
+    expect(spawner.calls).toHaveLength(1);
+  });
+
+  it("omitting concurrency uses HOOKASSERT_DEFAULT_CONCURRENCY", async () => {
+    const spawner = new CountingSpawner();
+    const hookCount = HOOKASSERT_DEFAULT_CONCURRENCY + 2;
+    const hooks = Array.from({ length: hookCount }, (_, index) =>
+      makeHook({ command: `default-cap-${String(index)}` }),
+    );
+    const deps = makeDeps({ spawner });
+
+    const outcomes = await executeHooks(
+      deps,
+      makePlan(hooks.map((hook) => makeStep(hook))),
+    );
+
+    expect(outcomes).toHaveLength(hookCount);
+    expect(spawner.calls).toHaveLength(hookCount);
+  });
+
+  it("a stubbed step still never reaches the Spawner while the cap is in effect", async () => {
+    const spawner = new CountingSpawner();
+    const stub: FixtureStubEntry = { exitCode: 3 };
+    const hooks = Array.from({ length: 5 }, (_, index) =>
+      makeHook({ command: `mixed-${String(index)}` }),
+    );
+    const steps = hooks.map((hook, index) =>
+      makeStep(hook, index === 2 ? { stub } : {}),
+    );
+    const deps = makeDeps({ spawner, concurrency: 2 });
+
+    const outcomes = await executeHooks(deps, makePlan(steps));
+
+    expect(outcomes).toHaveLength(5);
+    // 5 steps, 1 stubbed: only 4 ever reach the Spawner.
+    expect(spawner.calls).toHaveLength(4);
+    expect(spawner.calls.every((call) => call.command !== "mixed-2")).toBe(true);
+    expect(outcomes[2]?.outcome).toEqual({
+      exitCode: 3,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+    });
   });
 });
 

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildHookEnv,
@@ -511,16 +511,18 @@ describe("concurrency cap", () => {
   }
 
   /**
-   * Yields the microtask queue enough times for one released spawn's
-   * continuation chain (the spawn's own promise, then `runStep`'s adopted
-   * promise, then the per-step callback's `await`, then the worker's
-   * `await`) to reach the next synchronous dispatch — no real timer
-   * involved, since nothing here is waiting on wall-clock time.
+   * Releases every currently pending gated spawn call, then waits until a
+   * new call actually shows up in `spawner.calls` — rather than pumping a
+   * fixed number of microtask turns, which would silently need bumping if a
+   * future change added another async layer between a release and the next
+   * dispatched call.
    */
-  async function flushMicrotasks(): Promise<void> {
-    for (let i = 0; i < 20; i++) {
-      await Promise.resolve();
-    }
+  async function releaseAndWaitForNextCall(spawner: GatedSpawner): Promise<void> {
+    const before = spawner.calls.length;
+    spawner.releasePending();
+    await vi.waitFor(() => {
+      expect(spawner.calls.length).toBeGreaterThan(before);
+    });
   }
 
   it("never runs more than `concurrency` steps at once, still runs every step, and preserves each result's step pairing", async () => {
@@ -536,55 +538,64 @@ describe("concurrency cap", () => {
     // executeHooks' worker pool dispatches its first round synchronously:
     // each of the 3 workers runs up to its own first await (the pending
     // spawn call) before control returns here, so exactly `concurrency`
-    // calls have already started — no microtask flush needed yet.
+    // calls have already started — no wait needed yet.
     expect(spawner.calls).toHaveLength(3);
     expect(spawner.current).toBe(3);
 
     while (spawner.calls.length < steps.length) {
-      spawner.releasePending();
-      await flushMicrotasks();
+      await releaseAndWaitForNextCall(spawner);
     }
     spawner.releasePending();
-    await flushMicrotasks();
 
     const results = await resultPromise;
 
     expect(spawner.calls).toHaveLength(7);
     expect(spawner.current).toBe(0);
-    // The cap held for the whole run, not only at the start: this is the
-    // assertion the fix's completion checklist asks for.
+    // The cap held for the whole run, not only at the start.
     expect(spawner.maxObserved).toBe(3);
     expect(results).toHaveLength(7);
     // Each ExecutionResult still carries its own step, in plan order.
     expect(results.map((result) => result.step)).toEqual(steps);
   });
 
-  it("a concurrency below 1 is treated as 1 rather than deadlocking", async () => {
-    const spawner = new CountingSpawner();
-    const hook = makeHook({ command: "echo hi" });
-    const deps = makeDeps({ spawner, concurrency: 0 });
+  it.each([0, Number.NaN, 2.5])(
+    "rejects a concurrency of %s with a RangeError and spawns nothing",
+    async (concurrency) => {
+      const spawner = new CountingSpawner();
+      const hook = makeHook({ command: "echo hi" });
+      const deps = makeDeps({ spawner, concurrency });
 
-    const outcomes = await executeHooks(deps, makePlan([makeStep(hook)]));
-
-    expect(outcomes).toHaveLength(1);
-    expect(spawner.calls).toHaveLength(1);
-  });
+      await expect(executeHooks(deps, makePlan([makeStep(hook)]))).rejects.toThrow(
+        RangeError,
+      );
+      expect(spawner.calls).toHaveLength(0);
+    },
+  );
 
   it("omitting concurrency uses HOOKASSERT_DEFAULT_CONCURRENCY", async () => {
-    const spawner = new CountingSpawner();
+    // CountingSpawner's spawn() resolves synchronously, so it cannot tell
+    // the default cap apart from no cap at all — GatedSpawner, which holds
+    // each call open until released, is what actually proves the cap held.
+    const spawner = new GatedSpawner();
     const hookCount = HOOKASSERT_DEFAULT_CONCURRENCY + 2;
     const hooks = Array.from({ length: hookCount }, (_, index) =>
       makeHook({ command: `default-cap-${String(index)}` }),
     );
+    const steps = hooks.map((hook) => makeStep(hook));
     const deps = makeDeps({ spawner });
 
-    const outcomes = await executeHooks(
-      deps,
-      makePlan(hooks.map((hook) => makeStep(hook))),
-    );
+    const resultPromise = executeHooks(deps, makePlan(steps));
+
+    while (spawner.calls.length < steps.length) {
+      await releaseAndWaitForNextCall(spawner);
+    }
+    spawner.releasePending();
+
+    const outcomes = await resultPromise;
 
     expect(outcomes).toHaveLength(hookCount);
     expect(spawner.calls).toHaveLength(hookCount);
+    expect(spawner.maxObserved).toBe(HOOKASSERT_DEFAULT_CONCURRENCY);
   });
 
   it("a stubbed step still never reaches the Spawner while the cap is in effect", async () => {

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { runCli, type CliDeps } from "../src/cli.js";
 import { NodeSpawner } from "../src/internal/exec/spawner.js";
@@ -697,5 +697,83 @@ describe("machine guarantees", () => {
     );
     expect(testResult.exitCode).toBe(0);
     expect(spawner.calls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("cross-file concurrency cap (issue #40)", () => {
+  /**
+   * A `Spawner` whose calls stay pending until manually released, and which
+   * records the maximum number of calls in flight at once — used here to
+   * prove `runTest` runs its fixture files' pools one at a time rather than
+   * letting every file's own `HOOKASSERT_DEFAULT_CONCURRENCY`-sized pool run
+   * in parallel with the others (the fan-out issue #40 was filed against).
+   */
+  class GatedSpawner implements Spawner {
+    readonly calls: SpawnRequest[] = [];
+    readonly #pending: (() => void)[] = [];
+    #current = 0;
+    maxObserved = 0;
+
+    spawn(req: SpawnRequest): Promise<ExecOutcome> {
+      this.calls.push(req);
+      this.#current += 1;
+      this.maxObserved = Math.max(this.maxObserved, this.#current);
+      return new Promise((resolve) => {
+        this.#pending.push(() => {
+          this.#current -= 1;
+          resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+        });
+      });
+    }
+
+    /** Resolves every call currently pending, letting its worker move on. */
+    releasePending(): void {
+      const toRelease = this.#pending.splice(0, this.#pending.length);
+      for (const resolveOne of toRelease) {
+        resolveOne();
+      }
+    }
+  }
+
+  /** Releases every pending call, then waits until the next call shows up. */
+  async function releaseAndWaitForNextCall(spawner: GatedSpawner): Promise<void> {
+    const before = spawner.calls.length;
+    spawner.releasePending();
+    await vi.waitFor(() => {
+      expect(spawner.calls.length).toBeGreaterThan(before);
+    });
+  }
+
+  it("never runs more than one fixture file's pool at once across several files", async () => {
+    const spawner = new GatedSpawner();
+    const casesPerFile = [
+      { event: "PreToolUse", tool: "Bash", expect: {} },
+      { event: "PreToolUse", tool: "Write", expect: {} },
+      { event: "PreToolUse", tool: "Edit", expect: {} },
+    ];
+    const fixturePaths = Array.from({ length: 3 }, () =>
+      writeFixture({ cases: casesPerFile }),
+    );
+    const totalSpawns = fixturePaths.length * casesPerFile.length;
+
+    const resultPromise = runCli(
+      ["test", ...fixturePaths, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    while (spawner.calls.length < totalSpawns) {
+      await releaseAndWaitForNextCall(spawner);
+    }
+    spawner.releasePending();
+
+    const result = await resultPromise;
+
+    expect(spawner.calls).toHaveLength(totalSpawns);
+    // Each file's own pool spawns at most `casesPerFile.length` calls at
+    // once. If the files' pools ran in parallel instead of sequentially,
+    // this could reach up to `totalSpawns`.
+    expect(spawner.maxObserved).toBeLessThanOrEqual(casesPerFile.length);
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
`executeHooks` used to `Promise.all` every step of an `ExecutionPlan` at once, which for a real fixture set against a settings tree with several hooks per event can reach a few hundred simultaneous detached child processes — risking `EAGAIN`/`EMFILE` on the spawner (misreported as a hook failure) and spurious `timedOut` results from sibling contention. `executeHooks` now runs at most `ExecDeps.concurrency` (default `HOOKASSERT_DEFAULT_CONCURRENCY = 8`) steps at once through an in-repo worker pool, preserving `ExecutionResult`'s step pairing and order and leaving the `stub`-bypass and `Spawner` seam invariants intact. `runTest` runs its fixture files sequentially so a multi-file run keeps one pool in flight rather than one per file. An invalid `concurrency` (`0`, `NaN`, a fraction) is rejected with a `RangeError` instead of being clamped.

Closes #40

Release impact: yes — PATCH. `hookassert test` now bounds how many hook processes it launches at once; no import surface, CLI option, or output shape changes.

## How the default cap was chosen

Two throwaway benchmarks spawning real child processes at caps 1/4/8/16/32/unbounded, on a machine where `os.availableParallelism()` reports 8:

| workload | cap 1 | cap 8 | cap 16 | cap 32 | unbounded |
| --- | --- | --- | --- | --- | --- |
| I/O-bound, 200 × `sh -c "sleep 0.02"` | 7044 ms | 939 ms | 601 ms | 569 ms | 605 ms |
| CPU-bound, 64 × fresh `node -e` doing real work | — | 1576 ms | 1826 ms | 1791 ms | — |

8 is the CPU-bound optimum and already captures most of the I/O-bound benefit, so it is the fixed default rather than a dynamic `availableParallelism()` read.

## Test plan

- `pnpm exec vitest run tests/executor.test.ts tests/test-cmd.test.ts` — pass (55 tests). New coverage: a `GatedSpawner` that records maximum observed in-flight calls proves the cap holds for a whole run (7 steps at `concurrency: 3`) and that omitting `concurrency` really applies the default (`HOOKASSERT_DEFAULT_CONCURRENCY + 2` steps, max observed `=== 8`); `0`, `NaN`, and `2.5` each reject with `RangeError` and spawn nothing; a mixed real/stub plan proves stubbed steps still never reach the `Spawner`; a three-file `test` run proves the cap holds across files, not only within one.
- `pnpm check:quick` — pass (format, lint, typecheck, 34 test files / 1311 tests).

## Review findings addressed before this PR opened

A `/code-review medium` pass ran against the branch first; all six findings were applied: the per-file (rather than per-run) cap in `runTest`, the unguarded `NaN` clamp, a default-cap test that could not distinguish the default from no cap, a microtask flush hard-coded to today's await depth, and two comments that carried benchmark timings and an issue-checklist reference into source.

https://claude.ai/code/session_01Eg742R8ixiz1Fv8ThoAyGc
