### PR TITLE
chore: raise the package maxFileCount tripwire from 200 to 400 (#53)

### DIFF
--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -69,11 +69,15 @@ const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
  * limit. The values stay deliberately reviewable literals so raising one is a
  * visible policy decision rather than a silent change.
  *
+ * `maxFileCount` was raised from 200 to 400 in #53 once `src/` alone reached
+ * 199 files; a value under the current `src` module count times three is a
+ * misconfiguration, not a tighter policy.
+ *
  * @type {PackageLimits}
  */
 export const PACKAGE_LIMITS = {
   maxUnpackedBytes: 2_097_152,
-  maxFileCount: 200,
+  maxFileCount: 400,
   maxSingleFileBytes: 131_072,
 };
 

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -526,7 +526,7 @@ describe("inspectPackageEntries", () => {
   it("exposes the deliberately reviewable package limits", () => {
     expect(PACKAGE_LIMITS).toEqual({
       maxUnpackedBytes: 2 * 1024 * 1024,
-      maxFileCount: 200,
+      maxFileCount: 400,
       maxSingleFileBytes: 128 * 1024,
     });
   });


### PR DESCRIPTION
`scripts/check-package.mjs` declared `PACKAGE_LIMITS.maxFileCount: 200`. `src/` alone reached 199 shipped files at #52 (64 modules × `.js` + `.js.map` + `.d.ts`, plus the manifest, README, LICENSE, three schemas and one spec), so the next PR adding a single module tripped a check that exists to catch a bundled dependency or a committed binary — not ordinary feature work.

Closes #53

## The gate change, stated explicitly

`maxFileCount` is raised **200 → 400**. This is a deliberate policy change, not a threshold moved to make a run pass:

- **The maps stay.** They are self-contained (`inlineSources: true`, `declarationMap: false`) and are what lets a consumer's stack trace point at readable TypeScript. Dropping them to satisfy a tripwire would be a `public-api-contract` change to what a consumer receives, made for the wrong reason. Unpacked size is ~1.1 MiB against a 2 MiB ceiling, so bytes are not the pressure.
- **Why 400.** The remaining roadmap adds at most a few dozen modules, landing the tarball around 250–300 files. A bundled dependency tree large enough to matter still lands well past 400, so the tripwire keeps its purpose.
- The limits stay reviewable literals in a tracked file — not env-driven, not computed, no second "warn" threshold to maintain. `pnpm package:check` and `pnpm package:smoke` still assert every ceiling; no check is removed or skipped, and `tsconfig.build.json` is untouched.

Release impact: none — no published artifact changes.

## Test plan

- `pnpm package:check` — exit 0 (build, pack, publint, attw, consumer smoke test).
- `pnpm check:quick` — exit 0, 38 test files / 1552 tests passing.
- `tests/package.test.ts`'s pinned `PACKAGE_LIMITS` expectation updated in lockstep, so the literal cannot drift from its test.

Found while shipping #42, whose new `src/internal/decision/combine.ts` is the module that tripped the ceiling at 202 files.

https://claude.ai/code/session_01SL22JTzb3RmoXdnQGKbgLu
