### PR TITLE
feat: add the lint rule framework, the five matcher rules, and all three report formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ hookassert --help
   every matcher that did not fire printed with the reason. It never spawns a process —
   the Claude Code version it runs against comes only from `--claude-version` or the
   `HOOKASSERT_CLAUDE_VERSION` environment variable, falling back to `"undetermined"`.
-- `hookassert lint` checks hook declarations for matcher and command mistakes.
+- `hookassert lint` is a zero-execution static check over your settings tree: it never
+  spawns a process or writes a file, and reports every matcher mistake it finds as a
+  `Finding` — a dead exact-match item, a case mismatch, an unanchored regex that
+  over-matches, and a comma- or hyphen-notation matcher used against a Claude Code
+  version that cannot be confirmed to support it. Exits `1` when it finds anything, `0`
+  when it finds nothing. `--claude-version`, `--settings` and `--format`
+  (`pretty`/`json`/`github`) mean exactly what they do for `explain`.
 - `hookassert record` captures real hook payloads from a Claude Code session.
 - `hookassert test <fixture>...` replays one or more fixture files against your merged
   settings, runs the hooks that actually fire, and asserts what happened against each
@@ -47,8 +53,8 @@ hookassert --help
   `unknown` either), `1` when at least one fails, and `3` when there are no failures but
   `--ci` was given and at least one case is `unknown`.
 
-`lint` and `record` have no behavior yet: each currently exits `4` with `ERR_USAGE`, so
-a script that wires one up fails loudly instead of silently reporting success.
+`record` alone has no behavior yet: it currently exits `4` with `ERR_USAGE`, so a script
+that wires it up fails loudly instead of silently reporting success.
 
 ## API
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -382,6 +382,7 @@ export default defineConfig([
       "tests/fixture.test.ts",
       "tests/assert.test.ts",
       "tests/test-cmd.test.ts",
+      "tests/lint.test.ts",
     ],
     rules: {
       "no-restricted-imports": "off",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import {
   type FixtureFile,
   type FixtureSet,
 } from "./internal/fixture/index.js";
+import { buildLintContext, LINT_RULES } from "./internal/lint/index.js";
 import {
   matchHooks,
   type MatcherOutcome,
@@ -48,11 +49,13 @@ import {
   renderGithub,
   renderInFormat,
   renderJson,
+  renderLintPretty,
   renderPretty,
   renderTestGithub,
   renderTestJson,
   renderTestPretty,
   type ExplainReport,
+  type LintReport,
   type TestCaseReport,
   type TestReport,
 } from "./internal/report/index.js";
@@ -95,8 +98,8 @@ const SPEC_PATH = fileURLToPath(
  * usage text.
  *
  * @remarks
- * `explain` and `test` have real behavior; `lint` and `record` are still
- * stubs. Naming all four here anyway is what makes the usage text and the
+ * `explain`, `lint`, and `test` have real behavior; `record` is still a
+ * stub. Naming all four here anyway is what makes the usage text and the
  * "unknown command" message agree with each other, and with the routing that
  * replaces each stub once its own issue lands.
  */
@@ -448,6 +451,103 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   });
 
   return { exitCode: 0, stdout, stderr: "" };
+}
+
+/** `lint`'s own option table: `common` only — `lint` has no `<event>`/`[tool]` positionals. */
+const LINT_OPTIONS = {
+  settings: { type: "string", multiple: true },
+  "claude-version": { type: "string" },
+  format: { type: "string" },
+  help: { type: "boolean", short: "h" },
+} as const;
+
+/**
+ * `lint` is a zero-execution static check: it discovers settings the same
+ * way `explain` does, runs every registered `LintRule` over them, and exits
+ * `1` when any `Finding` was produced, `0` otherwise. `--ci` behaves
+ * identically to a plain run — lint findings are binary (found or not),
+ * unlike `test`'s three-way pass/fail/unknown, so there is no separate
+ * `--ci` branch here the way `resolveTestExitCode` has one.
+ *
+ * @remarks
+ * `--format json`/`--format github` are validated as recognized formats but
+ * rejected as not-yet-implemented for `lint`: wiring a `Finding` through
+ * those two reporters is a later issue's own scope — see
+ * `report/lintReport.ts`'s own remark. Only `pretty` (the default) actually
+ * renders here.
+ *
+ * @throws {UsageError} an option was malformed, a positional argument was
+ * given, `--format` named an unrecognized or not-yet-implemented format, or
+ * `--claude-version` was not a valid `major.minor.patch` version.
+ * (Also propagates every load-time error `loadSpecFile` can throw, and
+ * `SettingsNotFoundError` for a named `--settings` file that does not
+ * exist.)
+ */
+function runLint(args: readonly string[], deps: CliDeps): CliResult {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args,
+      strict: true,
+      allowPositionals: true,
+      options: LINT_OPTIONS,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new UsageError(`invalid options for lint: ${reason}`);
+  }
+
+  if (parsed.positionals.length > 0) {
+    throw new UsageError(
+      `lint accepts no positional arguments; got ${JSON.stringify(parsed.positionals[0])}.`,
+    );
+  }
+
+  // Validated here, before any I/O, per the same rule runExplain follows.
+  if (parsed.values.format !== undefined && !isReportFormat(parsed.values.format)) {
+    throw new UsageError(
+      `unrecognized --format ${JSON.stringify(parsed.values.format)}. ` +
+        `Expected one of: pretty, json, github.`,
+    );
+  }
+  if (parsed.values.format === "json" || parsed.values.format === "github") {
+    throw new UsageError(
+      `the --format ${parsed.values.format} for lint is not implemented yet.`,
+    );
+  }
+
+  const versionContext = resolveVersionContext(
+    parsed.values["claude-version"],
+    deps.env,
+  );
+  const spec = loadSpecFile(deps.specPath);
+
+  const explicitSettings = parsed.values.settings;
+  // Same rationale as runExplain: a settings file the caller named
+  // explicitly is an assertion it exists, unlike a discovered layer.
+  for (const file of explicitSettings ?? []) {
+    const resolved = path.resolve(deps.cwd, file);
+    if (!existsSync(resolved)) {
+      throw new SettingsNotFoundError(resolved);
+    }
+  }
+  const sources = discoverSources({
+    cwd: deps.cwd,
+    home: deps.home,
+    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
+  });
+
+  const ctx = buildLintContext(sources, spec, versionContext);
+  const findings = LINT_RULES.flatMap((rule) => rule.run(ctx));
+
+  const report: LintReport = {
+    header: buildReportHeader(versionContext, spec.claudeCodeRange),
+    findings,
+  };
+
+  const stdout = renderLintPretty(report);
+
+  return { exitCode: findings.length > 0 ? 1 : 0, stdout, stderr: "" };
 }
 
 /** `test`'s own option table: `common` plus consent, timing, and execution controls. */
@@ -1048,9 +1148,10 @@ export async function runCli(
     switch (subcommand) {
       case "explain":
         return runExplain(rest, resolveDeps(deps));
+      case "lint":
+        return runLint(rest, resolveDeps(deps));
       case "test":
         return await runTest(rest, resolveDeps(deps));
-      case "lint":
       case "record":
         // A recognised command with no implementation behind it is still a
         // usage error: fabricating partial behavior would make the gap

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -455,11 +455,15 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   return { exitCode: 0, stdout, stderr: "" };
 }
 
-/** `lint`'s own option table: `common` only — `lint` has no `<event>`/`[tool]` positionals. */
+/**
+ * `lint`'s own option table: `common` plus `--ci`, accepted and ignored —
+ * `lint` has no `<event>`/`[tool]` positionals.
+ */
 const LINT_OPTIONS = {
   settings: { type: "string", multiple: true },
   "claude-version": { type: "string" },
   format: { type: "string" },
+  ci: { type: "boolean" },
   help: { type: "boolean", short: "h" },
 } as const;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,8 @@ import {
   renderGithub,
   renderInFormat,
   renderJson,
+  renderLintGithub,
+  renderLintJson,
   renderLintPretty,
   renderPretty,
   renderTestGithub,
@@ -470,15 +472,16 @@ const LINT_OPTIONS = {
  * `--ci` branch here the way `resolveTestExitCode` has one.
  *
  * @remarks
- * `--format json`/`--format github` are validated as recognized formats but
- * rejected as not-yet-implemented for `lint`: wiring a `Finding` through
- * those two reporters is a later issue's own scope — see
- * `report/lintReport.ts`'s own remark. Only `pretty` (the default) actually
- * renders here.
+ * `--format` selects among `pretty`/`json`/`github` through the same
+ * `renderInFormat` selector `explain`/`test` already use — `renderLintGithub`
+ * takes `deps.cwd` as its workspace root, exactly as `runTest` passes
+ * `deps.cwd` to `renderTestGithub`, so a `Finding.file` (always absolute)
+ * renders relative to the repository checkout rather than as a raw
+ * absolute path.
  *
  * @throws {UsageError} an option was malformed, a positional argument was
- * given, `--format` named an unrecognized or not-yet-implemented format, or
- * `--claude-version` was not a valid `major.minor.patch` version.
+ * given, `--format` named an unrecognized format, or `--claude-version` was
+ * not a valid `major.minor.patch` version.
  * (Also propagates every load-time error `loadSpecFile` can throw, and
  * `SettingsNotFoundError` for a named `--settings` file that does not
  * exist.)
@@ -508,11 +511,6 @@ function runLint(args: readonly string[], deps: CliDeps): CliResult {
     throw new UsageError(
       `unrecognized --format ${JSON.stringify(parsed.values.format)}. ` +
         `Expected one of: pretty, json, github.`,
-    );
-  }
-  if (parsed.values.format === "json" || parsed.values.format === "github") {
-    throw new UsageError(
-      `the --format ${parsed.values.format} for lint is not implemented yet.`,
     );
   }
 
@@ -545,7 +543,11 @@ function runLint(args: readonly string[], deps: CliDeps): CliResult {
     findings,
   };
 
-  const stdout = renderLintPretty(report);
+  const stdout = renderInFormat(report, parsed.values.format, {
+    pretty: renderLintPretty,
+    json: renderLintJson,
+    github: (r: LintReport) => renderLintGithub(r, deps.cwd),
+  });
 
   return { exitCode: findings.length > 0 ? 1 : 0, stdout, stderr: "" };
 }

--- a/src/internal/lint/index.ts
+++ b/src/internal/lint/index.ts
@@ -1,0 +1,18 @@
+/**
+ * The lint rule framework's own internal surface.
+ *
+ * @remarks
+ * `src/cli.ts` is the composition root that imports from here; nothing here
+ * is re-exported from `src/index.ts` — see `types.ts`'s own doc comment for
+ * why that boundary is enforced mechanically, not just by convention.
+ */
+
+export { buildLintContext, readMatcherGroups } from "./parse.js";
+export { LINT_RULES } from "./registry.js";
+export type {
+  Finding,
+  LintContext,
+  LintMatcherGroup,
+  LintMatcherValue,
+  LintRule,
+} from "./types.js";

--- a/src/internal/lint/parse.ts
+++ b/src/internal/lint/parse.ts
@@ -1,0 +1,265 @@
+/**
+ * Reads every `hooks.<event>[]` matcher group out of a settings file,
+ * tolerant of a matcher declared as a JSON array.
+ *
+ * @remarks
+ * Static layer: reads a file's text and parses it, but never spawns a
+ * process and never writes anything back — the same guarantee
+ * `settings/load.ts` makes.
+ *
+ * `settings/load.ts`'s own `loadSourceHooks` cannot be reused here: it calls
+ * `requireString` on every declared `matcher`, which throws
+ * `SettingsParseError` the moment one is a JSON array
+ * (`tests/settings.test.ts`'s "a matcher written as a JSON array disables
+ * every hook in that settings file" describes exactly this). That is the
+ * right behavior for `explain`/`test`, which need a fully resolved
+ * `ResolvedHook[]` or nothing at all — but it is exactly the case
+ * `matcher-is-array` exists to turn into a `Finding` instead of a thrown
+ * error, so this module reads the same JSONC tree with the same structural
+ * strictness everywhere else, carving out only the one exception: a
+ * `matcher` may be `absent`, a `string`, or an `array` without ever
+ * throwing. Any other shape (a number, a boolean, an object) is still
+ * rejected exactly as `settings/load.ts` would reject it — this module is
+ * not a general-purpose lenient settings reader, only the one exception
+ * `matcher-is-array` needs.
+ */
+
+import { readFileSync } from "node:fs";
+
+import {
+  type Node,
+  type ParseError,
+  parseTree,
+  printParseErrorCode,
+} from "jsonc-parser";
+
+import type { EventName } from "../../types.js";
+import { SettingsParseError } from "../errors.js";
+import type { SettingsSource } from "../settings/index.js";
+import type { LintContext, LintMatcherGroup, LintMatcherValue } from "./types.js";
+
+/**
+ * The event names this reader recognizes — the same set
+ * `settings/load.ts`'s own `KNOWN_EVENT_NAMES` mirrors from `EventName`.
+ *
+ * @remarks
+ * Typed as `Record<EventName, true>` rather than an array so widening
+ * `EventName` without extending this map is a type error here, instead of a
+ * reader that quietly drops every group declared under the new event. A
+ * `hooks` key outside this set is not an error — see `KNOWN_EVENT_NAMES`'s
+ * own doc comment in `settings/load.ts` for why.
+ */
+const KNOWN_EVENT_NAMES: Readonly<Record<EventName, true>> = {
+  SessionStart: true,
+  Setup: true,
+  InstructionsLoaded: true,
+  UserPromptSubmit: true,
+  UserPromptExpansion: true,
+  MessageDisplay: true,
+  PreToolUse: true,
+  PermissionRequest: true,
+  PostToolUse: true,
+  PostToolUseFailure: true,
+  PostToolBatch: true,
+  PermissionDenied: true,
+  Notification: true,
+  SubagentStart: true,
+  SubagentStop: true,
+  TaskCreated: true,
+  TaskCompleted: true,
+  Stop: true,
+  StopFailure: true,
+  TeammateIdle: true,
+  ConfigChange: true,
+  CwdChanged: true,
+  DirectoryAdded: true,
+  FileChanged: true,
+  WorktreeCreate: true,
+  WorktreeRemove: true,
+  PreCompact: true,
+  PostCompact: true,
+  PreModelSwitch: true,
+  PostModelSwitch: true,
+  SessionEnd: true,
+  Elicitation: true,
+  ElicitationResult: true,
+};
+
+function isEventName(value: string): value is EventName {
+  return Object.hasOwn(KNOWN_EVENT_NAMES, value);
+}
+
+/** Find a property node's *value* node inside an object node, by key. */
+function getProperty(objectNode: Node, key: string): Node | undefined {
+  for (const property of objectNode.children ?? []) {
+    const [keyNode, valueNode] = property.children ?? [];
+    if (keyNode?.type === "string" && keyNode.value === key) {
+      return valueNode;
+    }
+  }
+  return undefined;
+}
+
+/** 1-based line of a UTF-16 code-unit offset into `text`. */
+function lineAt(text: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+    }
+  }
+  return line;
+}
+
+function describeParseErrors(errors: readonly ParseError[]): string {
+  return errors
+    .map(
+      (error) =>
+        `${printParseErrorCode(error.error)} at offset ${String(error.offset)}`,
+    )
+    .join(", ");
+}
+
+function fail(source: SettingsSource, reason: string): never {
+  throw new SettingsParseError(source.path, source.layer, reason);
+}
+
+function requireObject(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): Node {
+  if (node?.type !== "object") {
+    fail(source, `${description} must be an object`);
+  }
+  return node;
+}
+
+function requireArray(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): readonly Node[] {
+  if (node?.type !== "array") {
+    fail(source, `${description} must be an array`);
+  }
+  return node.children ?? [];
+}
+
+function requireString(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): string {
+  if (node?.type !== "string" || typeof node.value !== "string") {
+    fail(source, `${description} must be a string`);
+  }
+  return node.value;
+}
+
+/**
+ * Read one group's `matcher` property tolerantly: `absent`, `string`, or
+ * `array` never throw — anything else is still a structural error, exactly
+ * as `settings/load.ts`'s `requireString` would reject it.
+ */
+function readMatcherValue(
+  node: Node | undefined,
+  source: SettingsSource,
+  event: EventName,
+): LintMatcherValue {
+  if (node === undefined) {
+    return { kind: "absent" };
+  }
+  if (node.type === "string" && typeof node.value === "string") {
+    return { kind: "string", value: node.value };
+  }
+  if (node.type === "array") {
+    const items = (node.children ?? []).flatMap((child) =>
+      child.type === "string" && typeof child.value === "string" ? [child.value] : [],
+    );
+    return { kind: "array", items };
+  }
+  fail(source, `"hooks.${event}[].matcher" must be a string or an array`);
+}
+
+/**
+ * Read every matcher group `source` declares.
+ *
+ * @remarks
+ * A missing file contributes zero groups — the same "most projects declare
+ * only one or two of the three well-known layers" convention
+ * `settings/load.ts` follows. A file that exists but cannot be parsed as
+ * JSONC, or whose `hooks` value is not shaped the way Claude Code's own
+ * settings schema requires (beyond the one exception above), throws
+ * {@link SettingsParseError}.
+ */
+export function readMatcherGroups(source: SettingsSource): readonly LintMatcherGroup[] {
+  let text: string;
+  try {
+    text = readFileSync(source.path, "utf8");
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw error;
+  }
+
+  const errors: ParseError[] = [];
+  const root = parseTree(text, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    fail(source, describeParseErrors(errors));
+  }
+  const rootNode = requireObject(root, source, "the settings file");
+
+  const hooksNode = getProperty(rootNode, "hooks");
+  if (hooksNode === undefined) {
+    return [];
+  }
+  requireObject(hooksNode, source, '"hooks"');
+
+  const groups: LintMatcherGroup[] = [];
+  for (const property of hooksNode.children ?? []) {
+    const [keyNode, groupsNode] = property.children ?? [];
+    const eventKey = requireString(keyNode, source, 'every key of "hooks"');
+    if (!isEventName(eventKey)) {
+      // Forward-compatible: an event this reader does not yet know about is
+      // skipped rather than rejected. See KNOWN_EVENT_NAMES's doc comment.
+      continue;
+    }
+
+    const groupNodes = requireArray(groupsNode, source, `"hooks.${eventKey}"`);
+    for (const groupNode of groupNodes) {
+      requireObject(groupNode, source, `an entry of "hooks.${eventKey}"`);
+      const matcherNode = getProperty(groupNode, "matcher");
+      const matcher = readMatcherValue(matcherNode, source, eventKey);
+      const line = lineAt(text, matcherNode?.offset ?? groupNode.offset);
+      groups.push({
+        file: source.path,
+        layer: source.layer,
+        event: eventKey,
+        line,
+        matcher,
+      });
+    }
+  }
+
+  return groups;
+}
+
+/** Build the `LintContext` every `LintRule` runs over, from every settings source `lint` discovered. */
+export function buildLintContext(
+  sources: readonly SettingsSource[],
+  spec: LintContext["spec"],
+  versionContext: LintContext["versionContext"],
+): LintContext {
+  return {
+    spec,
+    versionContext,
+    groups: sources.flatMap((source) => readMatcherGroups(source)),
+  };
+}

--- a/src/internal/lint/registry.ts
+++ b/src/internal/lint/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * The active `LintRule`s the `lint` subcommand iterates.
+ *
+ * @remarks
+ * This issue ships only the five matcher rules; the six command/exit-code
+ * rules (`command-not-found`, `missing-shebang`, `not-executable`,
+ * `unquoted-var`, `exit-1-policy`, `exit-2-overrides-allow`) are a later
+ * issue's own scope and are not registered here.
+ */
+
+import { matcherCaseRule } from "./rules/matcherCase.js";
+import { matcherCommaVersionRule } from "./rules/matcherCommaVersion.js";
+import { matcherDeadRule } from "./rules/matcherDead.js";
+import { matcherHyphenVersionRule } from "./rules/matcherHyphenVersion.js";
+import { matcherIsArrayRule } from "./rules/matcherIsArray.js";
+import { matcherUnanchoredRule } from "./rules/matcherUnanchored.js";
+import type { LintRule } from "./types.js";
+
+/** Every lint rule `lint` runs, in the order findings are reported. */
+export const LINT_RULES: readonly LintRule[] = [
+  matcherIsArrayRule,
+  matcherCaseRule,
+  matcherCommaVersionRule,
+  matcherHyphenVersionRule,
+  matcherDeadRule,
+  matcherUnanchoredRule,
+];

--- a/src/internal/lint/rules/matcherCase.ts
+++ b/src/internal/lint/rules/matcherCase.ts
@@ -38,7 +38,13 @@ function findMismatches(
   return mismatches;
 }
 
+/** The delimiter `matcher` was split on — `"|"` when present, `","` otherwise (`splitListItems`'s own precedence). */
+function delimiterOf(matcher: string): string {
+  return matcher.includes("|") ? "|" : ",";
+}
+
 function correctedMatcher(
+  matcher: string,
   items: readonly string[],
   mismatches: readonly CaseMismatch[],
 ): string {
@@ -46,7 +52,7 @@ function correctedMatcher(
     .map(
       (item) => mismatches.find((mismatch) => mismatch.item === item)?.correct ?? item,
     )
-    .join(",");
+    .join(delimiterOf(matcher));
 }
 
 export const matcherCaseRule: LintRule = {
@@ -80,7 +86,7 @@ export const matcherCaseRule: LintRule = {
         message:
           `Matcher "${matcher}" uses the wrong case for ${names}. Matcher ` +
           "comparison is case-sensitive, so this never matches.",
-        suggestion: `Use "${correctedMatcher(items, mismatches)}" instead of "${matcher}".`,
+        suggestion: `Use "${correctedMatcher(matcher, items, mismatches)}" instead of "${matcher}".`,
       });
     }
     return findings;

--- a/src/internal/lint/rules/matcherCase.ts
+++ b/src/internal/lint/rules/matcherCase.ts
@@ -1,0 +1,88 @@
+/**
+ * `matcher-case`: a matcher whose case does not exactly match a known
+ * tool's own case.
+ *
+ * @remarks
+ * `spec.matcherSyntax.caseSensitive` is `true`, and `matcher/match.ts`
+ * compares an exact-list item against `req.target` with plain `===` — so
+ * `"bash"` when the tool is `"Bash"` is a real, silent non-match, not a
+ * style nit: the hook this matcher is attached to will never fire.
+ */
+
+import type { Finding, LintContext, LintRule } from "../types.js";
+import { isExactListSyntax, isToolNameEvent, splitListItems } from "../shared.js";
+
+interface CaseMismatch {
+  readonly item: string;
+  readonly correct: string;
+}
+
+function findCaseInsensitiveMatch(
+  knownTools: readonly string[],
+  item: string,
+): string | undefined {
+  return knownTools.find((tool) => tool.toLowerCase() === item.toLowerCase());
+}
+
+function findMismatches(
+  knownTools: readonly string[],
+  items: readonly string[],
+): readonly CaseMismatch[] {
+  const mismatches: CaseMismatch[] = [];
+  for (const item of items) {
+    const correct = findCaseInsensitiveMatch(knownTools, item);
+    if (correct !== undefined && correct !== item) {
+      mismatches.push({ item, correct });
+    }
+  }
+  return mismatches;
+}
+
+function correctedMatcher(
+  items: readonly string[],
+  mismatches: readonly CaseMismatch[],
+): string {
+  return items
+    .map(
+      (item) => mismatches.find((mismatch) => mismatch.item === item)?.correct ?? item,
+    )
+    .join(",");
+}
+
+export const matcherCaseRule: LintRule = {
+  id: "matcher-case",
+
+  run(ctx: LintContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const group of ctx.groups) {
+      if (group.matcher.kind !== "string") {
+        continue;
+      }
+      if (!isToolNameEvent(ctx.spec, group.event)) {
+        continue;
+      }
+      const matcher = group.matcher.value;
+      if (!isExactListSyntax(ctx.spec, group.event, matcher)) {
+        continue;
+      }
+
+      const items = splitListItems(matcher);
+      const mismatches = findMismatches(ctx.spec.knownTools, items);
+      if (mismatches.length === 0) {
+        continue;
+      }
+
+      const names = mismatches.map((mismatch) => `"${mismatch.item}"`).join(", ");
+      findings.push({
+        file: group.file,
+        line: group.line,
+        ruleId: "matcher-case",
+        message:
+          `Matcher "${matcher}" uses the wrong case for ${names}. Matcher ` +
+          "comparison is case-sensitive, so this never matches.",
+        suggestion: `Use "${correctedMatcher(items, mismatches)}" instead of "${matcher}".`,
+      });
+    }
+    return findings;
+  },
+};

--- a/src/internal/lint/rules/matcherCommaVersion.ts
+++ b/src/internal/lint/rules/matcherCommaVersion.ts
@@ -6,8 +6,9 @@
  */
 
 import { createVersionNotationRule } from "./versionNotationRule.js";
+import type { LintRule } from "../types.js";
 
-export const matcherCommaVersionRule = createVersionNotationRule({
+export const matcherCommaVersionRule: LintRule = createVersionNotationRule({
   ruleId: "matcher-comma-version",
   character: ",",
   matcherSyntaxRuleId: "comma-separated-list",

--- a/src/internal/lint/rules/matcherCommaVersion.ts
+++ b/src/internal/lint/rules/matcherCommaVersion.ts
@@ -1,0 +1,15 @@
+/**
+ * `matcher-comma-version`: a comma-separated-list matcher used with a
+ * detected (or undetermined) Claude Code version that cannot be confirmed
+ * to support `comma-separated-list` (`spec.matcherSyntax.rules[].sinceVersion`
+ * `2.1.191` in the transcribed spec).
+ */
+
+import { createVersionNotationRule } from "./versionNotationRule.js";
+
+export const matcherCommaVersionRule = createVersionNotationRule({
+  ruleId: "matcher-comma-version",
+  character: ",",
+  matcherSyntaxRuleId: "comma-separated-list",
+  notationLabel: "a comma-separated list",
+});

--- a/src/internal/lint/rules/matcherDead.ts
+++ b/src/internal/lint/rules/matcherDead.ts
@@ -14,6 +14,11 @@
  * classified as an unanchored regex is `matcher-unanchored`'s own concern —
  * a regex that matches no known tool at all is a narrower, harder-to-
  * characterize case this rule does not attempt.
+ *
+ * An item starting with `mcp__` is never reported: MCP tool names are
+ * project-specific and, by construction, never appear in `spec.knownTools`,
+ * so treating one as a typo would be a false positive on a perfectly valid
+ * matcher.
  */
 
 import type { Finding, LintContext, LintRule } from "../types.js";
@@ -41,7 +46,9 @@ export const matcherDeadRule: LintRule = {
       }
 
       const items = splitListItems(matcher);
-      const dead = items.filter((item) => !knownToolsLower.has(item.toLowerCase()));
+      const dead = items.filter(
+        (item) => !item.startsWith("mcp__") && !knownToolsLower.has(item.toLowerCase()),
+      );
       if (dead.length === 0) {
         continue;
       }
@@ -52,9 +59,8 @@ export const matcherDeadRule: LintRule = {
         line: group.line,
         ruleId: "matcher-dead",
         message:
-          `Matcher "${matcher}" includes ${names}, which matches none of the ` +
-          `known tools (${ctx.spec.knownTools.join(", ")}). This hook can ` +
-          `never fire for ${dead.length === 1 ? "it" : "these"}.`,
+          `Matcher "${matcher}" includes ${names}, which ${dead.length === 1 ? "is" : "are"} not ` +
+          `one of the tools the loaded spec knows (${ctx.spec.knownTools.join(", ")}).`,
         suggestion: `Check for a typo — did you mean one of: ${ctx.spec.knownTools.join(", ")}?`,
       });
     }

--- a/src/internal/lint/rules/matcherDead.ts
+++ b/src/internal/lint/rules/matcherDead.ts
@@ -1,0 +1,63 @@
+/**
+ * `matcher-dead`: an exact-match list item that matches none of
+ * `spec.knownTools`, most often a spelling mistake.
+ *
+ * @remarks
+ * Compares case-insensitively against `spec.knownTools` so a pure case
+ * mismatch (`"bash"` for `"Bash"`) is left to `matcher-case` — that item
+ * genuinely corresponds to a known tool, just spelled with the wrong case,
+ * which is a different, more specific fix than "this name does not exist at
+ * all". Only an item that matches no known tool even case-insensitively
+ * (`"Basher"`, say) is reported here.
+ *
+ * Scoped to matchers that are syntactically exact-match lists. A matcher
+ * classified as an unanchored regex is `matcher-unanchored`'s own concern —
+ * a regex that matches no known tool at all is a narrower, harder-to-
+ * characterize case this rule does not attempt.
+ */
+
+import type { Finding, LintContext, LintRule } from "../types.js";
+import { isExactListSyntax, isToolNameEvent, splitListItems } from "../shared.js";
+
+export const matcherDeadRule: LintRule = {
+  id: "matcher-dead",
+
+  run(ctx: LintContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    const knownToolsLower = new Set(
+      ctx.spec.knownTools.map((tool) => tool.toLowerCase()),
+    );
+
+    for (const group of ctx.groups) {
+      if (group.matcher.kind !== "string") {
+        continue;
+      }
+      if (!isToolNameEvent(ctx.spec, group.event)) {
+        continue;
+      }
+      const matcher = group.matcher.value;
+      if (!isExactListSyntax(ctx.spec, group.event, matcher)) {
+        continue;
+      }
+
+      const items = splitListItems(matcher);
+      const dead = items.filter((item) => !knownToolsLower.has(item.toLowerCase()));
+      if (dead.length === 0) {
+        continue;
+      }
+
+      const names = dead.map((item) => `"${item}"`).join(", ");
+      findings.push({
+        file: group.file,
+        line: group.line,
+        ruleId: "matcher-dead",
+        message:
+          `Matcher "${matcher}" includes ${names}, which matches none of the ` +
+          `known tools (${ctx.spec.knownTools.join(", ")}). This hook can ` +
+          `never fire for ${dead.length === 1 ? "it" : "these"}.`,
+        suggestion: `Check for a typo — did you mean one of: ${ctx.spec.knownTools.join(", ")}?`,
+      });
+    }
+    return findings;
+  },
+};

--- a/src/internal/lint/rules/matcherHyphenVersion.ts
+++ b/src/internal/lint/rules/matcherHyphenVersion.ts
@@ -1,0 +1,18 @@
+/**
+ * `matcher-hyphen-version`: an exact-list matcher item containing a hyphen,
+ * used with a detected (or undetermined) Claude Code version that cannot be
+ * confirmed to support `hyphen-exact-match`
+ * (`spec.matcherSyntax.rules[].sinceVersion` `2.1.195` in the transcribed
+ * spec) — the notation an MCP tool name such as `mcp__stripe-mcp__create`
+ * relies on for its hyphen to be treated as part of the exact name rather
+ * than rejected.
+ */
+
+import { createVersionNotationRule } from "./versionNotationRule.js";
+
+export const matcherHyphenVersionRule = createVersionNotationRule({
+  ruleId: "matcher-hyphen-version",
+  character: "-",
+  matcherSyntaxRuleId: "hyphen-exact-match",
+  notationLabel: "a hyphen in an exact-match item",
+});

--- a/src/internal/lint/rules/matcherHyphenVersion.ts
+++ b/src/internal/lint/rules/matcherHyphenVersion.ts
@@ -9,8 +9,9 @@
  */
 
 import { createVersionNotationRule } from "./versionNotationRule.js";
+import type { LintRule } from "../types.js";
 
-export const matcherHyphenVersionRule = createVersionNotationRule({
+export const matcherHyphenVersionRule: LintRule = createVersionNotationRule({
   ruleId: "matcher-hyphen-version",
   character: "-",
   matcherSyntaxRuleId: "hyphen-exact-match",

--- a/src/internal/lint/rules/matcherIsArray.ts
+++ b/src/internal/lint/rules/matcherIsArray.ts
@@ -1,0 +1,49 @@
+/**
+ * `matcher-is-array`: a matcher written as a JSON array rather than a
+ * string.
+ *
+ * @remarks
+ * The highest-impact of the five matcher rules: Claude Code's settings
+ * schema rejects an array-valued matcher, and `settings/load.ts`'s own
+ * `loadSourceHooks` proves the consequence
+ * (`tests/settings.test.ts`'s "a matcher written as a JSON array disables
+ * every hook in that settings file" test) — the failure is not scoped to
+ * the one offending hook, it discards every hook the whole settings file
+ * declares. `Finding.message` says so explicitly rather than a generic
+ * "invalid matcher type", because that blast radius is the entire point of
+ * flagging this before it reaches a real Claude Code session.
+ */
+
+import type { Finding, LintContext, LintRule } from "../types.js";
+
+function suggestionFor(items: readonly string[]): string {
+  if (items.length === 0) {
+    return 'Change the matcher to a comma-separated string, e.g. "Edit,Write".';
+  }
+  const joined = items.join(",");
+  return `Change the matcher to the string ${JSON.stringify(joined)} instead of a JSON array.`;
+}
+
+export const matcherIsArrayRule: LintRule = {
+  id: "matcher-is-array",
+
+  run(ctx: LintContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const group of ctx.groups) {
+      if (group.matcher.kind !== "array") {
+        continue;
+      }
+      findings.push({
+        file: group.file,
+        line: group.line,
+        ruleId: "matcher-is-array",
+        message:
+          `The "${group.event}" hook's matcher is a JSON array, not a string. ` +
+          "Claude Code's settings schema rejects this, which disables every " +
+          "hook declared in this entire settings file — not just this one hook.",
+        suggestion: suggestionFor(group.matcher.items),
+      });
+    }
+    return findings;
+  },
+};

--- a/src/internal/lint/rules/matcherUnanchored.ts
+++ b/src/internal/lint/rules/matcherUnanchored.ts
@@ -10,14 +10,21 @@
  * (`matcher/match.ts`'s `testUnanchoredRegex` special-cases it the same
  * way), not a mistake to flag.
  *
- * The "probably meant to target" tool is guessed from the matcher's own
- * literal prefix — the characters before its first regex metacharacter,
- * with a leading `^` anchor stripped first so an already-anchored,
- * single-match pattern (`"^Edit$"`) is never flagged (it matches at most one
- * known tool, which is gated out before the prefix guess is even
- * consulted). When two or more known tools match and the guessed prefix
- * does not equal one of them exactly, every match is reported as
- * unintended — there is no single obvious target to exclude.
+ * The "probably meant to target" tool(s) are guessed two ways. When
+ * `matcher`'s top-level alternation branches (`"Bash"`/`"Edit"` in
+ * `"^(Bash|Edit)$"` or `"(Edit|Write)"`) are all plain literals, every
+ * branch is treated as intended — that is what makes a correctly anchored
+ * alternation such as `"^(Bash|Edit)$"` produce no finding at all (it
+ * matches only its own branches, all of them intended) while an unanchored
+ * one such as `"(Edit|Write)"` still reports only the genuine over-match
+ * (`"NotebookEdit"`), not the two tools it was written for. Otherwise the
+ * guess falls back to the matcher's own literal prefix — the characters
+ * before its first regex metacharacter, with a leading `^` anchor stripped
+ * first so an already-anchored, single-match pattern (`"^Edit$"`) is never
+ * flagged (it matches at most one known tool, which is gated out before the
+ * prefix guess is even consulted). When two or more known tools match and
+ * none of the guessed intended targets equal them exactly, every such match
+ * is reported as unintended — there is no single obvious target to exclude.
  */
 
 import { classifyMatcher } from "../../matcher/index.js";
@@ -31,6 +38,97 @@ function literalPrefix(matcher: string): string {
   const stripped = matcher.startsWith("^") ? matcher.slice(1) : matcher;
   const metaIndex = stripped.search(REGEX_METACHARACTER);
   return metaIndex === -1 ? stripped : stripped.slice(0, metaIndex);
+}
+
+const LITERAL_BRANCH = /^[A-Za-z0-9_\- ]+$/;
+
+/** `body` with one layer of wrapping group parens removed, when `body` is entirely one group. */
+function stripWrappingGroup(body: string): string {
+  if (!body.startsWith("(") || !body.endsWith(")")) {
+    return body;
+  }
+  let depth = 0;
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === undefined) {
+      continue;
+    }
+    if (char === "\\") {
+      i += 1;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0 && i !== body.length - 1) {
+        // The first group closes before the string ends — not a single
+        // wrapping group (e.g. "(Edit)|(Write)").
+        return body;
+      }
+    }
+  }
+  const inner = body.slice(1, -1);
+  return inner.startsWith("?:") ? inner.slice(2) : inner;
+}
+
+/** Split `body` on `|` at nesting depth 0, so a `|` inside a group is not treated as a top-level branch boundary. */
+function splitTopLevel(body: string): readonly string[] {
+  const branches: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === undefined) {
+      continue;
+    }
+    const next = body[i + 1];
+    if (char === "\\" && next !== undefined) {
+      current += char + next;
+      i += 1;
+      continue;
+    }
+    if (char === "(" || char === "[") {
+      depth += 1;
+    } else if (char === ")" || char === "]") {
+      depth -= 1;
+    }
+    if (char === "|" && depth === 0) {
+      branches.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  branches.push(current);
+  return branches;
+}
+
+/**
+ * `matcher`'s top-level alternation branches — `["Bash", "Edit"]` for both
+ * `"^(Bash|Edit)$"` and `"(Edit|Write)"` — when every branch is a plain
+ * literal with no further regex metacharacter. `undefined` when `matcher`
+ * has no top-level `|` at all, or when a branch is not a plain literal, so
+ * the caller falls back to {@link literalPrefix}.
+ */
+function alternationBranches(matcher: string): readonly string[] | undefined {
+  let body = matcher;
+  if (body.startsWith("^")) {
+    body = body.slice(1);
+  }
+  if (body.endsWith("$")) {
+    body = body.slice(0, -1);
+  }
+  body = stripWrappingGroup(body);
+
+  const branches = splitTopLevel(body);
+  if (
+    branches.length <= 1 ||
+    !branches.every((branch) => LITERAL_BRANCH.test(branch))
+  ) {
+    return undefined;
+  }
+  return branches;
 }
 
 /** `new RegExp(matcher).test(tool)`, with `matcher/match.ts`'s own tolerance for `"*"` and an uncompilable pattern. */
@@ -72,13 +170,15 @@ export const matcherUnanchoredRule: LintRule = {
       if (matched.length <= 1) {
         continue;
       }
-      const intended = literalPrefix(matcher);
-      const unintended = matched.filter((tool) => tool !== intended);
+      const branches = alternationBranches(matcher);
+      const intended = branches ?? [literalPrefix(matcher)];
+      const unintended = matched.filter((tool) => !intended.includes(tool));
       if (unintended.length === 0) {
         continue;
       }
 
       const names = unintended.map((tool) => `"${tool}"`).join(", ");
+      const anchoredBody = matcher.replace(/^\^/, "").replace(/\$$/, "");
       findings.push({
         file: group.file,
         line: group.line,
@@ -87,7 +187,7 @@ export const matcherUnanchoredRule: LintRule = {
           `Matcher "${matcher}" is an unanchored regex and also matches ${names}, ` +
           "beyond the tool it was probably meant to target.",
         suggestion:
-          `Anchor the pattern, e.g. "^${matcher.replace(/^\^/, "")}$", or use an ` +
+          `Anchor the pattern, e.g. "^(?:${anchoredBody})$", or use an ` +
           "exact-match list naming only the intended tool(s).",
       });
     }

--- a/src/internal/lint/rules/matcherUnanchored.ts
+++ b/src/internal/lint/rules/matcherUnanchored.ts
@@ -1,0 +1,96 @@
+/**
+ * `matcher-unanchored`: an unanchored regex matcher that over-matches beyond
+ * the tool name it was probably meant to target.
+ *
+ * @remarks
+ * Builds directly on `matcher/classify.ts`'s own `classifyMatcher` — this
+ * issue is the first to build static analysis on top of that classification
+ * rather than a live firing decision. `"*"` is excluded outright: it is
+ * Claude Code's own documented "match everything" wildcard
+ * (`matcher/match.ts`'s `testUnanchoredRegex` special-cases it the same
+ * way), not a mistake to flag.
+ *
+ * The "probably meant to target" tool is guessed from the matcher's own
+ * literal prefix — the characters before its first regex metacharacter,
+ * with a leading `^` anchor stripped first so an already-anchored,
+ * single-match pattern (`"^Edit$"`) is never flagged (it matches at most one
+ * known tool, which is gated out before the prefix guess is even
+ * consulted). When two or more known tools match and the guessed prefix
+ * does not equal one of them exactly, every match is reported as
+ * unintended — there is no single obvious target to exclude.
+ */
+
+import { classifyMatcher } from "../../matcher/index.js";
+import type { Finding, LintContext, LintRule } from "../types.js";
+import { isToolNameEvent } from "../shared.js";
+
+const REGEX_METACHARACTER = /[.*+?^${}()|[\]\\]/;
+
+/** The literal characters before `matcher`'s first regex metacharacter, with a leading `^` anchor stripped. */
+function literalPrefix(matcher: string): string {
+  const stripped = matcher.startsWith("^") ? matcher.slice(1) : matcher;
+  const metaIndex = stripped.search(REGEX_METACHARACTER);
+  return metaIndex === -1 ? stripped : stripped.slice(0, metaIndex);
+}
+
+/** `new RegExp(matcher).test(tool)`, with `matcher/match.ts`'s own tolerance for `"*"` and an uncompilable pattern. */
+function testRegexSafe(matcher: string, tool: string): boolean {
+  if (matcher === "*") {
+    return true;
+  }
+  try {
+    return new RegExp(matcher).test(tool);
+  } catch {
+    return false;
+  }
+}
+
+export const matcherUnanchoredRule: LintRule = {
+  id: "matcher-unanchored",
+
+  run(ctx: LintContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const group of ctx.groups) {
+      if (group.matcher.kind !== "string") {
+        continue;
+      }
+      if (!isToolNameEvent(ctx.spec, group.event)) {
+        continue;
+      }
+      const matcher = group.matcher.value;
+      if (matcher === "*") {
+        continue;
+      }
+      const kind = classifyMatcher(ctx.spec, ctx.versionContext, group.event, matcher);
+      if (kind !== "unanchored-regex") {
+        continue;
+      }
+
+      const matched = ctx.spec.knownTools.filter((tool) =>
+        testRegexSafe(matcher, tool),
+      );
+      if (matched.length <= 1) {
+        continue;
+      }
+      const intended = literalPrefix(matcher);
+      const unintended = matched.filter((tool) => tool !== intended);
+      if (unintended.length === 0) {
+        continue;
+      }
+
+      const names = unintended.map((tool) => `"${tool}"`).join(", ");
+      findings.push({
+        file: group.file,
+        line: group.line,
+        ruleId: "matcher-unanchored",
+        message:
+          `Matcher "${matcher}" is an unanchored regex and also matches ${names}, ` +
+          "beyond the tool it was probably meant to target.",
+        suggestion:
+          `Anchor the pattern, e.g. "^${matcher.replace(/^\^/, "")}$", or use an ` +
+          "exact-match list naming only the intended tool(s).",
+      });
+    }
+    return findings;
+  },
+};

--- a/src/internal/lint/rules/versionNotationRule.ts
+++ b/src/internal/lint/rules/versionNotationRule.ts
@@ -18,10 +18,16 @@
  * rather than being silently omitted, mirroring `#5`'s own version-gating
  * rule that an undetermined version never silently passes — the message
  * says the version could not be determined rather than naming a definite
- * failure, so a reader can tell the two apart.
+ * failure, so a reader can tell the two apart. A known version outside
+ * `spec.claudeCodeRange` degrades the same way — `classify.ts`'s own
+ * `isVersionKnownOutOfRange` treats such a version as unable to confirm
+ * *anything* about the spec it is checked against, not only the notation
+ * rules this module gates, so this mirrors that rather than trusting
+ * `meetsSinceVersion` on a version the loaded spec was never declared to
+ * describe.
  */
 
-import { meetsSinceVersion } from "../../spec/index.js";
+import { isInDeclaredRange, meetsSinceVersion } from "../../spec/index.js";
 import type { VersionContext } from "../../matcher/index.js";
 import type { Finding, LintContext, LintRule } from "../types.js";
 import { isExactListSyntax, isToolNameEvent } from "../shared.js";
@@ -91,8 +97,13 @@ export function createVersionNotationRule(
           continue;
         }
 
+        const isOutOfRange =
+          ctx.versionContext.kind === "known" &&
+          !isInDeclaredRange(ctx.spec, ctx.versionContext.version);
+
         if (
           ctx.versionContext.kind === "known" &&
+          !isOutOfRange &&
           meetsSinceVersion(ctx.versionContext.version, rule.sinceVersion)
         ) {
           // Fully supported on the version this run assumes — nothing to report.
@@ -100,7 +111,7 @@ export function createVersionNotationRule(
         }
 
         const message =
-          ctx.versionContext.kind === "undetermined"
+          ctx.versionContext.kind === "undetermined" || isOutOfRange
             ? `Matcher "${matcher}" uses ${notationLabel}, supported since Claude ` +
               `Code ${rule.sinceVersion}, but the running Claude Code version could ` +
               "not be determined — this notation might not be supported."

--- a/src/internal/lint/rules/versionNotationRule.ts
+++ b/src/internal/lint/rules/versionNotationRule.ts
@@ -1,0 +1,125 @@
+/**
+ * The shared shape behind `matcher-comma-version` and `matcher-hyphen-version`:
+ * a matcher that relies on a version-gated exact-list notation character
+ * (a comma or a hyphen), checked against the Claude Code version this lint
+ * run assumes.
+ *
+ * @remarks
+ * Deliberately independent of `matcher/classify.ts`'s own version-gating —
+ * see `shared.ts`'s doc comment for why `isExactListSyntax` (which this
+ * builds on) does not fold the version gate into its own verdict.
+ *
+ * Mirrors `matcher/classify.ts`'s own `hasUnsatisfiedNotationRule`: both
+ * rules gate the original `"tool-name"` matcher grammar only — see that
+ * module's own remark for why a `"field"`/`"enum"` target's `sinceVersion:
+ * null` matcher domains were never subject to this notation gate at all.
+ *
+ * An undetermined version degrades to an unknown-confidence `Finding`
+ * rather than being silently omitted, mirroring `#5`'s own version-gating
+ * rule that an undetermined version never silently passes — the message
+ * says the version could not be determined rather than naming a definite
+ * failure, so a reader can tell the two apart.
+ */
+
+import { meetsSinceVersion } from "../../spec/index.js";
+import type { VersionContext } from "../../matcher/index.js";
+import type { Finding, LintContext, LintRule } from "../types.js";
+import { isExactListSyntax, isToolNameEvent } from "../shared.js";
+
+/**
+ * Format a `"known"` {@link VersionContext} as `major.minor.patch`.
+ *
+ * @remarks
+ * A small, local duplicate of `report/summary.ts`'s own `formatClaudeVersion`
+ * rather than an import from it: `report/` is the rendering layer built on
+ * top of `lint/`'s own domain types (see `report/lintReport.ts`), and a
+ * dependency the other way around would invert that. Only the `"known"`
+ * branch is needed here — this is only ever called after `ctx.versionContext.kind
+ * === "known"` has already been checked.
+ */
+function formatKnownVersion(
+  version: Extract<VersionContext, { kind: "known" }>,
+): string {
+  const { major, minor, patch } = version.version;
+  return `${String(major)}.${String(minor)}.${String(patch)}`;
+}
+
+interface VersionNotationRuleOptions {
+  /** `matcher-comma-version` or `matcher-hyphen-version`. */
+  readonly ruleId: string;
+
+  /** The character this notation adds to the exact-list grammar (`","` or `"-"`). */
+  readonly character: string;
+
+  /** The `spec.matcherSyntax.rules[].id` this notation is gated by (`"comma-separated-list"` or `"hyphen-exact-match"`). */
+  readonly matcherSyntaxRuleId: string;
+
+  /** How this notation reads in a message, e.g. `"a comma-separated list"`. */
+  readonly notationLabel: string;
+}
+
+/** Build the `LintRule` for one version-gated exact-list notation character. */
+export function createVersionNotationRule(
+  options: VersionNotationRuleOptions,
+): LintRule {
+  const { ruleId, character, matcherSyntaxRuleId, notationLabel } = options;
+
+  return {
+    id: ruleId,
+
+    run(ctx: LintContext): readonly Finding[] {
+      const rule = ctx.spec.matcherSyntax.rules.find(
+        (r) => r.id === matcherSyntaxRuleId,
+      );
+      if (rule === undefined) {
+        return [];
+      }
+
+      const findings: Finding[] = [];
+      for (const group of ctx.groups) {
+        if (group.matcher.kind !== "string") {
+          continue;
+        }
+        if (!isToolNameEvent(ctx.spec, group.event)) {
+          continue;
+        }
+        const matcher = group.matcher.value;
+        if (!matcher.includes(character)) {
+          continue;
+        }
+        if (!isExactListSyntax(ctx.spec, group.event, matcher)) {
+          continue;
+        }
+
+        if (
+          ctx.versionContext.kind === "known" &&
+          meetsSinceVersion(ctx.versionContext.version, rule.sinceVersion)
+        ) {
+          // Fully supported on the version this run assumes — nothing to report.
+          continue;
+        }
+
+        const message =
+          ctx.versionContext.kind === "undetermined"
+            ? `Matcher "${matcher}" uses ${notationLabel}, supported since Claude ` +
+              `Code ${rule.sinceVersion}, but the running Claude Code version could ` +
+              "not be determined — this notation might not be supported."
+            : `Matcher "${matcher}" uses ${notationLabel}, which requires Claude ` +
+              `Code >= ${rule.sinceVersion}, but the detected version is ` +
+              `${formatKnownVersion(ctx.versionContext)}.`;
+
+        findings.push({
+          file: group.file,
+          line: group.line,
+          ruleId,
+          message,
+          suggestion:
+            "Pass --claude-version to confirm the running Claude Code version, or " +
+            `upgrade to >= ${rule.sinceVersion}, or declare one hook per tool instead ` +
+            `of ${notationLabel}.`,
+        });
+      }
+      return findings;
+    },
+  };
+}

--- a/src/internal/lint/shared.ts
+++ b/src/internal/lint/shared.ts
@@ -1,0 +1,53 @@
+/**
+ * Small pieces of matcher-string logic shared by more than one rule.
+ *
+ * @remarks
+ * Static layer: pure — no I/O, no process, no write.
+ *
+ * Deliberately independent of `matcher/classify.ts`'s `classifyMatcher`,
+ * even though it decides a closely related question. `classifyMatcher` folds
+ * a version-gated notation rule (a comma or a hyphen, gated by
+ * `matcherSyntax.rules[].sinceVersion`) into its own "exact-list" verdict:
+ * under an undetermined or too-old version, a matcher that is syntactically
+ * an exact-match list — the very thing `matcher-case` and `matcher-dead`
+ * need to know to do their own job — classifies as `"unknown"` instead. That
+ * degradation is exactly `matcher-comma-version`'s and
+ * `matcher-hyphen-version`'s own concern, not `matcher-case`'s or
+ * `matcher-dead`'s: whether a matcher is *written* as a list of names is a
+ * property of its syntax and content, independent of whether the Claude Code
+ * version running it actually supports every character in that syntax.
+ * {@link isExactListSyntax} answers only the syntax question, so the four
+ * rules that do not care about version stay that way.
+ */
+
+import type { EventName } from "../../types.js";
+import type { Spec } from "../spec/index.js";
+
+/** Whether `event` targets a tool name — the only target kind `spec.knownTools` and the matcher-syntax rules describe. */
+export function isToolNameEvent(spec: Spec, event: EventName): boolean {
+  return spec.events[event]?.matcherTargets.kind === "tool-name";
+}
+
+/**
+ * Whether `matcher` is syntactically a comma/pipe-delimited exact-match
+ * list for `event`, independent of any version gate.
+ */
+export function isExactListSyntax(
+  spec: Spec,
+  event: EventName,
+  matcher: string,
+): boolean {
+  const useNarrowPattern = spec.matcherSyntax.narrowExactMatchEvents.includes(event);
+  const pattern = useNarrowPattern
+    ? spec.matcherSyntax.narrowExactListPattern
+    : spec.matcherSyntax.exactListPattern;
+  return new RegExp(pattern).test(matcher);
+}
+
+/** Split an exact-match list matcher into its trimmed, non-empty items — mirrors `matcher/match.ts`'s own `exactListItems`. */
+export function splitListItems(matcher: string): readonly string[] {
+  return matcher
+    .split(/[,|]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}

--- a/src/internal/lint/types.ts
+++ b/src/internal/lint/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal plumbing types for the lint rule framework.
+ *
+ * @remarks
+ * `Finding`, `LintRule`, `LintContext` and friends are not part of the
+ * published contract: `src/index.ts` re-exports only `src/types.ts`'s
+ * vocabulary, and ESLint's `public-api/internal-stays-private` block forbids
+ * `src/index.ts` from importing anything under `src/internal/` at all, so
+ * nothing declared here can leak into the public surface by accident. They
+ * live next to the modules that use them rather than in `src/types.ts`,
+ * which is reserved for the vocabulary every module speaks — this one is
+ * spoken only by `src/internal/lint/**`.
+ */
+
+import type { EventName, SettingsLayer } from "../../types.js";
+import type { Spec } from "../spec/index.js";
+import type { VersionContext } from "../matcher/index.js";
+
+/**
+ * One lint violation, ready to render.
+ *
+ * @remarks
+ * `file`, `line`, `ruleId`, and `suggestion` are all required — never
+ * optional — a hard acceptance criterion of the issue this type was built
+ * for: a `Finding` a reader cannot locate (`file`/`line`), cannot attribute
+ * to a rule (`ruleId`), or that offers no concrete fix (`suggestion`) is not
+ * useful enough to be worth reporting at all.
+ */
+export interface Finding {
+  /** Absolute path of the settings file the finding is about. */
+  readonly file: string;
+
+  /** 1-based line the finding points at. */
+  readonly line: number;
+
+  /** The `LintRule.id` that produced this finding. */
+  readonly ruleId: string;
+
+  /** Human-readable explanation of what is wrong. */
+  readonly message: string;
+
+  /**
+   * A concrete fix: the corrected matcher string or config change for this
+   * specific finding, not a restatement of `message`.
+   */
+  readonly suggestion: string;
+}
+
+/** One matcher declaration a `LintRule` can inspect. */
+export type LintMatcherValue =
+  | { readonly kind: "absent" }
+  | { readonly kind: "string"; readonly value: string }
+  | { readonly kind: "array"; readonly items: readonly string[] };
+
+/**
+ * One `hooks.<event>[]` matcher group, read tolerantly from a settings file.
+ *
+ * @remarks
+ * Unlike `settings/load.ts`'s `loadSourceHooks`, reading this never throws
+ * because a `matcher` is a JSON array rather than a string — that is exactly
+ * the shape `matcher-is-array` exists to report as a `Finding` instead of a
+ * thrown `SettingsParseError`. See `parse.ts`'s own remarks for why the
+ * strict loader cannot be reused for this.
+ */
+export interface LintMatcherGroup {
+  /** Absolute path of the settings file this group was declared in. */
+  readonly file: string;
+
+  /** Which merged layer {@link LintMatcherGroup.file} belongs to. */
+  readonly layer: SettingsLayer;
+
+  /** The event this matcher group is declared under. */
+  readonly event: EventName;
+
+  /** 1-based line of this group's `matcher` property, or the group itself when no `matcher` is declared. */
+  readonly line: number;
+
+  /** This group's own `matcher` value, read tolerantly. */
+  readonly matcher: LintMatcherValue;
+}
+
+/** What a `LintRule` reads from, to run over every settings source `lint` discovered. */
+export interface LintContext {
+  /** The loaded hooks spec every rule classifies matchers against. */
+  readonly spec: Spec;
+
+  /** The Claude Code version this lint run assumes, or the fact that none could be determined. */
+  readonly versionContext: VersionContext;
+
+  /** Every matcher group read from every settings source, across every layer. */
+  readonly groups: readonly LintMatcherGroup[];
+}
+
+/**
+ * One static check over a `LintContext`.
+ *
+ * @remarks
+ * `run` never spawns a process and never writes a file — `lint` is a
+ * zero-execution static check, structurally guaranteed by `#2`'s ESLint
+ * zone (`src/internal/lint/**` cannot import `exec/`/`record/`), not merely
+ * by convention.
+ */
+export interface LintRule {
+  /** Stable id, unchanged across non-breaking releases — the value `Finding.ruleId` carries for every finding this rule produces. */
+  readonly id: string;
+
+  /** Run this rule over `ctx`, returning every finding — an empty array when there is nothing to report. */
+  run(ctx: LintContext): readonly Finding[];
+}

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -28,5 +28,10 @@ export {
   toJsonTestReport,
 } from "./testReport.js";
 export type { JsonTestReport, TestCaseReport, TestReport } from "./testReport.js";
-export { renderLintPretty } from "./lintReport.js";
-export type { LintReport } from "./lintReport.js";
+export {
+  renderLintGithub,
+  renderLintJson,
+  renderLintPretty,
+  toJsonLintReport,
+} from "./lintReport.js";
+export type { JsonLintReport, LintReport } from "./lintReport.js";

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -28,3 +28,5 @@ export {
   toJsonTestReport,
 } from "./testReport.js";
 export type { JsonTestReport, TestCaseReport, TestReport } from "./testReport.js";
+export { renderLintPretty } from "./lintReport.js";
+export type { LintReport } from "./lintReport.js";

--- a/src/internal/report/lintReport.ts
+++ b/src/internal/report/lintReport.ts
@@ -1,19 +1,17 @@
 /**
- * The result shape `lint` renders, and its `pretty` renderer.
+ * The result shape `lint` renders, and its `pretty`/`json`/`github`
+ * renderers.
  *
  * @remarks
  * Static layer: pure string formatting — no I/O, no process, no write.
- * Mirrors `summary.ts`'s `ExplainReport`/`pretty.ts` split for `explain`,
- * but for `lint`'s own `Finding[]` (`src/internal/lint/`) rather than a
- * `MatchResult`.
- *
- * `json`/`github` rendering for a `LintReport` is out of scope for the issue
- * that added this module — see that issue's own "Not in scope" section —
- * and is left to a later issue, which reuses `ReportFinding`
- * (`report/github.ts`) to map a `Finding` onto a GitHub Actions annotation.
+ * Mirrors `summary.ts`'s `ExplainReport`/`pretty.ts`/`json.ts`/`github.ts`
+ * split for `explain`, and `testReport.ts`'s own three-renderer split for
+ * `test`, but for `lint`'s own `Finding[]` (`src/internal/lint/`) rather
+ * than a `MatchResult` or a `CaseResult[]`.
  */
 
 import type { Finding } from "../lint/index.js";
+import { renderGithubFinding, renderGithubHeader } from "./github.js";
 import type { ReportHeader } from "./summary.js";
 
 /** The full result `lint` renders. */
@@ -46,6 +44,97 @@ export function renderLintPretty(report: LintReport): string {
       );
       lines.push(`    suggestion: ${finding.suggestion}`);
     }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+/** JSON shape of one {@link Finding}, mirroring the domain type field for field. */
+interface JsonLintFinding {
+  readonly file: string;
+  readonly line: number;
+  readonly ruleId: string;
+  readonly message: string;
+  readonly suggestion: string;
+}
+
+/**
+ * The shape `renderLintJson` emits.
+ *
+ * @remarks
+ * `reportVersion` is versioned independently of `explain`'s own
+ * `JsonExplainReport` (`report/json.ts`) and `test`'s own `JsonTestReport`
+ * (`testReport.ts`) — each currently claims `reportVersion: "1"` for its
+ * own, different shape. `reportType` disambiguates the three: unlike
+ * `explain`'s `JsonExplainReport`, this shape has no `schema/*.schema.json`
+ * of its own yet — a later issue that wants schema-checked `lint` JSON adds
+ * one against this documented shape rather than reshaping it silently.
+ */
+export interface JsonLintReport {
+  readonly reportVersion: "1";
+  readonly reportType: "lint";
+  readonly header: {
+    readonly claudeVersion: string;
+    readonly specRange: string;
+    readonly notices: readonly string[];
+  };
+  readonly findings: readonly JsonLintFinding[];
+}
+
+/** Build the JSON-serializable shape {@link renderLintJson} stringifies. */
+export function toJsonLintReport(report: LintReport): JsonLintReport {
+  return {
+    reportVersion: "1",
+    reportType: "lint",
+    header: {
+      claudeVersion: report.header.claudeVersion,
+      specRange: report.header.specRange,
+      notices: report.header.notices,
+    },
+    findings: report.findings.map((finding) => ({
+      file: finding.file,
+      line: finding.line,
+      ruleId: finding.ruleId,
+      message: finding.message,
+      suggestion: finding.suggestion,
+    })),
+  };
+}
+
+/** Render a {@link LintReport} as JSON. */
+export function renderLintJson(report: LintReport): string {
+  return `${JSON.stringify(toJsonLintReport(report), null, 2)}\n`;
+}
+
+/**
+ * Render a {@link LintReport} as GitHub Actions workflow commands: the
+ * leading header line, then one `::error` per finding.
+ *
+ * @remarks
+ * Maps each `Finding` onto `report/github.ts`'s own decoupled
+ * `ReportFinding` shape — `ruleId` becomes the annotation's `title`, and
+ * `suggestion` is folded into the message body rather than dropped, since a
+ * GitHub Actions annotation carries no separate "suggestion" field of its
+ * own. `workspaceRoot` is threaded through exactly as `renderTestGithub`
+ * threads it for `test`, so a `Finding.file` (always absolute — see
+ * `lint/parse.ts`) renders relative to the repository checkout the same way
+ * `explain`/`test`'s own github output does.
+ */
+export function renderLintGithub(report: LintReport, workspaceRoot: string): string {
+  const lines: string[] = [renderGithubHeader(report.header)];
+
+  for (const finding of report.findings) {
+    lines.push(
+      renderGithubFinding(
+        {
+          file: finding.file,
+          line: finding.line,
+          title: finding.ruleId,
+          message: `${finding.message} Suggestion: ${finding.suggestion}`,
+        },
+        workspaceRoot,
+      ),
+    );
   }
 
   return `${lines.join("\n")}\n`;

--- a/src/internal/report/lintReport.ts
+++ b/src/internal/report/lintReport.ts
@@ -1,0 +1,52 @@
+/**
+ * The result shape `lint` renders, and its `pretty` renderer.
+ *
+ * @remarks
+ * Static layer: pure string formatting — no I/O, no process, no write.
+ * Mirrors `summary.ts`'s `ExplainReport`/`pretty.ts` split for `explain`,
+ * but for `lint`'s own `Finding[]` (`src/internal/lint/`) rather than a
+ * `MatchResult`.
+ *
+ * `json`/`github` rendering for a `LintReport` is out of scope for the issue
+ * that added this module — see that issue's own "Not in scope" section —
+ * and is left to a later issue, which reuses `ReportFinding`
+ * (`report/github.ts`) to map a `Finding` onto a GitHub Actions annotation.
+ */
+
+import type { Finding } from "../lint/index.js";
+import type { ReportHeader } from "./summary.js";
+
+/** The full result `lint` renders. */
+export interface LintReport {
+  /** Printed first by every reporter format. */
+  readonly header: ReportHeader;
+
+  /** Every finding from every registered rule, in `LINT_RULES` order. */
+  readonly findings: readonly Finding[];
+}
+
+/** Render a {@link LintReport} for a terminal. */
+export function renderLintPretty(report: LintReport): string {
+  const lines: string[] = [];
+
+  lines.push(`Claude Code version: ${report.header.claudeVersion}`);
+  lines.push(`Spec range: ${report.header.specRange}`);
+  for (const notice of report.header.notices) {
+    lines.push(`Notice: ${notice}`);
+  }
+
+  lines.push("");
+  if (report.findings.length === 0) {
+    lines.push("Findings: none");
+  } else {
+    lines.push(`Findings (${String(report.findings.length)}):`);
+    for (const finding of report.findings) {
+      lines.push(
+        `  [${finding.ruleId}] ${finding.file}:${String(finding.line)} — ${finding.message}`,
+      );
+      lines.push(`    suggestion: ${finding.suggestion}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -30,6 +30,7 @@ const NO_SUCH_DIR = path.join(FIXTURES_DIR, "no-such-directory");
 const LINT_VIOLATING_FIXTURE = fileURLToPath(
   new URL("./fixtures/lint/matcher-is-array/violating.json", import.meta.url),
 );
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 /** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
 const SPEC_RANGE = ">=2.1.251 <2.2.0";
@@ -550,18 +551,71 @@ describe("runCli lint", () => {
     expect(result.stderr).toContain("ERR_SETTINGS_NOT_FOUND");
   });
 
-  it.each(["json", "github"])(
-    "rejects --format %s as not implemented yet",
-    async (format) => {
-      const result = await runCli(
-        ["lint", "--format", format],
-        "hookassert",
-        explainDeps(),
-      );
+  it.each(["json", "github"])("selects the %s reporter", async (format) => {
+    const result = await runCli(
+      ["lint", "--format", format],
+      "hookassert",
+      explainDeps(),
+    );
 
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr).toContain("ERR_USAGE");
-      expect(result.stderr).toContain(format);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("--format json carries every finding field for a settings file with a violation", async () => {
+    const result = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE, "--format", "json"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout) as {
+      readonly reportType: string;
+      readonly findings: readonly {
+        readonly file: string;
+        readonly line: number;
+        readonly ruleId: string;
+        readonly message: string;
+        readonly suggestion: string;
+      }[];
+    };
+    expect(parsed.reportType).toBe("lint");
+    const finding = parsed.findings.find((f) => f.ruleId === "matcher-is-array");
+    expect(finding?.file).toBe(LINT_VIOLATING_FIXTURE);
+    expect(finding?.line).toBe(5);
+    expect(finding?.message.length).toBeGreaterThan(0);
+    expect(finding?.suggestion.length).toBeGreaterThan(0);
+  });
+
+  it("--format github emits one ::error line per finding with a repository-relative path", async () => {
+    const result = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE, "--format", "github"],
+      "hookassert",
+      explainDeps({ cwd: REPO_ROOT }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(
+      "::error file=tests/fixtures/lint/matcher-is-array/violating.json,line=5," +
+        "title=matcher-is-array::",
+    );
+    // The relative path form only — the absolute fixture path must not leak
+    // into a github annotation meant to attach to a line in the PR diff.
+    expect(result.stdout).not.toContain(LINT_VIOLATING_FIXTURE);
+  });
+
+  it.each(["json", "github"])(
+    "--format %s performs exactly zero spawns even when findings are reported",
+    async (format) => {
+      const spawner = new CountingSpawner();
+      const result = await runCli(
+        ["lint", "--settings", LINT_VIOLATING_FIXTURE, "--format", format],
+        "hookassert",
+        explainDeps({ spawner }),
+      );
+      expect(result.exitCode).toBe(1);
+      expect(spawner.calls).toHaveLength(0);
     },
   );
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,6 +27,9 @@ const EXPLICIT_SETTINGS_FILE = path.join(FIXTURES_DIR, "explicit-settings.json")
 // Never created on disk: loadSourceHooks treats a missing settings file as
 // contributing zero hooks, so this is how a test opts a layer out entirely.
 const NO_SUCH_DIR = path.join(FIXTURES_DIR, "no-such-directory");
+const LINT_VIOLATING_FIXTURE = fileURLToPath(
+  new URL("./fixtures/lint/matcher-is-array/violating.json", import.meta.url),
+);
 
 /** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
 const SPEC_RANGE = ">=2.1.251 <2.2.0";
@@ -63,8 +66,8 @@ function explainDefaultSpecPath(): string {
 /** The commands hookassert will ship, in the order the usage text lists them. */
 const SUBCOMMANDS = ["explain", "lint", "record", "test"] as const;
 
-/** The commands with no behavior yet — `explain` and `test` are both real now. */
-const STUB_SUBCOMMANDS = ["lint", "record"] as const;
+/** The commands with no behavior yet — `explain`, `lint`, and `test` are all real now. */
+const STUB_SUBCOMMANDS = ["record"] as const;
 
 /** The `ERR_` shape AGENTS.md fixes for every published error code. */
 const ERROR_CODE = /^ERR_[A-Z0-9_]+$/;
@@ -462,6 +465,145 @@ describe("runCli explain", () => {
         explainDeps(),
       ),
     ).rejects.toThrow(/EISDIR/);
+  });
+});
+
+describe("runCli lint", () => {
+  it("wires settings + spec + rules and exits 0 with zero findings for a clean project", async () => {
+    const result = await runCli(["lint"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Findings: none");
+  });
+
+  it("exits 1 and reports a Finding for a settings file with a lint violation", async () => {
+    const result = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("matcher-is-array");
+    expect(result.stdout).toContain(LINT_VIOLATING_FIXTURE);
+  });
+
+  it("always prints the spec's declared claudeCodeRange", async () => {
+    const result = await runCli(["lint"], "hookassert", explainDeps());
+
+    expect(result.stdout).toContain(`Spec range: ${SPEC_RANGE}`);
+  });
+
+  it("prints 'undetermined' when no Claude Code version can be resolved", async () => {
+    const result = await runCli(["lint"], "hookassert", explainDeps());
+
+    expect(result.stdout).toContain("Claude Code version: undetermined");
+  });
+
+  it("resolves --claude-version the same way explain does", async () => {
+    const result = await runCli(
+      ["lint", "--claude-version", "2.1.300"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.stdout).toContain("Claude Code version: 2.1.300");
+  });
+
+  it("exits 4 with ERR_USAGE when lint is given an unrecognized option", async () => {
+    const result = await runCli(["lint", "--bogus"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ERR_USAGE");
+  });
+
+  it("exits 4 with ERR_USAGE on a positional argument", async () => {
+    const result = await runCli(["lint", "stray"], "hookassert", explainDeps());
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+    expect(result.stderr).toContain("stray");
+  });
+
+  it("exits 4 with ERR_USAGE when --claude-version is not major.minor.patch", async () => {
+    const result = await runCli(
+      ["lint", "--claude-version", "not-a-version"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+  });
+
+  it("exits 5 with ERR_SETTINGS_NOT_FOUND when an explicit --settings file does not exist", async () => {
+    const missing = path.join(FIXTURES_DIR, "no-such-settings-file.json");
+    const result = await runCli(
+      ["lint", "--settings", missing],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain("ERR_SETTINGS_NOT_FOUND");
+  });
+
+  it.each(["json", "github"])(
+    "rejects --format %s as not implemented yet",
+    async (format) => {
+      const result = await runCli(
+        ["lint", "--format", format],
+        "hookassert",
+        explainDeps(),
+      );
+
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr).toContain("ERR_USAGE");
+      expect(result.stderr).toContain(format);
+    },
+  );
+
+  it("accepts --format pretty explicitly", async () => {
+    const result = await runCli(
+      ["lint", "--format", "pretty"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 4 with ERR_USAGE on an unrecognized --format", async () => {
+    const result = await runCli(
+      ["lint", "--format", "yaml"],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("ERR_USAGE");
+  });
+
+  it("performs exactly zero spawns", async () => {
+    const spawner = new CountingSpawner();
+    const result = await runCli(["lint"], "hookassert", explainDeps({ spawner }));
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+  });
+
+  it("performs exactly zero spawns even when findings are reported", async () => {
+    const spawner = new CountingSpawner();
+    const result = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE],
+      "hookassert",
+      explainDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(spawner.calls).toHaveLength(0);
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -490,6 +490,31 @@ describe("runCli lint", () => {
     expect(result.stdout).toContain(LINT_VIOLATING_FIXTURE);
   });
 
+  it("accepts --ci and behaves identically to a plain run", async () => {
+    const plain = await runCli(["lint"], "hookassert", explainDeps());
+    const withCi = await runCli(["lint", "--ci"], "hookassert", explainDeps());
+
+    expect(withCi.exitCode).toBe(plain.exitCode);
+    expect(withCi.stdout).toBe(plain.stdout);
+    expect(withCi.stderr).toBe(plain.stderr);
+  });
+
+  it("accepts --ci alongside a violation the same way a plain run does", async () => {
+    const plain = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE],
+      "hookassert",
+      explainDeps(),
+    );
+    const withCi = await runCli(
+      ["lint", "--ci", "--settings", LINT_VIOLATING_FIXTURE],
+      "hookassert",
+      explainDeps(),
+    );
+
+    expect(withCi.exitCode).toBe(plain.exitCode);
+    expect(withCi.stdout).toBe(plain.stdout);
+  });
+
   it("always prints the spec's declared claudeCodeRange", async () => {
     const result = await runCli(["lint"], "hookassert", explainDeps());
 

--- a/tests/fixtures/lint/matcher-case/clean.json
+++ b/tests/fixtures/lint/matcher-case/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-case/violating.json
+++ b/tests/fixtures/lint/matcher-case/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-comma-version/clean.json
+++ b/tests/fixtures/lint/matcher-comma-version/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-comma-version/violating.json
+++ b/tests/fixtures/lint/matcher-comma-version/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash,Edit",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-dead/clean.json
+++ b/tests/fixtures/lint/matcher-dead/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-dead/violating.json
+++ b/tests/fixtures/lint/matcher-dead/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Basher",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-hyphen-version/clean.json
+++ b/tests/fixtures/lint/matcher-hyphen-version/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-hyphen-version/violating.json
+++ b/tests/fixtures/lint/matcher-hyphen-version/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__stripe-mcp__create_payment",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-is-array/clean.json
+++ b/tests/fixtures/lint/matcher-is-array/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit,Write",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-is-array/violating.json
+++ b/tests/fixtures/lint/matcher-is-array/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ["Edit", "Write"],
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-unanchored/clean.json
+++ b/tests/fixtures/lint/matcher-unanchored/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Edit$",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-unanchored/violating.json
+++ b/tests/fixtures/lint/matcher-unanchored/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit.*",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1,0 +1,313 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SettingsParseError } from "../src/internal/errors.js";
+import {
+  buildLintContext,
+  LINT_RULES,
+  readMatcherGroups,
+} from "../src/internal/lint/index.js";
+import type { LintContext, LintRule } from "../src/internal/lint/index.js";
+import type { VersionContext } from "../src/internal/matcher/index.js";
+import type { SettingsSource } from "../src/internal/settings/index.js";
+import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
+import type { Spec } from "../src/internal/spec/index.js";
+
+// Reaching src/internal/lint/, src/internal/spec/, src/internal/matcher/,
+// and src/internal/settings/ directly (rather than through src/index.ts's
+// exports, per the writing-tests skill) is a deliberate, narrowly scoped
+// exception: none of these modules has a public surface in this issue and
+// never will one for their own plumbing types — see eslint.config.mjs's
+// "tests/static-layer-unit-tests" block for the full reasoning.
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
+const REAL_SPEC: Spec = loadSpecFile(REAL_SPEC_PATH);
+
+const LINT_FIXTURES_DIR = fileURLToPath(new URL("./fixtures/lint/", import.meta.url));
+const SETTINGS_FIXTURES_DIR = fileURLToPath(
+  new URL("./fixtures/settings/", import.meta.url),
+);
+
+const UNDETERMINED: VersionContext = { kind: "undetermined" };
+
+/** A version below both `comma-separated-list`'s and `hyphen-exact-match`'s own `sinceVersion`. */
+const OLD_VERSION: VersionContext = {
+  kind: "known",
+  version: parseClaudeVersion("2.1.100"),
+};
+
+/** Exactly `comma-separated-list`'s own `sinceVersion` (`2.1.191`) — the boundary is inclusive. */
+const COMMA_SATISFIED_VERSION: VersionContext = {
+  kind: "known",
+  version: parseClaudeVersion("2.1.191"),
+};
+
+/** Exactly `hyphen-exact-match`'s own `sinceVersion` (`2.1.195`) — the boundary is inclusive. */
+const HYPHEN_SATISFIED_VERSION: VersionContext = {
+  kind: "known",
+  version: parseClaudeVersion("2.1.195"),
+};
+
+function ruleFixtureSource(
+  ruleId: string,
+  file: "violating.json" | "clean.json",
+): SettingsSource {
+  return { path: path.join(LINT_FIXTURES_DIR, ruleId, file), layer: "project" };
+}
+
+function settingsFixtureSource(caseDir: string, file: string): SettingsSource {
+  return { path: path.join(SETTINGS_FIXTURES_DIR, caseDir, file), layer: "project" };
+}
+
+function contextFor(
+  source: SettingsSource,
+  versionContext: VersionContext = UNDETERMINED,
+): LintContext {
+  return buildLintContext([source], REAL_SPEC, versionContext);
+}
+
+function ruleById(id: string): LintRule {
+  const rule = LINT_RULES.find((candidate) => candidate.id === id);
+  if (rule === undefined) {
+    throw new Error(`no LintRule is registered with id ${JSON.stringify(id)}`);
+  }
+  return rule;
+}
+
+/** The five matcher rules this issue ships, in `LINT_RULES`'s own order. */
+const RULE_IDS = [
+  "matcher-is-array",
+  "matcher-case",
+  "matcher-comma-version",
+  "matcher-hyphen-version",
+  "matcher-dead",
+  "matcher-unanchored",
+] as const;
+
+describe("LINT_RULES: the registry", () => {
+  it("registers exactly the five matcher rules this issue ships", () => {
+    expect(LINT_RULES.map((rule) => rule.id)).toEqual(RULE_IDS);
+  });
+});
+
+describe("every matcher rule", () => {
+  it.each(RULE_IDS)(
+    "%s reports a Finding with file/line/ruleId/suggestion all set for its violating fixture",
+    (ruleId) => {
+      const source = ruleFixtureSource(ruleId, "violating.json");
+      const findings = ruleById(ruleId).run(contextFor(source));
+
+      expect(findings.length).toBeGreaterThan(0);
+      for (const finding of findings) {
+        expect(finding.ruleId).toBe(ruleId);
+        expect(finding.file).toBe(source.path);
+        expect(finding.line).toBeGreaterThan(0);
+        expect(finding.message.length).toBeGreaterThan(0);
+        // The suggestion must be a concrete fix, not a restatement of the
+        // message — see the issue's own "Trap" note. Checked precisely by
+        // each rule's own dedicated test below; this is the floor every
+        // rule must clear.
+        expect(finding.suggestion.length).toBeGreaterThan(0);
+        expect(finding.suggestion).not.toBe(finding.message);
+      }
+    },
+  );
+
+  it.each(RULE_IDS)("%s reports zero findings for its clean fixture", (ruleId) => {
+    const source = ruleFixtureSource(ruleId, "clean.json");
+    expect(ruleById(ruleId).run(contextFor(source))).toEqual([]);
+  });
+});
+
+describe("matcher-is-array", () => {
+  const rule = ruleById("matcher-is-array");
+
+  it("states that the ENTIRE file's hooks are disabled, not just the one hook", () => {
+    const source = ruleFixtureSource("matcher-is-array", "violating.json");
+    const [finding] = rule.run(contextFor(source));
+
+    expect(finding?.message).toContain("entire settings file");
+    expect(finding?.message).not.toBe("invalid matcher type");
+  });
+
+  it("names the concrete corrected matcher string in its suggestion", () => {
+    const source = ruleFixtureSource("matcher-is-array", "violating.json");
+    const [finding] = rule.run(contextFor(source));
+
+    // The violating fixture declares `"matcher": ["Edit", "Write"]`.
+    expect(finding?.suggestion).toContain('"Edit,Write"');
+  });
+
+  it("does not throw for a matcher declared as a JSON array, unlike settings/load.ts's strict loader", () => {
+    // tests/settings.test.ts's "a matcher written as a JSON array disables
+    // every hook in that settings file" proves loadSettings throws
+    // SettingsParseError for exactly this shape — that is right for
+    // explain/test, but would make matcher-is-array's own Finding
+    // unreachable. readMatcherGroups is the tolerant reader this rule
+    // actually runs over.
+    const source = ruleFixtureSource("matcher-is-array", "violating.json");
+    const groups = readMatcherGroups(source);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.matcher).toEqual({ kind: "array", items: ["Edit", "Write"] });
+  });
+});
+
+describe("matcher-case", () => {
+  it("names the correctly-cased matcher string in its suggestion", () => {
+    const source = ruleFixtureSource("matcher-case", "violating.json");
+    const [finding] = ruleById("matcher-case").run(contextFor(source));
+
+    // The violating fixture declares `"matcher": "bash"`.
+    expect(finding?.suggestion).toContain('"Bash"');
+  });
+});
+
+describe("matcher-dead", () => {
+  it("names the actual typo'd matcher item in its message", () => {
+    const source = ruleFixtureSource("matcher-dead", "violating.json");
+    const [finding] = ruleById("matcher-dead").run(contextFor(source));
+
+    expect(finding?.message).toContain('"Basher"');
+  });
+});
+
+describe("matcher-unanchored", () => {
+  const rule = ruleById("matcher-unanchored");
+
+  it("enumerates the specific unintendedly-matched tool names for Edit.* matching NotebookEdit", () => {
+    const source = ruleFixtureSource("matcher-unanchored", "violating.json");
+    const [finding] = rule.run(contextFor(source));
+
+    expect(finding?.message).toContain("NotebookEdit");
+    // "Edit" is the intended target the matcher was written for; only the
+    // unintended extra match belongs in the finding.
+    expect(finding?.message).not.toContain('"Edit"');
+  });
+
+  it("does not flag an already-anchored pattern that matches only one known tool", () => {
+    const source = ruleFixtureSource("matcher-unanchored", "clean.json");
+    expect(rule.run(contextFor(source))).toEqual([]);
+  });
+
+  it("never flags the documented '*' catch-all wildcard", () => {
+    const source: SettingsSource = {
+      path: path.join(LINT_FIXTURES_DIR, "matcher-unanchored", "violating.json"),
+      layer: "project",
+    };
+    // Same event/target as the violating fixture, but with the literal
+    // wildcard matcher instead of "Edit.*".
+    const ctx: LintContext = {
+      spec: REAL_SPEC,
+      versionContext: UNDETERMINED,
+      groups: [
+        {
+          file: source.path,
+          layer: "project",
+          event: "PreToolUse",
+          line: 1,
+          matcher: { kind: "string", value: "*" },
+        },
+      ],
+    };
+    expect(rule.run(ctx)).toEqual([]);
+  });
+});
+
+describe.each([
+  {
+    ruleId: "matcher-comma-version",
+    notation: "comma-separated-list",
+    sinceVersion: "2.1.191",
+    satisfiedVersion: COMMA_SATISFIED_VERSION,
+  },
+  {
+    ruleId: "matcher-hyphen-version",
+    notation: "hyphen-exact-match",
+    sinceVersion: "2.1.195",
+    satisfiedVersion: HYPHEN_SATISFIED_VERSION,
+  },
+])("$ruleId", ({ ruleId, sinceVersion, satisfiedVersion }) => {
+  const rule = ruleById(ruleId);
+  const source = ruleFixtureSource(ruleId, "violating.json");
+
+  it("emits no finding when the known version satisfies the notation rule's sinceVersion", () => {
+    expect(rule.run(contextFor(source, satisfiedVersion))).toEqual([]);
+  });
+
+  it("emits a finding naming the required and detected versions when the known version is older", () => {
+    const [finding] = rule.run(contextFor(source, OLD_VERSION));
+
+    expect(finding?.message).toContain(sinceVersion);
+    expect(finding?.message).toContain("2.1.100");
+  });
+
+  it("degrades to an unknown-confidence finding — rather than omitting it — when the version is undetermined", () => {
+    const [finding] = rule.run(contextFor(source, UNDETERMINED));
+
+    expect(finding).toBeDefined();
+    expect(finding?.message).toContain("could not be determined");
+  });
+
+  it("produces a message distinguishable from the definite-failure case", () => {
+    const [undeterminedFinding] = rule.run(contextFor(source, UNDETERMINED));
+    const [oldVersionFinding] = rule.run(contextFor(source, OLD_VERSION));
+
+    expect(undeterminedFinding?.message).not.toBe(oldVersionFinding?.message);
+  });
+});
+
+describe("readMatcherGroups: the tolerant reader's own structural strictness", () => {
+  it("still throws SettingsParseError for a non-string, non-array matcher", () => {
+    // tests/fixtures/settings/structural-errors/matcher-not-string.json
+    // declares `"matcher": 5` — matcher-is-array's own tolerance is scoped
+    // to exactly "absent | string | array", not every non-string shape.
+    const source = settingsFixtureSource(
+      "structural-errors",
+      "matcher-not-string.json",
+    );
+
+    let caught: unknown;
+    try {
+      readMatcherGroups(source);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SettingsParseError);
+  });
+
+  it("still throws SettingsParseError for a root that is not an object", () => {
+    const source = settingsFixtureSource("structural-errors", "root-not-object.json");
+    expect(() => readMatcherGroups(source)).toThrow(SettingsParseError);
+  });
+
+  it("still throws SettingsParseError for unparsable JSONC", () => {
+    const source = settingsFixtureSource("malformed-jsonc", "project.json");
+    expect(() => readMatcherGroups(source)).toThrow(SettingsParseError);
+  });
+
+  it("returns zero groups for a settings file that does not exist", () => {
+    const source: SettingsSource = {
+      path: path.join(SETTINGS_FIXTURES_DIR, "no-such-directory", "project.json"),
+      layer: "project",
+    };
+    expect(readMatcherGroups(source)).toEqual([]);
+  });
+});
+
+describe("buildLintContext", () => {
+  it("flattens groups across every settings source given", () => {
+    const ctx = buildLintContext(
+      [
+        ruleFixtureSource("matcher-case", "violating.json"),
+        ruleFixtureSource("matcher-dead", "violating.json"),
+      ],
+      REAL_SPEC,
+      UNDETERMINED,
+    );
+    expect(ctx.groups).toHaveLength(2);
+  });
+});

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -33,6 +33,18 @@ const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const REAL_SPEC: Spec = loadSpecFile(REAL_SPEC_PATH);
 
+/**
+ * The real spec's own `claudeCodeRange` (`">=2.1.251 <2.2.0"`) starts past
+ * both notation rules' `sinceVersion` (`2.1.191`, `2.1.195`), so a version
+ * below either — as `OLD_VERSION`, `COMMA_SATISFIED_VERSION` and
+ * `HYPHEN_SATISFIED_VERSION` below all are — is also outside the real
+ * spec's declared range. Widening the range here isolates the
+ * `sinceVersion` boundary these versions exist to test from the separate
+ * `spec.claudeCodeRange` check `OUT_OF_RANGE_VERSION` exists to test —
+ * mirrors `tests/matcher.test.ts`'s own `widenedSpec`.
+ */
+const WIDENED_RANGE_SPEC: Spec = { ...REAL_SPEC, claudeCodeRange: ">=2.1.0 <2.2.0" };
+
 const LINT_FIXTURES_DIR = fileURLToPath(new URL("./fixtures/lint/", import.meta.url));
 const SETTINGS_FIXTURES_DIR = fileURLToPath(
   new URL("./fixtures/settings/", import.meta.url),
@@ -58,6 +70,16 @@ const HYPHEN_SATISFIED_VERSION: VersionContext = {
   version: parseClaudeVersion("2.1.195"),
 };
 
+/**
+ * Known, and above both notation rules' own `sinceVersion`, but outside
+ * `REAL_SPEC.claudeCodeRange` (`">=2.1.251 <2.2.0"`) — the loaded spec
+ * cannot vouch for a version this far from what it describes.
+ */
+const OUT_OF_RANGE_VERSION: VersionContext = {
+  kind: "known",
+  version: parseClaudeVersion("3.0.0"),
+};
+
 function ruleFixtureSource(
   ruleId: string,
   file: "violating.json" | "clean.json",
@@ -72,8 +94,9 @@ function settingsFixtureSource(caseDir: string, file: string): SettingsSource {
 function contextFor(
   source: SettingsSource,
   versionContext: VersionContext = UNDETERMINED,
+  spec: Spec = REAL_SPEC,
 ): LintContext {
-  return buildLintContext([source], REAL_SPEC, versionContext);
+  return buildLintContext([source], spec, versionContext);
 }
 
 function ruleById(id: string): LintRule {
@@ -171,6 +194,27 @@ describe("matcher-case", () => {
     // The violating fixture declares `"matcher": "bash"`.
     expect(finding?.suggestion).toContain('"Bash"');
   });
+
+  it("preserves a pipe delimiter in its suggestion rather than switching to comma notation", () => {
+    const source = ruleFixtureSource("matcher-case", "violating.json");
+    const ctx: LintContext = {
+      spec: REAL_SPEC,
+      versionContext: UNDETERMINED,
+      groups: [
+        {
+          file: source.path,
+          layer: "project",
+          event: "PreToolUse",
+          line: 1,
+          matcher: { kind: "string", value: "bash|Write" },
+        },
+      ],
+    };
+    const [finding] = ruleById("matcher-case").run(ctx);
+
+    expect(finding?.suggestion).toContain('"Bash|Write"');
+    expect(finding?.suggestion).not.toContain('"Bash,Write"');
+  });
 });
 
 describe("matcher-dead", () => {
@@ -179,6 +223,24 @@ describe("matcher-dead", () => {
     const [finding] = ruleById("matcher-dead").run(contextFor(source));
 
     expect(finding?.message).toContain('"Basher"');
+  });
+
+  it("never flags an mcp__* item, which is never in spec.knownTools by construction", () => {
+    const source = ruleFixtureSource("matcher-dead", "violating.json");
+    const ctx: LintContext = {
+      spec: REAL_SPEC,
+      versionContext: UNDETERMINED,
+      groups: [
+        {
+          file: source.path,
+          layer: "project",
+          event: "PreToolUse",
+          line: 1,
+          matcher: { kind: "string", value: "mcp__github__create_issue" },
+        },
+      ],
+    };
+    expect(ruleById("matcher-dead").run(ctx)).toEqual([]);
   });
 });
 
@@ -222,6 +284,48 @@ describe("matcher-unanchored", () => {
     };
     expect(rule.run(ctx)).toEqual([]);
   });
+
+  function unanchoredCtx(matcher: string): LintContext {
+    const source = ruleFixtureSource("matcher-unanchored", "violating.json");
+    return {
+      spec: REAL_SPEC,
+      versionContext: UNDETERMINED,
+      groups: [
+        {
+          file: source.path,
+          layer: "project",
+          event: "PreToolUse",
+          line: 1,
+          matcher: { kind: "string", value: matcher },
+        },
+      ],
+    };
+  }
+
+  it("does not flag a correctly anchored alternation that matches only its own branches", () => {
+    expect(rule.run(unanchoredCtx("^(Bash|Edit)$"))).toEqual([]);
+  });
+
+  it("for an unanchored alternation, lists only the genuine over-match, not the alternation's own branches", () => {
+    const [finding] = rule.run(unanchoredCtx("(Edit|Write)"));
+
+    expect(finding?.message).toContain("NotebookEdit");
+    expect(finding?.message).not.toContain('"Edit"');
+    expect(finding?.message).not.toContain('"Write"');
+  });
+
+  it("suggests a non-capturing anchored wrap rather than doubling an existing trailing $", () => {
+    const [finding] = rule.run(unanchoredCtx("Edit$"));
+
+    expect(finding?.suggestion).toContain('"^(?:Edit)$"');
+    expect(finding?.suggestion).not.toContain("$$");
+  });
+
+  it("suggests a non-capturing anchored wrap rather than anchoring only the first alternation branch", () => {
+    const [finding] = rule.run(unanchoredCtx("Edit|Write.*"));
+
+    expect(finding?.suggestion).toContain('"^(?:Edit|Write.*)$"');
+  });
 });
 
 describe.each([
@@ -242,28 +346,41 @@ describe.each([
   const source = ruleFixtureSource(ruleId, "violating.json");
 
   it("emits no finding when the known version satisfies the notation rule's sinceVersion", () => {
-    expect(rule.run(contextFor(source, satisfiedVersion))).toEqual([]);
+    expect(rule.run(contextFor(source, satisfiedVersion, WIDENED_RANGE_SPEC))).toEqual(
+      [],
+    );
   });
 
   it("emits a finding naming the required and detected versions when the known version is older", () => {
-    const [finding] = rule.run(contextFor(source, OLD_VERSION));
+    const [finding] = rule.run(contextFor(source, OLD_VERSION, WIDENED_RANGE_SPEC));
 
     expect(finding?.message).toContain(sinceVersion);
     expect(finding?.message).toContain("2.1.100");
   });
 
   it("degrades to an unknown-confidence finding — rather than omitting it — when the version is undetermined", () => {
-    const [finding] = rule.run(contextFor(source, UNDETERMINED));
+    const [finding] = rule.run(contextFor(source, UNDETERMINED, WIDENED_RANGE_SPEC));
 
     expect(finding).toBeDefined();
     expect(finding?.message).toContain("could not be determined");
   });
 
   it("produces a message distinguishable from the definite-failure case", () => {
-    const [undeterminedFinding] = rule.run(contextFor(source, UNDETERMINED));
-    const [oldVersionFinding] = rule.run(contextFor(source, OLD_VERSION));
+    const [undeterminedFinding] = rule.run(
+      contextFor(source, UNDETERMINED, WIDENED_RANGE_SPEC),
+    );
+    const [oldVersionFinding] = rule.run(
+      contextFor(source, OLD_VERSION, WIDENED_RANGE_SPEC),
+    );
 
     expect(undeterminedFinding?.message).not.toBe(oldVersionFinding?.message);
+  });
+
+  it("degrades to the same unknown-confidence finding — rather than silently passing — when the known version is outside spec.claudeCodeRange", () => {
+    const [finding] = rule.run(contextFor(source, OUT_OF_RANGE_VERSION));
+
+    expect(finding).toBeDefined();
+    expect(finding?.message).toContain("could not be determined");
   });
 });
 

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -11,6 +11,13 @@ import {
 } from "../src/internal/lint/index.js";
 import type { LintContext, LintRule } from "../src/internal/lint/index.js";
 import type { VersionContext } from "../src/internal/matcher/index.js";
+import {
+  buildReportHeader,
+  renderLintGithub,
+  renderLintJson,
+  toJsonLintReport,
+  type LintReport,
+} from "../src/internal/report/index.js";
 import type { SettingsSource } from "../src/internal/settings/index.js";
 import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
 import type { Spec } from "../src/internal/spec/index.js";
@@ -309,5 +316,97 @@ describe("buildLintContext", () => {
       UNDETERMINED,
     );
     expect(ctx.groups).toHaveLength(2);
+  });
+});
+
+describe("lint report rendering: json and github", () => {
+  function reportFor(
+    source: SettingsSource,
+    versionContext: VersionContext = UNDETERMINED,
+  ): LintReport {
+    const ctx = contextFor(source, versionContext);
+    const findings = LINT_RULES.flatMap((rule) => rule.run(ctx));
+    return {
+      header: buildReportHeader(versionContext, REAL_SPEC.claudeCodeRange),
+      findings,
+    };
+  }
+
+  const violatingSource = ruleFixtureSource("matcher-is-array", "violating.json");
+
+  describe("renderLintJson / toJsonLintReport", () => {
+    it("tags the report as reportType 'lint'", () => {
+      const json = toJsonLintReport(reportFor(violatingSource));
+      expect(json.reportType).toBe("lint");
+      expect(json.reportVersion).toBe("1");
+    });
+
+    it("carries every Finding field for each finding, unmodified", () => {
+      const report = reportFor(violatingSource);
+      const json = toJsonLintReport(report);
+
+      expect(json.findings).toHaveLength(report.findings.length);
+      json.findings.forEach((jsonFinding, index) => {
+        const finding = report.findings[index];
+        expect(jsonFinding).toEqual({
+          file: finding?.file,
+          line: finding?.line,
+          ruleId: finding?.ruleId,
+          message: finding?.message,
+          suggestion: finding?.suggestion,
+        });
+      });
+    });
+
+    it("renderLintJson stringifies exactly toJsonLintReport's own shape", () => {
+      const report = reportFor(violatingSource);
+      expect(JSON.parse(renderLintJson(report)) as unknown).toEqual(
+        toJsonLintReport(report),
+      );
+    });
+
+    it("carries an empty findings array, not an omitted one, when there is nothing to report", () => {
+      // matcher-dead's own clean.json ("Bash") is clean across every rule,
+      // unlike matcher-is-array's own clean.json ("Edit,Write"), which is
+      // clean only for matcher-is-array itself and still trips
+      // matcher-comma-version under an undetermined version.
+      const cleanSource = ruleFixtureSource("matcher-dead", "clean.json");
+      const json = toJsonLintReport(reportFor(cleanSource));
+      expect(json.findings).toEqual([]);
+    });
+  });
+
+  describe("renderLintGithub", () => {
+    it("emits one ::error line per finding, with a workspace-relative path", () => {
+      const report = reportFor(violatingSource);
+      const output = renderLintGithub(report, REPO_ROOT);
+
+      const relativePath = path
+        .relative(REPO_ROOT, violatingSource.path)
+        .split(path.sep)
+        .join("/");
+      expect(output).toContain(
+        `::error file=${relativePath},line=5,title=matcher-is-array::`,
+      );
+      // The absolute path must never leak into a github annotation.
+      expect(output).not.toContain(violatingSource.path);
+    });
+
+    it("folds the suggestion into the message body rather than dropping it", () => {
+      const report = reportFor(violatingSource);
+      const [finding] = report.findings;
+      const output = renderLintGithub(report, REPO_ROOT);
+
+      expect(finding).toBeDefined();
+      expect(output).toContain(finding?.suggestion ?? "");
+    });
+
+    it("emits only the header line, no ::error, for a clean report", () => {
+      const cleanSource = ruleFixtureSource("matcher-dead", "clean.json");
+      const output = renderLintGithub(reportFor(cleanSource), REPO_ROOT);
+
+      expect(output).not.toContain("::error");
+      expect(output).toContain("::notice");
+    });
   });
 });

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -671,7 +671,7 @@ describe("machine guarantees", () => {
     expect(report.cases[0]?.result.kind).toBe("pass");
   });
 
-  it("explain and lint (already covered by earlier issues) remain at 0 spawns when run alongside test in the same CLI process", async () => {
+  it("explain and lint (both zero-execution static checks) remain at 0 spawns when run alongside test in the same CLI process", async () => {
     const spawner = new FakeSpawner();
     const deps = testDeps({ spawner });
 
@@ -683,8 +683,11 @@ describe("machine guarantees", () => {
     expect(explainResult.exitCode).toBe(0);
     expect(spawner.calls).toHaveLength(0);
 
+    // Exit 0: this shared project's own settings.json (see beforeAll above)
+    // declares only correctly-cased, known-tool matchers ("Bash", "Write",
+    // "Edit"), so none of the five matcher rules has anything to report.
     const lintResult = await runCli(["lint"], "hookassert", deps);
-    expect(lintResult.exitCode).toBe(4);
+    expect(lintResult.exitCode).toBe(0);
     expect(spawner.calls).toHaveLength(0);
 
     const fixturePath = writeFixture({


### PR DESCRIPTION
Builds `src/internal/lint/` — the `LintRule`/`Finding`/`LintContext` framework, a tolerant settings reader that reports an array-valued matcher as a `Finding` instead of throwing (unlike `settings/load.ts`'s strict loader), and the five matcher rules (`matcher-is-array`, `matcher-case`, `matcher-comma-version`, `matcher-hyphen-version`, `matcher-dead`, `matcher-unanchored`) built on `matcher/classify.ts`'s classification. Wires `lint` into `src/cli.ts` as a zero-execution, zero-write static check (exit 1 on any finding, 0 otherwise; `--ci` accepted and identical), proven spawn-free with `CountingSpawner`, with `--format pretty|json|github` routed through the shared `renderInFormat` selector: `renderLintPretty`, `renderLintJson`/`toJsonLintReport` (mirroring `JsonExplainReport`/`JsonTestReport`, `reportType: "lint"`), and `renderLintGithub` (via `report/github.ts`'s `ReportFinding`/`renderGithubFinding`, workspace-relative paths). The README's `lint` bullet now describes the real command.

Closes #13

Release impact: yes — MINOR. `hookassert lint` gains real behavior (previously a stub exiting 4 with `ERR_USAGE`), including a new JSON output shape (`reportType: "lint"`) and GitHub Actions annotations. No exported type from `src/index.ts` changes.

## Test plan

- `pnpm exec vitest run tests/lint.test.ts tests/cli.test.ts` — pass. Per rule: a `Finding` with `file`/`line`/`ruleId`/`suggestion` all set for its violating fixture and zero findings for its clean fixture (`tests/fixtures/lint/<rule-id>/{violating,clean}.json`); `matcher-is-array`'s message states the entire file's hooks are disabled; `matcher-unanchored` enumerates the unintended tools (`Edit.*` → `NotebookEdit`), leaves `^(Bash|Edit)$` alone, and lists only `NotebookEdit` for `(Edit|Write)`; the two version rules degrade to an unknown-confidence finding for an undetermined or out-of-range version; `matcher-dead` skips `mcp__*` names; `matcher-case`'s suggestion preserves a `|` delimiter; `lint` exits 1 with findings and 0 without, `--ci` behaves identically, all three formats render (github lines are `::error file=<repo-relative>,line=<n>,title=<rule-id>::…`), and every path performs zero spawns.
- `pnpm check:quick` — pass (format, lint, typecheck, 35 test files / 1380 tests) on the branch after merging `main`.
- `pnpm build` — pass (the `isolatedDeclarations` build config, which `check:quick` does not run).

`tests/lint.test.ts` joins `eslint.config.mjs`'s existing `tests/static-layer-unit-tests` allowlist, added by name the way that list documents; a stale cross-command assertion in `tests/test-cmd.test.ts` that pinned `lint`'s old stub exit code now asserts the real behavior. No coverage floor was moved and no rule was relaxed.

## Review findings addressed before this PR opened

A `/code-review medium` pass ran against the branch first; all eight findings were applied: a TS9010 build break under `isolatedDeclarations` on two exported rule consts (green under `check:quick`, red under `pnpm build`), `matcher-dead` false positives on MCP tool names, `lint --ci` rejected as an unknown option, `^(Bash|Edit)$` reported as over-matching, a malformed anchoring suggestion (`^Edit$$`), a `matcher-case` suggestion that silently switched `|` to the version-gated `,` notation, the version rules ignoring a version outside `spec.claudeCodeRange`, and the README still describing `lint` as a stub.

https://claude.ai/code/session_01Eg742R8ixiz1Fv8ThoAyGc
