### PR TITLE
fix: fold every firing hook's Decision into one case verdict (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ hookassert --help
   milliseconds for hooks that declare none (a fixture file's own `defaults.timeoutMs`
   still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
   variable into every spawned hook's environment by name — a value is never accepted
-  here, only a name. Exits `0` when every case passes (and, with `--ci`, none is
-  `unknown` either), `1` when at least one fails, and `3` when there are no failures but
-  `--ci` was given and at least one case is `unknown`.
+  here, only a name. When several hooks fire for one case, any deny wins; the report
+  names the hook that decided. Exits `0` when every case passes (and, with `--ci`, none
+  is `unknown` either), `1` when at least one fails, and `3` when there are no failures
+  but `--ci` was given and at least one case is `unknown`.
 
 ## API
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   isStubOnly,
   summarize,
   type CaseObservation,
+  type FiredHook,
 } from "./internal/assert/index.js";
 import { resolveDecision } from "./internal/decision/index.js";
 import {
@@ -1019,24 +1020,24 @@ function resolveTestExitCode(
   return 0;
 }
 
-/** One fixture case, prepared for execution: its matcher result and (once assigned) its authoritative step. */
+/** One fixture case, prepared for execution: its matcher result and every step it spawns. */
 interface PreparedCase {
   readonly fixturePath: string;
   readonly index: number;
   readonly caseData: FixtureCase;
   /**
-   * The step whose outcome this case's `Decision` is built from — the first
-   * hook the matcher resolved as firing, in `ResolvedHook` order — or
-   * `undefined` when the case was pre-skipped or nothing fired for it.
+   * Every step this case spawns — one per hook the matcher resolved as
+   * firing, in `ResolvedHook` order. Empty when the case was pre-skipped or
+   * nothing fired for it.
    *
    * @remarks
-   * When more than one hook fires for the same case, every one of them is
-   * still spawned (a real Claude Code session would run them all), but only
-   * this first one is read back for the case's own pass/fail/unknown
-   * verdict — `CaseObservation` carries a single `decision`, not one per
-   * firing hook.
+   * Every firing hook is still spawned (a real Claude Code session would
+   * run them all), and every one of their outcomes is read back into this
+   * case's `CaseObservation.fired` — `assertCase` folds them into one
+   * verdict itself, through `combineDecisions`, rather than this module
+   * picking a single "authoritative" step ahead of time.
    */
-  readonly firstStep: ExecutionStep | undefined;
+  readonly steps: readonly ExecutionStep[];
   readonly rejectedByMatcher: readonly MatcherOutcome[];
   readonly excludedHooks: readonly ResolvedHook[];
 }
@@ -1175,9 +1176,9 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
           ? { ...rawCaseData, dryRun: true }
           : rawCaseData;
 
-      let firstStep: ExecutionStep | undefined;
+      const steps: ExecutionStep[] = [];
       if (!isPreSkipped(caseData)) {
-        match.firing.forEach((hook, hookIndex) => {
+        for (const hook of match.firing) {
           const step: ExecutionStep = {
             event: caseData.event,
             hook,
@@ -1186,17 +1187,15 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
             stub: caseData.stub?.[hook.command],
           };
           filePlan.steps.push(step);
-          if (hookIndex === 0) {
-            firstStep = step;
-          }
-        });
+          steps.push(step);
+        }
       }
 
       prepared.push({
         fixturePath,
         index,
         caseData,
-        firstStep,
+        steps,
         rejectedByMatcher: match.rejected,
         excludedHooks,
       });
@@ -1239,15 +1238,23 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
   const caseReports: TestCaseReport[] = [];
   const caseResults: CaseResult[] = [];
   for (const p of prepared) {
-    const outcome =
-      p.firstStep === undefined ? undefined : outcomesByStep.get(p.firstStep);
-    const decision =
-      outcome === undefined
-        ? undefined
-        : resolveDecision(spec, p.caseData.event, outcome);
+    // Every firing step's outcome is folded in, in firing order — assertCase
+    // (via combineDecisions) is what picks the case's single verdict from
+    // among them, not this loop.
+    const fired: FiredHook[] = [];
+    for (const step of p.steps) {
+      const outcome = outcomesByStep.get(step);
+      if (outcome === undefined) {
+        continue;
+      }
+      fired.push({
+        hook: step.hook,
+        execOutcome: outcome,
+        decision: resolveDecision(spec, p.caseData.event, outcome),
+      });
+    }
     const observation: CaseObservation = {
-      decision,
-      execOutcome: outcome,
+      fired,
       rejectedByMatcher: p.rejectedByMatcher,
       excludedHooks: p.excludedHooks,
     };
@@ -1259,6 +1266,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
       event: p.caseData.event,
       tool: p.caseData.tool,
       result,
+      firedCount: fired.length,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@
 export type {
   CaseResult,
   Decision,
+  DecidingHook,
   EventName,
   ExecOutcome,
   ExpectationDiff,

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -4,22 +4,26 @@
  *
  * @remarks
  * Static layer: pure comparison — no I/O, no process, no write. This module
- * only consumes a `Decision`, an `ExecOutcome`, and the matcher engine's
- * `MatcherOutcome`s for the case, all of which the caller already obtained;
- * it never resolves a decision or classifies a matcher itself.
+ * consumes a `Decision` per firing hook, an `ExecOutcome` per firing hook,
+ * and the matcher engine's `MatcherOutcome`s for the case, all of which the
+ * caller already obtained; it never resolves a decision or classifies a
+ * matcher itself, and its own `combineDecisions` call
+ * (`src/internal/decision/`) only folds `Decision`s the caller already
+ * resolved rather than resolving one itself.
  */
 
 import type {
   CaseResult,
   Decision,
+  DecidingHook,
   EventName,
-  ExecOutcome,
   ExpectationDiff,
   NonFiringExplanation,
   RejectedMatch,
 } from "../../types.js";
+import { combineDecisions } from "../decision/index.js";
 import type { FixtureCase, FixtureExpectation } from "../fixture/index.js";
-import type { CaseObservation } from "./types.js";
+import type { CaseObservation, FiredHook } from "./types.js";
 
 /** Whether `expect` declares no assertion at all — every field is `undefined`. */
 function isEmptyExpectation(expect: FixtureExpectation): boolean {
@@ -81,18 +85,23 @@ function deriveNonFiring(
 }
 
 /**
- * Every {@link ExpectationDiff} between `expect` and a firing hook's
- * resolved `decision` and `execOutcome`.
+ * Every {@link ExpectationDiff} between `expect` and the case's combined
+ * `decision`, checked against every firing hook's own stream and timeout.
  *
  * @remarks
  * Only called once the caller has already excluded `decision.kind ===
  * "unknown"` — an unresolved decision produces its own `CaseResult.kind ===
- * "unknown"` rather than a `diffs` mismatch.
+ * "unknown"` rather than a `diffs` mismatch. `decision`/`exitCode` are
+ * compared against the combined verdict (`exitCode` is the deciding hook's
+ * own, since that is whose `Decision` won the fold); `stdoutContains`,
+ * `stderrContains`, and `timedOut` are checked against *every* firing hook
+ * — a real Claude Code session shows every hook's output, not only the one
+ * that decided — so any one of them satisfying the expectation is enough.
  */
 function computeFiredDiffs(
   expect: FixtureExpectation,
   decision: Exclude<Decision, { kind: "unknown" }>,
-  execOutcome: ExecOutcome | undefined,
+  fired: readonly [FiredHook, ...FiredHook[]],
 ): ExpectationDiff[] {
   const diffs: ExpectationDiff[] = [];
 
@@ -116,26 +125,32 @@ function computeFiredDiffs(
     });
   }
 
-  const stdout = execOutcome?.stdout ?? "";
-  if (expect.stdoutContains !== undefined && !stdout.includes(expect.stdoutContains)) {
-    diffs.push({
-      field: "stdoutContains",
-      expectedSubstring: expect.stdoutContains,
-      actualStdout: stdout,
-    });
+  if (expect.stdoutContains !== undefined) {
+    const substring = expect.stdoutContains;
+    const matched = fired.some((f) => f.execOutcome.stdout.includes(substring));
+    if (!matched) {
+      diffs.push({
+        field: "stdoutContains",
+        expectedSubstring: substring,
+        actualStdout: fired.map((f) => f.execOutcome.stdout).join("\n"),
+      });
+    }
   }
 
-  const stderr = execOutcome?.stderr ?? "";
-  if (expect.stderrContains !== undefined && !stderr.includes(expect.stderrContains)) {
-    diffs.push({
-      field: "stderrContains",
-      expectedSubstring: expect.stderrContains,
-      actualStderr: stderr,
-    });
+  if (expect.stderrContains !== undefined) {
+    const substring = expect.stderrContains;
+    const matched = fired.some((f) => f.execOutcome.stderr.includes(substring));
+    if (!matched) {
+      diffs.push({
+        field: "stderrContains",
+        expectedSubstring: substring,
+        actualStderr: fired.map((f) => f.execOutcome.stderr).join("\n"),
+      });
+    }
   }
 
   if (expect.timedOut !== undefined) {
-    const actualTimedOut = execOutcome?.timedOut ?? false;
+    const actualTimedOut = fired.some((f) => f.execOutcome.timedOut);
     if (expect.timedOut !== actualTimedOut) {
       diffs.push({
         field: "timedOut",
@@ -146,6 +161,13 @@ function computeFiredDiffs(
   }
 
   return diffs;
+}
+
+/** Type guard narrowing `fired` to a non-empty tuple once its length has been checked. */
+function isNonEmptyFired(
+  fired: readonly FiredHook[],
+): fired is readonly [FiredHook, ...FiredHook[]] {
+  return fired.length > 0;
 }
 
 /**
@@ -159,12 +181,20 @@ function computeFiredDiffs(
  * 2. No hook fired at all: `expect.fires: true` → `"fail"` with
  *    {@link NonFiringExplanation}; otherwise → `"pass"`, since nothing else
  *    was declared to compare against a case that was not expected to fire.
- * 3. A hook fired but its resolved `Decision` could not be asserted with
- *    confidence (`decision.kind === "unknown"`) → `"unknown"`, carrying the
- *    same `reasons` the `Decision` itself carries.
- * 4. A hook fired and its `Decision` resolved with confidence → every
- *    declared `expect` field is compared against what was observed; any
- *    mismatch produces `"fail"` with a non-empty `diffs`, otherwise
+ * 3. One or more hooks fired: every firing hook's own `Decision` is folded
+ *    into one combined verdict by `combineDecisions`
+ *    (`deny` > `unknown` > `error` > `allow` > `pass` — any deny wins,
+ *    regardless of which hook produced it or how many others fired), and
+ *    the hook that produced the winning `Decision` is recorded as
+ *    `decidedBy` on every branch below.
+ * 4. The combined `Decision` could not be asserted with confidence
+ *    (`decision.kind === "unknown"`) → `"unknown"`, carrying the same
+ *    `reasons` that `Decision` itself carries.
+ * 5. The combined `Decision` resolved with confidence → every declared
+ *    `expect` field is compared against what was observed (`decision`/
+ *    `exitCode` against the combined verdict, `stdoutContains`/
+ *    `stderrContains`/`timedOut` against every firing hook's own stream);
+ *    any mismatch produces `"fail"` with a non-empty `diffs`, otherwise
  *    `"pass"`.
  */
 export function assertCase(
@@ -180,26 +210,41 @@ export function assertCase(
     return { kind: "skipped", origin, reason: "stub-only" };
   }
 
-  if (observation.decision === undefined) {
+  const { fired } = observation;
+  if (!isNonEmptyFired(fired)) {
     if (caseData.expect.fires === true) {
       return {
         kind: "fail",
         origin,
         diffs: [],
         nonFiring: deriveNonFiring(caseData.event, observation),
+        decidedBy: undefined,
       };
     }
-    return { kind: "pass", origin };
+    return { kind: "pass", origin, decidedBy: undefined };
   }
 
-  const { decision } = observation;
-  if (decision.kind === "unknown") {
-    return { kind: "unknown", origin, reasons: decision.reasons };
+  const decisions: readonly [Decision, ...Decision[]] = [
+    fired[0].decision,
+    ...fired.slice(1).map((f) => f.decision),
+  ];
+  const combined = combineDecisions(decisions);
+  // combined.index is always a valid index into `fired` — combineDecisions
+  // picks it from `decisions`, built 1:1 with `fired` above — but a dynamic
+  // numeric index into an array still types as possibly undefined under
+  // noUncheckedIndexedAccess; `fired[0]` is the unreachable-in-practice
+  // fallback, itself guaranteed present by the tuple type `fired` narrowed
+  // to above.
+  const decidingHook = (fired[combined.index] ?? fired[0]).hook;
+  const decidedBy: DecidingHook = { hook: decidingHook, decision: combined.decision };
+
+  if (combined.decision.kind === "unknown") {
+    return { kind: "unknown", origin, reasons: combined.decision.reasons, decidedBy };
   }
 
-  const diffs = computeFiredDiffs(caseData.expect, decision, observation.execOutcome);
+  const diffs = computeFiredDiffs(caseData.expect, combined.decision, fired);
   if (diffs.length > 0) {
-    return { kind: "fail", origin, diffs, nonFiring: undefined };
+    return { kind: "fail", origin, diffs, nonFiring: undefined, decidedBy };
   }
-  return { kind: "pass", origin };
+  return { kind: "pass", origin, decidedBy };
 }

--- a/src/internal/assert/index.ts
+++ b/src/internal/assert/index.ts
@@ -13,4 +13,4 @@
 
 export { assertCase, isStubOnly } from "./assertCase.js";
 export { summarize } from "./summarize.js";
-export type { CaseObservation } from "./types.js";
+export type { CaseObservation, FiredHook } from "./types.js";

--- a/src/internal/assert/types.ts
+++ b/src/internal/assert/types.ts
@@ -16,6 +16,24 @@ import type { Decision, ExecOutcome, ResolvedHook } from "../../types.js";
 import type { MatcherOutcome } from "../matcher/index.js";
 
 /**
+ * One hook that fired for a fixture case, paired with what it actually
+ * produced.
+ *
+ * @remarks
+ * Static layer: plain data, no I/O — `src/cli.ts`'s composition root is what
+ * actually runs a hook and produces these values; `assertCase` only ever
+ * reads them.
+ */
+export interface FiredHook {
+  /** The hook that fired. */
+  readonly hook: ResolvedHook;
+  /** The raw exec outcome this hook produced. */
+  readonly execOutcome: ExecOutcome;
+  /** This hook's own resolved `Decision`, from `resolveDecision`. */
+  readonly decision: Decision;
+}
+
+/**
  * What actually happened for one fixture case, gathered from the matcher
  * engine and the decision resolver — everything `assertCase` needs beyond
  * the case's own declared `expect`.
@@ -27,22 +45,22 @@ import type { MatcherOutcome } from "../matcher/index.js";
  */
 export interface CaseObservation {
   /**
-   * The resolved `Decision` when a hook fired and ran; `undefined` when
-   * nothing fired for this case at all.
+   * Every hook that fired for this case, in firing order, each carrying its
+   * own outcome and resolved `Decision`. Empty when nothing fired at all.
+   *
+   * @remarks
+   * More than one entry is the ordinary product of the three-layer settings
+   * merge (a project-layer hook behind a user-layer one, say): every firing
+   * hook is spawned, and `assertCase` folds all of their `Decision`s into
+   * one case verdict through `combineDecisions`
+   * (`src/internal/decision/combine.ts`) rather than reading only the first.
    */
-  readonly decision: Decision | undefined;
-
-  /**
-   * The raw exec outcome the firing hook produced. `undefined` whenever
-   * {@link CaseObservation.decision} is `undefined` — nothing ran to
-   * produce one.
-   */
-  readonly execOutcome: ExecOutcome | undefined;
+  readonly fired: readonly FiredHook[];
 
   /**
    * Every hook under this case's event that was a matcher candidate — read
    * from a settings layer the fixture's `settings:` list included — but did
-   * not fire. Empty whenever {@link CaseObservation.decision} is defined, or
+   * not fire. Empty whenever {@link CaseObservation.fired} is non-empty, or
    * when no candidate hook was rejected by the matcher.
    */
   readonly rejectedByMatcher: readonly MatcherOutcome[];

--- a/src/internal/decision/combine.ts
+++ b/src/internal/decision/combine.ts
@@ -1,0 +1,69 @@
+/**
+ * Folds every firing hook's {@link Decision} for one fixture case into a
+ * single verdict.
+ *
+ * @remarks
+ * Static layer: pure fold, no I/O — `resolveDecision` still maps one
+ * `ExecOutcome` to one `Decision`; this module only combines `Decision`s a
+ * caller already resolved, and never touches an `ExecOutcome` itself. More
+ * than one hook firing for the same event is the ordinary product of the
+ * three-layer settings merge (`settings/merge.ts`), and Claude Code itself
+ * runs every matching hook in parallel and honors a blocking result from
+ * any one of them — this is the fold that reproduces that same verdict from
+ * hookassert's own per-hook `Decision`s.
+ */
+
+import type { Decision } from "../../types.js";
+
+/**
+ * `Decision.kind`'s precedence, lowest number wins: `deny` outranks
+ * everything (a confident deny from any hook is the session's outcome
+ * regardless of what the others said or whether they could be resolved),
+ * `unknown` outranks `error`/`allow`/`pass` (nothing denied, but at least
+ * one hook could not be resolved with confidence, so the case cannot be
+ * asserted with confidence either), `error` outranks `allow`/`pass` (a hook
+ * that broke is more important to surface than a sibling that succeeded),
+ * and `allow` outranks `pass` (an explicit allow is a decision; a pass is
+ * the absence of one).
+ */
+const PRECEDENCE: Readonly<Record<Decision["kind"], number>> = {
+  deny: 0,
+  unknown: 1,
+  error: 2,
+  allow: 3,
+  pass: 4,
+};
+
+/** The fold of every firing hook's `Decision` into one case verdict. */
+export interface CombinedDecision {
+  /** The winning `Decision`, by {@link PRECEDENCE}. */
+  readonly decision: Decision;
+  /**
+   * Index into the input tuple of the hook that produced
+   * {@link CombinedDecision.decision} — the first hook at the winning
+   * precedence, in firing order, when more than one hook ties.
+   */
+  readonly index: number;
+}
+
+/**
+ * Fold `decisions` — one per firing hook, in firing order — into the single
+ * verdict the case is reported against: `deny` > `unknown` > `error` >
+ * `allow` > `pass`.
+ *
+ * @param decisions - Every firing hook's resolved `Decision`, in the same
+ * order the hooks fired. Required to be non-empty: a case with no firing
+ * hook at all has no `Decision` to combine, and is handled by the caller
+ * before this is ever called.
+ */
+export function combineDecisions(
+  decisions: readonly [Decision, ...Decision[]],
+): CombinedDecision {
+  let winner: CombinedDecision = { decision: decisions[0], index: 0 };
+  decisions.forEach((decision, index) => {
+    if (PRECEDENCE[decision.kind] < PRECEDENCE[winner.decision.kind]) {
+      winner = { decision, index };
+    }
+  });
+  return winner;
+}

--- a/src/internal/decision/index.ts
+++ b/src/internal/decision/index.ts
@@ -13,3 +13,5 @@
 
 export { allowed, denied, errored, passed, unknownDecision } from "./factory.js";
 export { canProduceDeny, exit2OverridesAllowJson, resolveDecision } from "./resolve.js";
+export { combineDecisions } from "./combine.js";
+export type { CombinedDecision } from "./combine.js";

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -14,9 +14,11 @@
 
 import type {
   CaseResult,
+  DecidingHook,
   EventName,
   ExpectationDiff,
   NonFiringExplanation,
+  PayloadOrigin,
   Summary,
   UnknownReason,
 } from "../../types.js";
@@ -39,6 +41,17 @@ export interface TestCaseReport {
 
   /** What `assertCase` produced for this case. */
   readonly result: CaseResult;
+
+  /**
+   * How many hooks fired for this case.
+   *
+   * @remarks
+   * Not part of `CaseResult` itself — it exists here only so
+   * `renderCaseLine` can gate its `— decided by …` annotation on more than
+   * one hook having fired, without `CaseResult` carrying a count nothing
+   * else needs.
+   */
+  readonly firedCount: number;
 }
 
 /** The full result `test <fixture>...` renders. */
@@ -111,6 +124,27 @@ function describeDiff(diff: ExpectationDiff): string {
   }
 }
 
+/** `<command> (<file>:<line>)` for the hook a multi-hook case's verdict came from. */
+function describeDecidedBy(decidedBy: DecidingHook): string {
+  const { hook } = decidedBy;
+  return `${hook.command} (${hook.provenance.file}:${String(hook.provenance.line)})`;
+}
+
+/**
+ * ` — decided by …` suffix for a `FAIL`/`UNKNOWN` line, shown only when more
+ * than one hook fired for the case — naming the hook for a single-hook case
+ * would just repeat what the line already says.
+ */
+function decidedBySuffix(
+  report: TestCaseReport,
+  decidedBy: DecidingHook | undefined,
+): string {
+  if (decidedBy === undefined || report.firedCount <= 1) {
+    return "";
+  }
+  return ` — decided by ${describeDecidedBy(decidedBy)}`;
+}
+
 /** One human-readable line per {@link TestCaseReport}, for `renderTestPretty`. */
 function renderCaseLine(report: TestCaseReport): string {
   const label = caseLabel(report);
@@ -120,14 +154,16 @@ function renderCaseLine(report: TestCaseReport): string {
       return `PASS  ${label}`;
     case "skipped":
       return `SKIP  ${label} (${result.reason})`;
-    case "unknown":
-      return `UNKNOWN ${label} — ${result.reasons.map(describeUnknownReason).join("; ")}`;
+    case "unknown": {
+      const reasons = result.reasons.map(describeUnknownReason).join("; ");
+      return `UNKNOWN ${label} — ${reasons}${decidedBySuffix(report, result.decidedBy)}`;
+    }
     case "fail": {
       const detail =
         result.nonFiring === undefined
           ? result.diffs.map(describeDiff).join("; ")
           : describeNonFiring(result.nonFiring);
-      return `FAIL  ${label} — ${detail}`;
+      return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy)}`;
     }
   }
 }
@@ -162,13 +198,78 @@ export function renderTestPretty(report: TestReport): string {
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * `CaseResult`, with `decidedBy` normalized to `null` rather than dropped
+ * when absent.
+ *
+ * @remarks
+ * `JSON.stringify` omits an object property whose value is `undefined`
+ * rather than emitting `null` for it, so `CaseResult.decidedBy` would
+ * silently vanish from a `"pass"`/`"unknown"` result's JSON rather than
+ * appearing as the explicit `null` a consumer can rely on being present.
+ * `toJsonCaseResult` is the one place that substitution happens.
+ */
+type JsonCaseResult =
+  | {
+      readonly kind: "pass";
+      readonly origin: PayloadOrigin;
+      readonly decidedBy: DecidingHook | null;
+    }
+  | {
+      readonly kind: "fail";
+      readonly origin: PayloadOrigin;
+      readonly diffs: readonly ExpectationDiff[];
+      readonly nonFiring: NonFiringExplanation | undefined;
+      readonly decidedBy: DecidingHook | null;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly origin: PayloadOrigin;
+      readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+      readonly decidedBy: DecidingHook | null;
+    }
+  | {
+      readonly kind: "skipped";
+      readonly origin: PayloadOrigin;
+      readonly reason: "dry-run" | "stub-only";
+    };
+
+/** Build the {@link JsonCaseResult} `renderTestJson` emits for one `CaseResult`. */
+function toJsonCaseResult(result: CaseResult): JsonCaseResult {
+  switch (result.kind) {
+    case "pass":
+      return {
+        kind: "pass",
+        origin: result.origin,
+        decidedBy: result.decidedBy ?? null,
+      };
+    case "fail":
+      return {
+        kind: "fail",
+        origin: result.origin,
+        diffs: result.diffs,
+        nonFiring: result.nonFiring,
+        decidedBy: result.decidedBy ?? null,
+      };
+    case "unknown":
+      return {
+        kind: "unknown",
+        origin: result.origin,
+        reasons: result.reasons,
+        decidedBy: result.decidedBy ?? null,
+      };
+    case "skipped":
+      return { kind: "skipped", origin: result.origin, reason: result.reason };
+  }
+}
+
 /** JSON-serializable shape one {@link TestCaseReport} renders to. */
 interface JsonTestCaseReport {
   readonly file: string;
   readonly index: number;
   readonly event: EventName;
   readonly tool: string | null;
-  readonly result: CaseResult;
+  readonly result: JsonCaseResult;
 }
 
 /**
@@ -209,7 +310,7 @@ export function toJsonTestReport(report: TestReport): JsonTestReport {
       index: caseReport.index,
       event: caseReport.event,
       tool: caseReport.tool ?? null,
-      result: caseReport.result,
+      result: toJsonCaseResult(caseReport.result),
     })),
     summary: report.summary,
   };
@@ -228,7 +329,11 @@ export function renderTestJson(report: TestReport): string {
  * A fixture case carries no line number of its own the way a `ResolvedHook`
  * does through `Provenance` — `fixture/load.ts` never records one — so every
  * annotation points at line 1 of its fixture file, identified instead by the
- * case's own 0-based index and event/target in the annotation's title.
+ * case's own 0-based index and event/target in the annotation's title,
+ * *unless* the failure names a `decidedBy` hook — a hook fired and its own
+ * `Decision` decided the case's verdict — in which case the annotation
+ * points at that hook's own `Provenance` instead, the more actionable
+ * location.
  */
 export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
   const lines: string[] = [renderGithubHeader(report.header)];
@@ -237,15 +342,23 @@ export function renderTestGithub(report: TestReport, workspaceRoot: string): str
     if (caseReport.result.kind !== "fail") {
       continue;
     }
+    const { result } = caseReport;
     const detail =
-      caseReport.result.nonFiring === undefined
-        ? caseReport.result.diffs.map(describeDiff).join("; ")
-        : describeNonFiring(caseReport.result.nonFiring);
+      result.nonFiring === undefined
+        ? result.diffs.map(describeDiff).join("; ")
+        : describeNonFiring(result.nonFiring);
+    const location =
+      result.decidedBy === undefined
+        ? { file: caseReport.file, line: 1 }
+        : {
+            file: result.decidedBy.hook.provenance.file,
+            line: result.decidedBy.hook.provenance.line,
+          };
     lines.push(
       renderGithubFinding(
         {
-          file: caseReport.file,
-          line: 1,
+          file: location.file,
+          line: location.line,
           title: `test case #${String(caseReport.index)}: ${caseLabel(caseReport)}`,
           message: detail,
         },

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -22,7 +22,11 @@ import type {
   Summary,
   UnknownReason,
 } from "../../types.js";
-import { renderGithubFinding, renderGithubHeader } from "./github.js";
+import {
+  relativizeForGithub,
+  renderGithubFinding,
+  renderGithubHeader,
+} from "./github.js";
 import type { ReportHeader } from "./summary.js";
 
 /** One fixture case's result, identified by which file and position it came from. */
@@ -236,31 +240,13 @@ type JsonCaseResult =
 
 /** Build the {@link JsonCaseResult} `renderTestJson` emits for one `CaseResult`. */
 function toJsonCaseResult(result: CaseResult): JsonCaseResult {
-  switch (result.kind) {
-    case "pass":
-      return {
-        kind: "pass",
-        origin: result.origin,
-        decidedBy: result.decidedBy ?? null,
-      };
-    case "fail":
-      return {
-        kind: "fail",
-        origin: result.origin,
-        diffs: result.diffs,
-        nonFiring: result.nonFiring,
-        decidedBy: result.decidedBy ?? null,
-      };
-    case "unknown":
-      return {
-        kind: "unknown",
-        origin: result.origin,
-        reasons: result.reasons,
-        decidedBy: result.decidedBy ?? null,
-      };
-    case "skipped":
-      return { kind: "skipped", origin: result.origin, reason: result.reason };
+  if (result.kind === "skipped") {
+    return result;
   }
+  // Spread rather than rebuild field by field: a field added to `CaseResult`
+  // later then reaches the JSON report on its own, instead of silently
+  // vanishing from it until someone notices this function was not updated.
+  return { ...result, decidedBy: result.decidedBy ?? null };
 }
 
 /** JSON-serializable shape one {@link TestCaseReport} renders to. */
@@ -322,6 +308,17 @@ export function renderTestJson(report: TestReport): string {
 }
 
 /**
+ * Whether `file` resolves to a path inside `workspaceRoot` — the only place a
+ * GitHub Actions annotation can attach, since `file=` is resolved relative to
+ * the checkout root and an absolute path outside it matches no line in the
+ * diff view.
+ */
+function attachesInWorkspace(file: string, workspaceRoot: string): boolean {
+  const relative = relativizeForGithub(file, workspaceRoot);
+  return !relative.startsWith("/") && !/^[A-Za-z]:\//.test(relative);
+}
+
+/**
  * Render a {@link TestReport} as GitHub Actions workflow commands: the
  * leading header line, then one `::error` per `"fail"` case.
  *
@@ -333,7 +330,11 @@ export function renderTestJson(report: TestReport): string {
  * *unless* the failure names a `decidedBy` hook — a hook fired and its own
  * `Decision` decided the case's verdict — in which case the annotation
  * points at that hook's own `Provenance` instead, the more actionable
- * location.
+ * location. A deciding hook declared outside the workspace (the user layer's
+ * `~/.claude/settings.json`, or the enterprise layer's) is the exception: an
+ * annotation whose `file=` is not inside `GITHUB_WORKSPACE` silently attaches
+ * to nothing, so the annotation stays on the fixture — which is inside the
+ * checkout — and names the deciding hook in its message instead.
  */
 export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
   const lines: string[] = [renderGithubHeader(report.header)];
@@ -347,20 +348,27 @@ export function renderTestGithub(report: TestReport, workspaceRoot: string): str
       result.nonFiring === undefined
         ? result.diffs.map(describeDiff).join("; ")
         : describeNonFiring(result.nonFiring);
-    const location =
-      result.decidedBy === undefined
-        ? { file: caseReport.file, line: 1 }
-        : {
-            file: result.decidedBy.hook.provenance.file,
-            line: result.decidedBy.hook.provenance.line,
-          };
+    const { decidedBy } = result;
+    const attachable =
+      decidedBy !== undefined &&
+      attachesInWorkspace(decidedBy.hook.provenance.file, workspaceRoot);
+    const location = attachable
+      ? {
+          file: decidedBy.hook.provenance.file,
+          line: decidedBy.hook.provenance.line,
+        }
+      : { file: caseReport.file, line: 1 };
+    const message =
+      decidedBy === undefined || attachable
+        ? detail
+        : `${detail} — decided by ${describeDecidedBy(decidedBy)}`;
     lines.push(
       renderGithubFinding(
         {
           file: location.file,
           line: location.line,
           title: `test case #${String(caseReport.index)}: ${caseLabel(caseReport)}`,
-          message: detail,
+          message,
         },
         workspaceRoot,
       ),

--- a/src/types.ts
+++ b/src/types.ts
@@ -465,6 +465,28 @@ export type NonFiringExplanation =
     };
 
 /**
+ * The hook whose `Decision` a case's combined verdict came from, and that
+ * `Decision` itself.
+ *
+ * @remarks
+ * When more than one hook fires for a case — the ordinary product of the
+ * three-layer settings merge — `assertCase` folds every firing hook's
+ * `Decision` into one verdict by precedence (`deny` > `unknown` > `error` >
+ * `allow` > `pass`, see `combineDecisions` in
+ * `src/internal/decision/combine.ts`) and names the hook that produced the
+ * winning one here, so a report can point at it rather than leaving a
+ * multi-hook case's verdict unattributed.
+ *
+ * @public
+ */
+export interface DecidingHook {
+  /** The hook whose `Decision` won the fold. */
+  readonly hook: ResolvedHook;
+  /** The case's combined `Decision` — this hook's own, since it is the one that decided. */
+  readonly decision: Decision;
+}
+
+/**
  * The comparison between one fixture case's declared `expect` and what
  * actually happened, produced by `assertCase` (`src/internal/assert/`).
  *
@@ -482,6 +504,8 @@ export type CaseResult =
       readonly kind: "pass";
       /** Where the case's input payload came from. */
       readonly origin: PayloadOrigin;
+      /** The hook whose `Decision` this case's verdict came from; `undefined` when no hook fired at all. */
+      readonly decidedBy: DecidingHook | undefined;
     }
   | {
       /** At least one declared expectation was not met. */
@@ -499,6 +523,8 @@ export type CaseResult =
        * mismatch (on this same result) on a hook that did fire.
        */
       readonly nonFiring: NonFiringExplanation | undefined;
+      /** The hook whose `Decision` this case's verdict came from; `undefined` when no hook fired at all. */
+      readonly decidedBy: DecidingHook | undefined;
     }
   | {
       /**
@@ -512,6 +538,8 @@ export type CaseResult =
       readonly origin: PayloadOrigin;
       /** Every reason nothing more specific could be asserted. */
       readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+      /** The hook whose `Decision` this case's verdict came from; `undefined` when no hook fired at all. */
+      readonly decidedBy: DecidingHook | undefined;
     }
   | {
       /** The case declared nothing to compare, so it was skipped rather than asserted or left `unknown`. */

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { assertCase, summarize } from "../src/internal/assert/index.js";
-import type { CaseObservation } from "../src/internal/assert/index.js";
+import type { CaseObservation, FiredHook } from "../src/internal/assert/index.js";
 import type { FixtureCase, FixtureExpectation } from "../src/internal/fixture/index.js";
 import type { MatcherOutcome } from "../src/internal/matcher/index.js";
 import type {
   CaseResult,
+  Decision,
   EventName,
   ExecOutcome,
   PayloadOrigin,
@@ -75,23 +76,38 @@ function makeCase(overrides: Partial<FixtureCase> = {}): FixtureCase {
   };
 }
 
+function makeExecOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
+  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
+}
+
+function makeFired(overrides: Partial<FiredHook> = {}): FiredHook {
+  return {
+    hook: makeHook(),
+    execOutcome: makeExecOutcome(),
+    decision: { kind: "pass", exitCode: 0 },
+    ...overrides,
+  };
+}
+
 function makeObservation(overrides: Partial<CaseObservation> = {}): CaseObservation {
   return {
-    decision: undefined,
-    execOutcome: undefined,
+    fired: [],
     rejectedByMatcher: [],
     excludedHooks: [],
     ...overrides,
   };
 }
 
-function makeExecOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
-  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
-}
-
 function expectFail(result: CaseResult): Extract<CaseResult, { kind: "fail" }> {
   if (result.kind !== "fail") {
     throw new Error(`expected a fail CaseResult, got ${result.kind}`);
+  }
+  return result;
+}
+
+function expectPass(result: CaseResult): Extract<CaseResult, { kind: "pass" }> {
+  if (result.kind !== "pass") {
+    throw new Error(`expected a pass CaseResult, got ${result.kind}`);
   }
   return result;
 }
@@ -114,7 +130,7 @@ describe("assertCase: expectation diffing", () => {
   it("a case whose hook fired but returned a different decision than expected produces a fail CaseResult with a non-empty diffs array", () => {
     const caseData = makeCase({ expect: makeExpect({ decision: "deny" }) });
     const observation = makeObservation({
-      decision: { kind: "pass", exitCode: 0 },
+      fired: [makeFired({ decision: { kind: "pass", exitCode: 0 } })],
     });
 
     const result = expectFail(assertCase(caseData, observation));
@@ -126,7 +142,7 @@ describe("assertCase: expectation diffing", () => {
   it("the diff data is sufficient to render 'expected deny / actual pass' style text", () => {
     const caseData = makeCase({ expect: makeExpect({ decision: "deny" }) });
     const observation = makeObservation({
-      decision: { kind: "pass", exitCode: 0 },
+      fired: [makeFired({ decision: { kind: "pass", exitCode: 0 } })],
     });
 
     const result = expectFail(assertCase(caseData, observation));
@@ -161,8 +177,7 @@ describe("assertCase: expectation diffing", () => {
     (field, expectation, decision) => {
       const caseData = makeCase({ expect: expectation });
       const observation = makeObservation({
-        decision,
-        execOutcome: makeExecOutcome(),
+        fired: [makeFired({ decision })],
       });
 
       const result = expectFail(assertCase(caseData, observation));
@@ -183,13 +198,17 @@ describe("assertCase: expectation diffing", () => {
       }),
     });
     const observation = makeObservation({
-      decision: { kind: "deny", source: "exit-code", exitCode: 2 },
-      execOutcome: makeExecOutcome({
-        exitCode: 2,
-        stdout: "action blocked by policy",
-        stderr: "reason: not allowed",
-        timedOut: false,
-      }),
+      fired: [
+        makeFired({
+          decision: { kind: "deny", source: "exit-code", exitCode: 2 },
+          execOutcome: makeExecOutcome({
+            exitCode: 2,
+            stdout: "action blocked by policy",
+            stderr: "reason: not allowed",
+            timedOut: false,
+          }),
+        }),
+      ],
     });
 
     const result = assertCase(caseData, observation);
@@ -203,21 +222,150 @@ describe("assertCase: expectation diffing", () => {
 
     expect(result.kind).toBe("pass");
   });
+});
 
-  it("expect.timedOut defaults the actual value to false when the fired hook carries no execOutcome", () => {
-    const caseData = makeCase({ expect: makeExpect({ timedOut: true }) });
+describe("assertCase: multiple firing hooks", () => {
+  it("a second hook's deny wins over a first hook's pass, regardless of firing order", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "pass" }) });
+    const firstHook = makeHook({ command: "./first.sh" });
+    const secondHook = makeHook({ command: "./second.sh" });
     const observation = makeObservation({
-      decision: { kind: "allow", exitCode: 0 },
-      execOutcome: undefined,
+      fired: [
+        makeFired({ hook: firstHook, decision: { kind: "pass", exitCode: 0 } }),
+        makeFired({
+          hook: secondHook,
+          decision: { kind: "deny", source: "exit-code", exitCode: 2 },
+        }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "decision",
+      expectedDecision: "pass",
+      actualDecision: "deny",
+    });
+    expect(result.decidedBy?.hook).toBe(secondHook);
+    expect(result.decidedBy?.decision).toEqual({
+      kind: "deny",
+      source: "exit-code",
+      exitCode: 2,
+    });
+  });
+
+  it("a first hook's deny still wins over a second hook's pass", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "pass" }) });
+    const firstHook = makeHook({ command: "./first.sh" });
+    const secondHook = makeHook({ command: "./second.sh" });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          hook: firstHook,
+          decision: { kind: "deny", source: "exit-code", exitCode: 2 },
+        }),
+        makeFired({ hook: secondHook, decision: { kind: "pass", exitCode: 0 } }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.hook).toBe(firstHook);
+  });
+
+  it("a second hook timing out sets timedOut: true even though the first hook did not", () => {
+    const caseData = makeCase({ expect: makeExpect({ timedOut: false }) });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          decision: { kind: "pass", exitCode: 0 },
+          execOutcome: makeExecOutcome({ timedOut: false }),
+        }),
+        makeFired({
+          decision: { kind: "pass", exitCode: 0 },
+          execOutcome: makeExecOutcome({ timedOut: true }),
+        }),
+      ],
     });
 
     const result = expectFail(assertCase(caseData, observation));
 
     expect(result.diffs).toContainEqual({
       field: "timedOut",
-      expectedTimedOut: true,
-      actualTimedOut: false,
+      expectedTimedOut: false,
+      actualTimedOut: true,
     });
+  });
+
+  it("two hooks agreeing on the same Decision kind produce a pass CaseResult, decided by the first", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "allow" }) });
+    const firstHook = makeHook({ command: "./first.sh" });
+    const secondHook = makeHook({ command: "./second.sh" });
+    const observation = makeObservation({
+      fired: [
+        makeFired({ hook: firstHook, decision: { kind: "allow", exitCode: 0 } }),
+        makeFired({ hook: secondHook, decision: { kind: "allow", exitCode: 0 } }),
+      ],
+    });
+
+    const result = expectPass(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.hook).toBe(firstHook);
+  });
+
+  it("expect.stdoutContains is satisfied when only the second hook's stdout carries the substring", () => {
+    const caseData = makeCase({
+      expect: makeExpect({ stdoutContains: "only in the second hook" }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          decision: { kind: "allow", exitCode: 0 },
+          execOutcome: makeExecOutcome({ stdout: "first hook's own output" }),
+        }),
+        makeFired({
+          decision: { kind: "allow", exitCode: 0 },
+          execOutcome: makeExecOutcome({ stdout: "only in the second hook's output" }),
+        }),
+      ],
+    });
+
+    const result = expectPass(assertCase(caseData, observation));
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("expect.stdoutContains fails when no firing hook's stdout carries the substring", () => {
+    const caseData = makeCase({
+      expect: makeExpect({ stdoutContains: "nowhere to be found" }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({ execOutcome: makeExecOutcome({ stdout: "first" }) }),
+        makeFired({ execOutcome: makeExecOutcome({ stdout: "second" }) }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs.some((diff) => diff.field === "stdoutContains")).toBe(true);
+  });
+
+  it("decidedBy is undefined when nothing fired at all", () => {
+    const caseData = makeCase();
+    const result = expectPass(assertCase(caseData, makeObservation()));
+
+    expect(result.decidedBy).toBeUndefined();
+  });
+
+  it("decidedBy names the single firing hook when exactly one fired", () => {
+    const caseData = makeCase();
+    const hook = makeHook();
+    const observation = makeObservation({ fired: [makeFired({ hook })] });
+
+    const result = expectPass(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.hook).toBe(hook);
   });
 });
 
@@ -307,8 +455,9 @@ describe("assertCase: unresolved decisions", () => {
       detected: "9.9.9",
       specRange: ">=2.1.251 <2.2.0",
     };
+    const decision: Decision = { kind: "unknown", reasons: [reason] };
     const observation = makeObservation({
-      decision: { kind: "unknown", reasons: [reason] },
+      fired: [makeFired({ decision })],
     });
 
     const result = expectUnknown(assertCase(caseData, observation));
@@ -325,13 +474,32 @@ describe("assertCase: unresolved decisions", () => {
       kind: "plugin-hooks-present",
       files: ["/etc/plugin.json"],
     };
+    const decision: Decision = { kind: "unknown", reasons: [reason] };
     const observation = makeObservation({
-      decision: { kind: "unknown", reasons: [reason] },
+      fired: [makeFired({ decision })],
     });
 
     const result = assertCase(caseData, observation);
 
     expect(result.kind).toBe("unknown");
+  });
+
+  it("a deny from one hook outranks an unknown from another, even when the unknown hook fired first", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "pass" }) });
+    const reason: UnknownReason = {
+      kind: "plugin-hooks-present",
+      files: ["/etc/plugin.json"],
+    };
+    const observation = makeObservation({
+      fired: [
+        makeFired({ decision: { kind: "unknown", reasons: [reason] } }),
+        makeFired({ decision: { kind: "deny", source: "exit-code", exitCode: 2 } }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.decision.kind).toBe("deny");
   });
 });
 
@@ -386,14 +554,27 @@ const syntheticOrigin: PayloadOrigin = { kind: "synthetic" };
 describe("summarize", () => {
   it("folds pass+fail into asserted, counts recorded-origin passes/fails into fromRecorded, and counts unknown/skipped separately", () => {
     const results: CaseResult[] = [
-      { kind: "pass", origin: syntheticOrigin },
-      { kind: "pass", origin: recordedOrigin },
-      { kind: "fail", origin: recordedOrigin, diffs: [], nonFiring: undefined },
-      { kind: "fail", origin: syntheticOrigin, diffs: [], nonFiring: undefined },
+      { kind: "pass", origin: syntheticOrigin, decidedBy: undefined },
+      { kind: "pass", origin: recordedOrigin, decidedBy: undefined },
+      {
+        kind: "fail",
+        origin: recordedOrigin,
+        diffs: [],
+        nonFiring: undefined,
+        decidedBy: undefined,
+      },
+      {
+        kind: "fail",
+        origin: syntheticOrigin,
+        diffs: [],
+        nonFiring: undefined,
+        decidedBy: undefined,
+      },
       {
         kind: "unknown",
         origin: syntheticOrigin,
         reasons: [{ kind: "plugin-hooks-present", files: [] }],
+        decidedBy: undefined,
       },
       { kind: "skipped", origin: syntheticOrigin, reason: "dry-run" },
       { kind: "skipped", origin: recordedOrigin, reason: "stub-only" },
@@ -422,13 +603,20 @@ describe("summarize", () => {
 
   it("never double-counts a case across two Summary fields", () => {
     const results: CaseResult[] = [
-      { kind: "pass", origin: syntheticOrigin },
-      { kind: "pass", origin: recordedOrigin },
-      { kind: "fail", origin: syntheticOrigin, diffs: [], nonFiring: undefined },
+      { kind: "pass", origin: syntheticOrigin, decidedBy: undefined },
+      { kind: "pass", origin: recordedOrigin, decidedBy: undefined },
+      {
+        kind: "fail",
+        origin: syntheticOrigin,
+        diffs: [],
+        nonFiring: undefined,
+        decidedBy: undefined,
+      },
       {
         kind: "unknown",
         origin: syntheticOrigin,
         reasons: [{ kind: "plugin-hooks-present", files: [] }],
+        decidedBy: undefined,
       },
       { kind: "skipped", origin: syntheticOrigin, reason: "dry-run" },
     ];

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   allowed,
+  combineDecisions,
   denied,
   errored,
   exit2OverridesAllowJson,
@@ -536,5 +537,102 @@ describe("factory functions build exactly the Decision shape they name", () => {
       exitCode: 127,
       cause: "nonzero-exit-without-json",
     });
+  });
+});
+
+describe("combineDecisions", () => {
+  /** The precedence table combineDecisions is documented to implement: deny > unknown > error > allow > pass. */
+  const KINDS = ["deny", "unknown", "error", "allow", "pass"] as const;
+  type Kind = (typeof KINDS)[number];
+  const PRECEDENCE: Readonly<Record<Kind, number>> = {
+    deny: 0,
+    unknown: 1,
+    error: 2,
+    allow: 3,
+    pass: 4,
+  };
+
+  /** One representative `Decision` of the given `kind`, distinguishable by more than just `kind`. */
+  function sample(kind: Kind): Decision {
+    switch (kind) {
+      case "deny":
+        return denied("exit-code", 2);
+      case "unknown":
+        return unknownDecision({ kind: "plugin-hooks-present", files: [] });
+      case "error":
+        return errored(1, "nonzero-exit-without-json");
+      case "allow":
+        return allowed(0);
+      case "pass":
+        return passed(0);
+    }
+  }
+
+  const everyOrderedPair = KINDS.flatMap((first) =>
+    KINDS.map((second) => [first, second] as const),
+  );
+
+  it.each(everyOrderedPair)(
+    "(%s, %s): the higher-precedence kind wins; the first hook wins a tie",
+    (firstKind, secondKind) => {
+      const decisions: readonly [Decision, ...Decision[]] = [
+        sample(firstKind),
+        sample(secondKind),
+      ];
+
+      const result = combineDecisions(decisions);
+
+      const expectedIndex = PRECEDENCE[firstKind] <= PRECEDENCE[secondKind] ? 0 : 1;
+      expect(result.index).toBe(expectedIndex);
+      expect(result.decision).toEqual(decisions[expectedIndex]);
+    },
+  );
+
+  it("a single-decision tuple returns that decision at index 0", () => {
+    const decision = sample("allow");
+
+    expect(combineDecisions([decision])).toEqual({ decision, index: 0 });
+  });
+
+  it("the full precedence order holds with all five kinds firing at once, regardless of firing order", () => {
+    const ascending: readonly [Decision, ...Decision[]] = [
+      sample("pass"),
+      sample("allow"),
+      sample("error"),
+      sample("unknown"),
+      sample("deny"),
+    ];
+    expect(combineDecisions(ascending)).toEqual({ decision: sample("deny"), index: 4 });
+
+    const descending: readonly [Decision, ...Decision[]] = [
+      sample("deny"),
+      sample("unknown"),
+      sample("error"),
+      sample("allow"),
+      sample("pass"),
+    ];
+    expect(combineDecisions(descending)).toEqual({
+      decision: sample("deny"),
+      index: 0,
+    });
+
+    const shuffled: readonly [Decision, ...Decision[]] = [
+      sample("error"),
+      sample("pass"),
+      sample("deny"),
+      sample("allow"),
+      sample("unknown"),
+    ];
+    expect(combineDecisions(shuffled)).toEqual({ decision: sample("deny"), index: 2 });
+  });
+
+  it("three hooks tied on the same kind resolve to the first one's index", () => {
+    const decisions: readonly [Decision, ...Decision[]] = [
+      sample("error"),
+      sample("error"),
+      sample("error"),
+    ];
+
+    expect(combineDecisions(decisions).index).toBe(0);
   });
 });

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { runCli, type CliDeps } from "../src/cli.js";
 import { NodeSpawner } from "../src/internal/exec/spawner.js";
@@ -163,10 +163,22 @@ interface JsonTestSummary {
   readonly skipped: number;
 }
 
+interface JsonDecidedBy {
+  readonly hook: {
+    readonly command: string;
+    readonly provenance: { readonly layer: string; readonly file: string };
+  };
+  readonly decision: { readonly kind: string };
+}
+
 interface JsonTestCase {
   readonly event: string;
   readonly tool: string | null;
-  readonly result: { readonly kind: string; readonly reason?: string };
+  readonly result: {
+    readonly kind: string;
+    readonly reason?: string;
+    readonly decidedBy?: JsonDecidedBy | null;
+  };
 }
 
 interface JsonTestReportShape {
@@ -248,6 +260,9 @@ describe("the full pipeline", () => {
     );
     expect(pretty.stdout).toContain('decision: expected "allow", got "deny"');
     expect(pretty.stdout).toContain("no hook is declared under SessionStart");
+    // Exactly one hook fired for each case here — pretty only names the
+    // deciding hook once more than one fired for the same case.
+    expect(pretty.stdout).not.toContain("decided by");
 
     const github = await runCli(
       [
@@ -265,6 +280,201 @@ describe("the full pipeline", () => {
     expect(github.stdout).toContain("::error file=");
     expect(github.stdout).toContain("test case #0");
     expect(github.stdout).toContain("test case #1");
+  });
+});
+
+describe("combining more than one firing hook (issue #42)", () => {
+  // A dedicated project/home pair per test, isolated from the shared
+  // projectDir's own settings.json: two hooks (one per settings layer) fire
+  // for the same case, and only one of them denies — proving `test` folds
+  // every firing hook's Decision (any deny wins) rather than reading back
+  // only the first one.
+  let multiHookProjectDir: string;
+  let multiHookHomeDir: string;
+
+  afterEach(() => {
+    rmSync(multiHookProjectDir, { recursive: true, force: true });
+    rmSync(multiHookHomeDir, { recursive: true, force: true });
+  });
+
+  function settingsDeclaring(script: string): unknown {
+    return {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: process.execPath, args: [script] }],
+          },
+        ],
+      },
+    };
+  }
+
+  /** One hook in the user layer, one in the project layer, each running `userScript`/`projectScript`. */
+  function setUpTwoLayers(userScript: string, projectScript: string): void {
+    multiHookProjectDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-multi-hook-project-"),
+    );
+    multiHookHomeDir = mkdtempSync(path.join(tmpdir(), "hookassert-multi-hook-home-"));
+    mkdirSync(path.join(multiHookProjectDir, ".claude"), { recursive: true });
+    mkdirSync(path.join(multiHookHomeDir, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(multiHookHomeDir, ".claude", "settings.json"),
+      JSON.stringify(settingsDeclaring(userScript), null, 2),
+    );
+    writeFileSync(
+      path.join(multiHookProjectDir, ".claude", "settings.json"),
+      JSON.stringify(settingsDeclaring(projectScript), null, 2),
+    );
+  }
+
+  function multiHookFixturePath(): string {
+    const filePath = path.join(multiHookProjectDir, "fixture.yaml");
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+        },
+        null,
+        2,
+      ),
+    );
+    return filePath;
+  }
+
+  const denyOutcomes = new Map<string, FakeOutcome>([
+    [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+  ]);
+
+  it("a project-layer deny behind a user-layer pass is reported as failing, not passing", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const fixturePath = multiHookFixturePath();
+    const spawner = new FakeSpawner(denyOutcomes);
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({
+        cwd: multiHookProjectDir,
+        home: multiHookHomeDir,
+        spawner,
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(spawner.calls).toHaveLength(2);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result.kind).toBe("fail");
+    expect(report.cases[0]?.result.decidedBy?.decision.kind).toBe("deny");
+    expect(report.cases[0]?.result.decidedBy?.hook.provenance.layer).toBe("project");
+  });
+
+  it("the verdict is identical when the two hooks' settings layers are swapped", async () => {
+    setUpTwoLayers(EXIT2_STDERR, EXIT0_SILENT);
+    const fixturePath = multiHookFixturePath();
+    const spawner = new FakeSpawner(denyOutcomes);
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({
+        cwd: multiHookProjectDir,
+        home: multiHookHomeDir,
+        spawner,
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result.kind).toBe("fail");
+    expect(report.cases[0]?.result.decidedBy?.decision.kind).toBe("deny");
+    expect(report.cases[0]?.result.decidedBy?.hook.provenance.layer).toBe("user");
+  });
+
+  it("a second hook that times out while the first did not still sets expect.timedOut's actual value to true", async () => {
+    // Two distinct scripts, one per layer: identical declarations across
+    // layers collapse into a single dedupeKey (settings/merge.ts), which
+    // would leave only one hook firing here.
+    setUpTwoLayers(EXIT0_SILENT, PRINT_ARGV);
+    const filePath = path.join(multiHookProjectDir, "fixture-timeout.yaml");
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          cases: [
+            {
+              event: "PreToolUse",
+              tool: "Bash",
+              expect: { timedOut: true },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    class TimeoutOnSecondSpawner implements Spawner {
+      readonly calls: SpawnRequest[] = [];
+      spawn(req: SpawnRequest): Promise<ExecOutcome> {
+        this.calls.push(req);
+        const timedOut = this.calls.length > 1;
+        return Promise.resolve({ exitCode: 0, stdout: "", stderr: "", timedOut });
+      }
+    }
+    const spawner = new TimeoutOnSecondSpawner();
+
+    const result = await runCli(
+      ["test", filePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ cwd: multiHookProjectDir, home: multiHookHomeDir, spawner }),
+    );
+
+    expect(spawner.calls).toHaveLength(2);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.result.kind).toBe("pass");
+  });
+
+  it("the pretty and github reporters name the deciding hook only when more than one hook fired", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const fixturePath = multiHookFixturePath();
+
+    const pretty = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({
+        cwd: multiHookProjectDir,
+        home: multiHookHomeDir,
+        spawner: new FakeSpawner(denyOutcomes),
+      }),
+    );
+    expect(pretty.stdout).toContain("decided by");
+    // The deciding hook is the project-layer one (it declares EXIT2_STDERR here).
+    expect(pretty.stdout).toContain(
+      path.join(multiHookProjectDir, ".claude", "settings.json"),
+    );
+
+    const github = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "github",
+      ],
+      "hookassert",
+      testDeps({
+        cwd: multiHookProjectDir,
+        home: multiHookHomeDir,
+        spawner: new FakeSpawner(denyOutcomes),
+      }),
+    );
+    // The deciding hook's own settings file (project layer, under cwd) is
+    // annotated instead of line 1 of the fixture.
+    expect(github.stdout).toContain("file=.claude/settings.json");
   });
 });
 

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -476,6 +476,38 @@ describe("combining more than one firing hook (issue #42)", () => {
     // annotated instead of line 1 of the fixture.
     expect(github.stdout).toContain("file=.claude/settings.json");
   });
+
+  it("a deciding hook outside the workspace keeps the github annotation on the fixture and names the hook in the message", async () => {
+    // The user layer denies here, and its settings file lives under the home
+    // dir — outside `cwd`, so an annotation pointing at it would attach to
+    // nothing in the checkout.
+    setUpTwoLayers(EXIT2_STDERR, EXIT0_SILENT);
+    const fixturePath = multiHookFixturePath();
+
+    const github = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "github",
+      ],
+      "hookassert",
+      testDeps({
+        cwd: multiHookProjectDir,
+        home: multiHookHomeDir,
+        spawner: new FakeSpawner(denyOutcomes),
+      }),
+    );
+
+    expect(github.stdout).toContain("file=fixture.yaml");
+    expect(github.stdout).not.toContain(
+      `file=${path.join(multiHookHomeDir, ".claude", "settings.json")}`,
+    );
+    expect(github.stdout).toContain("decided by");
+  });
 });
 
 describe("the consent gate", () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
   CaseResult,
   Decision,
+  DecidingHook,
   EventName,
   ExecOutcome,
   ExpectationDiff,
@@ -460,6 +461,18 @@ const hook: ResolvedHook = {
   dedupeKey: "PreToolUse::./hook.sh",
 };
 
+/** A complete `DecidingHook`, reused by the `CaseResult` cases below. */
+const decidingHook: DecidingHook = { hook, decision: { kind: "pass", exitCode: 0 } };
+
+describe("DecidingHook", () => {
+  it("carries the deciding hook and the Decision it produced", () => {
+    expectTypeOf(decidingHook).toEqualTypeOf<{
+      readonly hook: ResolvedHook;
+      readonly decision: Decision;
+    }>();
+  });
+});
+
 describe("CaseResult", () => {
   it("narrows on kind to each variant's own fields", () => {
     const narrow = (result: CaseResult): void => {
@@ -468,6 +481,7 @@ describe("CaseResult", () => {
           expectTypeOf(result).toEqualTypeOf<{
             readonly kind: "pass";
             readonly origin: PayloadOrigin;
+            readonly decidedBy: DecidingHook | undefined;
           }>();
           break;
         }
@@ -477,6 +491,7 @@ describe("CaseResult", () => {
             readonly origin: PayloadOrigin;
             readonly diffs: readonly ExpectationDiff[];
             readonly nonFiring: NonFiringExplanation | undefined;
+            readonly decidedBy: DecidingHook | undefined;
           }>();
           break;
         }
@@ -485,6 +500,7 @@ describe("CaseResult", () => {
             readonly kind: "unknown";
             readonly origin: PayloadOrigin;
             readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
+            readonly decidedBy: DecidingHook | undefined;
           }>();
           break;
         }
@@ -498,23 +514,26 @@ describe("CaseResult", () => {
         }
       }
     };
-    narrow({ kind: "pass", origin: { kind: "synthetic" } });
+    narrow({ kind: "pass", origin: { kind: "synthetic" }, decidedBy: undefined });
     narrow({
       kind: "fail",
       origin: { kind: "synthetic" },
       diffs: [{ field: "exitCode", expectedExitCode: 2, actualExitCode: 0 }],
       nonFiring: undefined,
+      decidedBy: decidingHook,
     });
     narrow({
       kind: "fail",
       origin: { kind: "synthetic" },
       diffs: [],
       nonFiring: { kind: "no-hook-configured", event: "PreToolUse" },
+      decidedBy: undefined,
     });
     narrow({
       kind: "unknown",
       origin: { kind: "synthetic" },
       reasons: [{ kind: "plugin-hooks-present", files: [] }],
+      decidedBy: decidingHook,
     });
     narrow({ kind: "skipped", origin: { kind: "synthetic" }, reason: "dry-run" });
   });
@@ -526,6 +545,7 @@ describe("CaseResult", () => {
         origin: { kind: "synthetic" },
         // @ts-expect-error reasons is a non-empty tuple, not a plain array — an empty array cannot construct it
         reasons: [],
+        decidedBy: undefined,
       };
       void result;
     };
@@ -538,6 +558,7 @@ describe("CaseResult", () => {
       kind: "unknown",
       origin: { kind: "synthetic" },
       reasons: [reason],
+      decidedBy: undefined,
     };
     expectTypeOf(result.reasons).toEqualTypeOf<
       readonly [UnknownReason, ...UnknownReason[]]
@@ -551,10 +572,35 @@ describe("CaseResult", () => {
         kind: "fail",
         origin: { kind: "synthetic" },
         diffs: [],
+        decidedBy: undefined,
       };
       void result;
     };
     expect(rejected).toBeTypeOf("function");
+  });
+
+  it("rejects a pass variant missing decidedBy", () => {
+    const rejected = (): void => {
+      // @ts-expect-error decidedBy must be present, even as undefined, per exactOptionalPropertyTypes
+      const result: CaseResult = { kind: "pass", origin: { kind: "synthetic" } };
+      void result;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("accepts decidedBy as either a DecidingHook or undefined", () => {
+    const withHook: CaseResult = {
+      kind: "pass",
+      origin: { kind: "synthetic" },
+      decidedBy: decidingHook,
+    };
+    const withoutHook: CaseResult = {
+      kind: "pass",
+      origin: { kind: "synthetic" },
+      decidedBy: undefined,
+    };
+    expectTypeOf(withHook.decidedBy).toEqualTypeOf<DecidingHook | undefined>();
+    expectTypeOf(withoutHook.decidedBy).toEqualTypeOf<DecidingHook | undefined>();
   });
 });
 


### PR DESCRIPTION
`test` previously spawned every firing hook for a case but read only the first one's outcome into the verdict, silently ignoring a second hook's deny — for example a project-layer hook sitting behind a user-layer one. `assertCase` now folds every firing hook's `Decision` through a new `combineDecisions` (any deny wins: `deny` > `unknown` > `error` > `allow` > `pass`) and names the deciding hook on `CaseResult` via `decidedBy`. `stdoutContains`, `stderrContains` and `timedOut` are checked against every firing hook's own stream, matching what a real Claude Code session shows.

Closes #42

## Release impact

Release impact: yes — MINOR. Adds the `DecidingHook` export and a `decidedBy` field to `CaseResult`'s `pass`/`fail`/`unknown` variants (`src/types.ts`, re-exported from `src/index.ts`). Additive for anything that only reads a `CaseResult`, which is the only way one is ever obtained — nothing constructs one directly.

## Test plan

- `pnpm check:quick` — exit 0, 38 test files / 1596 tests passing.
- `tests/decision.test.ts` — `combineDecisions` over every ordered pair of `Decision.kind`s, plus first-index tie-breaking and the full five-kind ordering.
- `tests/assert.test.ts` — the multi-hook fold: second hook denies, deny outranks unknown, `stdoutContains` satisfied only by the second hook, second hook times out, `decidedBy` naming.
- `tests/test-cmd.test.ts` — end-to-end two-layer fixture where only the project-layer hook denies, the identical verdict with the layers swapped, a second hook timing out, and the pretty/github reporters naming the deciding hook only for multi-hook cases.
- `tests/types.test.ts` — compile-time checks for `DecidingHook` and `CaseResult.decidedBy`.

## Review notes

A pre-merge `/code-review` pass caught that pointing a GitHub annotation at the deciding hook's provenance breaks when that hook comes from the user or enterprise layer: the path is absolute and outside `GITHUB_WORKSPACE`, so the annotation attaches to nothing and the CI marker disappears for exactly the multi-layer case this PR is about. The annotation now stays on the fixture in that case and names the deciding hook in its message instead.

https://claude.ai/code/session_01SL22JTzb3RmoXdnQGKbgLu
