### PR TITLE
chore: let tests reach an internal module through its index, drop the allowlist (#24)

### DIFF
--- a/.agents/skills/public-api-contract/SKILL.md
+++ b/.agents/skills/public-api-contract/SKILL.md
@@ -46,11 +46,14 @@ public API by accident.
   directory, not the name, is what makes it private. Exporting one of its symbols from
   `index.ts` publishes it. Enforced by the public-api/internal-stays-private block in
   `eslint.config.mjs`, a `src/index.ts`-scoped `no-restricted-syntax` rule.
-- Nothing outside `src/**` may import from `src/internal/` directly; reach it only
-  through what `index.ts` re-exports. Enforced by the
-  boundaries/internal-is-not-importable block in `eslint.config.mjs`, a
-  `no-restricted-imports` rule over `tests/**/*.ts` and `scripts/**/*.mjs`. It covers
-  the built copy under dist as well as the source — the same private module either way.
+- Nothing outside `src/**` may import from `src/internal/` directly, except `tests/**`,
+  which may import a module's `index.ts` — a test is not a consumer. Repository
+  automation is: `scripts/**/*.mjs` reaches the package only through what `src/index.ts`
+  re-exports. Enforced by two `no-restricted-imports` blocks in `eslint.config.mjs` —
+  boundaries/internal-is-not-importable over `scripts/**/*.mjs` (unconditional) and
+  boundaries/tests-reach-internal-through-its-index over `tests/**/*.ts` (index-only).
+  Both cover the built copy under dist as well as the source — the same private module
+  either way, and a test never reads build output.
 
 ## `package.json` allowlists
 

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -23,10 +23,14 @@ tests (`type-testing`), the shape of the error classes a test asserts against
   `it("rejects a fractional timeout", ...)`, not `it("calls validate")`.
 - One behavior per `it`. Branching inside a test body belongs in a separate `it` or an
   `it.each` table, never an `if` in the test.
-- Test public behavior through `src/index.ts`'s exports, never through
-  `src/internal/**`. The interface is the test surface: if you find yourself wanting to
-  reach past a module's exports to assert something, the module is the wrong shape, not
-  the test.
+- Test a module through its own index. Public behavior goes through `src/index.ts`'s
+  exports; an internal module — most of the static layer has no public surface and never
+  will — is tested through `src/internal/<dir>/index.ts` (or `src/internal/errors.ts`).
+  **Never import a file beneath a module's index.** A symbol that is not on the index is
+  one the module has not decided to expose, and a test must not decide for it: if you
+  find yourself wanting to reach past it, either the module should export the symbol or
+  it is the wrong shape — the test is not the place to settle that. Enforced by the
+  boundaries/tests-reach-internal-through-its-index block in `eslint.config.mjs`.
 - Cover the happy path and the error path of every public function.
 
 ## Asserting errors
@@ -50,11 +54,11 @@ the failure path too, not only on success.
 
 The observable contract of a command is `argv` → exit code, stdout, and stderr. Drive
 that contract through the CLI entry, such as `src/cli.ts`'s exported runner, and assert
-the complete result for representative arguments. Do not reach into `src/internal/` to
-make command logic testable; if direct unit access is required, the
-`public-api-contract` decision makes that logic public instead. A child-process test may
-exercise the installed command path when the executable boundary itself matters, but it
-should still assert only those caller-visible streams and status.
+the complete result for representative arguments. Do not reach past a module's index to
+make command logic testable; if direct unit access is required, the module's own
+`index.ts` exports it, or the `public-api-contract` decision makes that logic public. A
+child-process test may exercise the installed command path when the executable boundary
+itself matters, but it should still assert only those caller-visible streams and status.
 
 ## Expected values come from outside the code
 

--- a/.claude/skills/public-api-contract/SKILL.md
+++ b/.claude/skills/public-api-contract/SKILL.md
@@ -46,11 +46,14 @@ public API by accident.
   directory, not the name, is what makes it private. Exporting one of its symbols from
   `index.ts` publishes it. Enforced by the public-api/internal-stays-private block in
   `eslint.config.mjs`, a `src/index.ts`-scoped `no-restricted-syntax` rule.
-- Nothing outside `src/**` may import from `src/internal/` directly; reach it only
-  through what `index.ts` re-exports. Enforced by the
-  boundaries/internal-is-not-importable block in `eslint.config.mjs`, a
-  `no-restricted-imports` rule over `tests/**/*.ts` and `scripts/**/*.mjs`. It covers
-  the built copy under dist as well as the source — the same private module either way.
+- Nothing outside `src/**` may import from `src/internal/` directly, except `tests/**`,
+  which may import a module's `index.ts` — a test is not a consumer. Repository
+  automation is: `scripts/**/*.mjs` reaches the package only through what `src/index.ts`
+  re-exports. Enforced by two `no-restricted-imports` blocks in `eslint.config.mjs` —
+  boundaries/internal-is-not-importable over `scripts/**/*.mjs` (unconditional) and
+  boundaries/tests-reach-internal-through-its-index over `tests/**/*.ts` (index-only).
+  Both cover the built copy under dist as well as the source — the same private module
+  either way, and a test never reads build output.
 
 ## `package.json` allowlists
 

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -23,10 +23,14 @@ tests (`type-testing`), the shape of the error classes a test asserts against
   `it("rejects a fractional timeout", ...)`, not `it("calls validate")`.
 - One behavior per `it`. Branching inside a test body belongs in a separate `it` or an
   `it.each` table, never an `if` in the test.
-- Test public behavior through `src/index.ts`'s exports, never through
-  `src/internal/**`. The interface is the test surface: if you find yourself wanting to
-  reach past a module's exports to assert something, the module is the wrong shape, not
-  the test.
+- Test a module through its own index. Public behavior goes through `src/index.ts`'s
+  exports; an internal module — most of the static layer has no public surface and never
+  will — is tested through `src/internal/<dir>/index.ts` (or `src/internal/errors.ts`).
+  **Never import a file beneath a module's index.** A symbol that is not on the index is
+  one the module has not decided to expose, and a test must not decide for it: if you
+  find yourself wanting to reach past it, either the module should export the symbol or
+  it is the wrong shape — the test is not the place to settle that. Enforced by the
+  boundaries/tests-reach-internal-through-its-index block in `eslint.config.mjs`.
 - Cover the happy path and the error path of every public function.
 
 ## Asserting errors
@@ -50,11 +54,11 @@ the failure path too, not only on success.
 
 The observable contract of a command is `argv` → exit code, stdout, and stderr. Drive
 that contract through the CLI entry, such as `src/cli.ts`'s exported runner, and assert
-the complete result for representative arguments. Do not reach into `src/internal/` to
-make command logic testable; if direct unit access is required, the
-`public-api-contract` decision makes that logic public instead. A child-process test may
-exercise the installed command path when the executable boundary itself matters, but it
-should still assert only those caller-visible streams and status.
+the complete result for representative arguments. Do not reach past a module's index to
+make command logic testable; if direct unit access is required, the module's own
+`index.ts` exports it, or the `public-api-contract` decision makes that logic public. A
+child-process test may exercise the installed command path when the executable boundary
+itself matters, but it should still assert only those caller-visible streams and status.
 
 ## Expected values come from outside the code
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,7 +67,10 @@ const DYNAMIC_LAYER_SPECIFIERS = DYNAMIC_LAYER.flatMap((directory) => [
 
 /** What `src/internal/**` is, in the words of the rule that made it private. */
 const INTERNAL_IS_PRIVATE =
-  'src/internal/ is private: see "Architecture" in AGENTS.md. Tests reach it through the public surface in src/index.ts (see the `writing-tests` skill), and repository automation must not depend on package internals at all.';
+  'src/internal/ is private: see "Architecture" in AGENTS.md. Repository automation is a consumer and must reach the package through src/index.ts, never through package internals.';
+
+const INTERNAL_INDEX_ONLY =
+  "A test reaches an internal module through its own index: import src/internal/<dir>/index.js (or src/internal/errors.js), never a file beneath it. A symbol that is not on the module's index is one the module has not decided to expose, and a test must not decide for it. See the `writing-tests` skill. dist/internal/ is never importable from a test: a test reads source, not build output.";
 
 /**
  * Read one property off a value of unknown shape.
@@ -321,8 +324,12 @@ export default defineConfig([
     },
   },
   {
+    // Repository automation is a consumer, and a consumer goes through
+    // `src/index.ts`. Nothing under either internal tree is importable here,
+    // unconditionally — `scripts/**` gets no equivalent of the tests/**
+    // index exception below.
     name: "boundaries/internal-is-not-importable",
-    files: ["tests/**/*.ts", "scripts/**/*.mjs"],
+    files: ["scripts/**/*.mjs"],
     rules: {
       "no-restricted-imports": [
         "error",
@@ -346,48 +353,54 @@ export default defineConfig([
     },
   },
   {
-    // `boundaries/internal-is-not-importable`'s own message says a test
-    // "reaches [src/internal/] through the public surface in src/index.ts" —
-    // true once a static-layer module is wired into the CLI, but every
-    // static module (settings, spec, matcher, fixture, decision, assert,
-    // lint, report) is built and TDD'd in its own issue *before* the
-    // cli-explain issue that wires it up, and `src/index.ts` can never
-    // re-export anything under `./internal/` at all (see
-    // `public-api/internal-stays-private` above) — there is no public
-    // surface for these modules to reach through yet, and never will be one
-    // for their internal types. Without this narrow exception a static
-    // module's own dedicated unit test could not import it, and `src/**`'s
-    // coverage floor (see `vitest.config.ts`) would fail on every line the
-    // untested module added, for as long as that module has no consumer.
+    // A test is not a consumer. Every static-layer module is built and TDD'd
+    // in its own issue *before* the CLI issue that wires it up, and
+    // `src/index.ts` can never re-export anything under `./internal/` at all
+    // (see `public-api/internal-stays-private` above) — so there is no public
+    // surface for these modules to be tested through, and never will be one
+    // for their internal types.
     //
-    // This is deliberately an explicit per-file allowlist, the same shape as
-    // `vitest.config.ts`'s `automationTests` list, rather than a directory
-    // glob: each static module's own test file is added here individually,
-    // by name, when it is created — never a blanket carve-out for
-    // `tests/**/*.ts`, and never for `scripts/**/*.mjs`, which
-    // `boundaries/internal-is-not-importable` continues to cover in full.
-    // `boundaries.test.ts` asserts the general rule is still registered and
-    // still reaches every static directory; nothing here narrows that
-    // assertion, only what a handful of named files may additionally do.
-    name: "tests/static-layer-unit-tests",
-    files: [
-      "tests/settings.test.ts",
-      "tests/spec.test.ts",
-      "tests/decision.test.ts",
-      "tests/executor.test.ts",
-      "tests/matcher.test.ts",
-      "tests/cli.test.ts",
-      "tests/report.test.ts",
-      "tests/reporters.test.ts",
-      "tests/fixture.test.ts",
-      "tests/assert.test.ts",
-      "tests/test-cmd.test.ts",
-      "tests/lint.test.ts",
-      "tests/record.test.ts",
-      "tests/troubleshooting-map.test.ts",
-    ],
+    // The boundary that is real here is not "internal is unreachable" but
+    // "internal is reachable only where the module says so": a module's own
+    // `index.ts` is its test surface, and a test that reaches past it into
+    // `exec/spawner.js` or `settings/edit.js` is depending on a shape the
+    // module never published. That is what the negations below express, and
+    // it is why this replaced a per-file allowlist that had grown to name
+    // every test file it applied to (#24) — a rule switched off everywhere it
+    // would fire is a ritual, not a boundary.
+    name: "boundaries/tests-reach-internal-through-its-index",
+    files: ["tests/**/*.ts"],
     rules: {
-      "no-restricted-imports": "off",
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              // Gitignore-style negation: forbid the whole internal tree, then
+              // carve back the two spellings a test may name — a module
+              // directory's own index, and the shared error vocabulary, which
+              // is a bare module with no directory of its own.
+              group: [
+                // No bare "**/src/internal" here, unlike the scripts zone:
+                // gitignore semantics cannot re-include a path below an
+                // excluded *directory*, so listing the directory itself would
+                // silently defeat both negations below and forbid even a
+                // module index. There is no `src/internal/index.ts` for a bare
+                // specifier to resolve to anyway.
+                "**/src/internal/**",
+                "!**/src/internal/*",
+                "**/src/internal/*.js",
+                "!**/src/internal/errors.js",
+                "**/src/internal/*/**",
+                "!**/src/internal/*/index.js",
+                "**/dist/internal",
+                "**/dist/internal/**",
+              ],
+              message: INTERNAL_INDEX_ONLY,
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -15,16 +15,9 @@ import type {
   UnknownReason,
 } from "../src/types.js";
 
-// Reaching src/internal/assert/, src/internal/fixture/, and
-// src/internal/matcher/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: none of these modules has a public runtime surface in this
-// issue and assertCase/summarize won't have one until a later `test`-command
-// issue's composition root wires them in — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning. The
-// *published types* (`CaseResult`, `Summary`, `ExecOutcome`, `PayloadOrigin`,
-// `UnknownReason`, ...) are already part of the public contract, so those
-// come from "../src/types.js" like any other type test's imports.
+// The *published types* (`CaseResult`, `Summary`, `ExecOutcome`, `PayloadOrigin`,
+// `UnknownReason`, ...) are part of the public contract, so those come from
+// "../src/types.js" like any other type test's imports.
 
 let nextOffset = 0;
 

--- a/tests/boundaries.test.ts
+++ b/tests/boundaries.test.ts
@@ -21,6 +21,8 @@ import eslintConfig from "../eslint.config.mjs";
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const ZONE_NAME = "boundaries/static-does-not-reach-dynamic";
+const TESTS_ZONE_NAME = "boundaries/tests-reach-internal-through-its-index";
+const SCRIPTS_ZONE_NAME = "boundaries/internal-is-not-importable";
 
 /** The static layer, from AGENTS.md's Architecture section. */
 const STATIC_DIRECTORIES = [
@@ -52,10 +54,10 @@ function readStringArray(value: unknown, key: string): readonly string[] {
     : [];
 }
 
-function zone(): unknown {
-  const found = configs.find((entry) => readKey(entry, "name") === ZONE_NAME);
+function zone(name: string = ZONE_NAME): unknown {
+  const found = configs.find((entry) => readKey(entry, "name") === name);
   if (found === undefined) {
-    throw new Error(`eslint.config.mjs declares no config named ${ZONE_NAME}`);
+    throw new Error(`eslint.config.mjs declares no config named ${name}`);
   }
   return found;
 }
@@ -68,14 +70,14 @@ function zone(): unknown {
  * module could use have to appear in this list. Reading the options rather
  * than the file's text means a reformat or a reordering cannot break it.
  */
-function restrictedGroups(): readonly string[] {
-  const setting = readKey(readKey(zone(), "rules"), "no-restricted-imports");
+function restrictedGroups(name: string = ZONE_NAME): readonly string[] {
+  const setting = readKey(readKey(zone(name), "rules"), "no-restricted-imports");
   // A rule setting is `[severity, options]`, and an array index is an ordinary
   // key — reading it through `readKey` keeps the value `unknown` instead of
   // widening to `any` the way `Array.isArray` narrowing would.
   const patterns = readKey(readKey(setting, "1"), "patterns");
   if (!Array.isArray(patterns)) {
-    throw new Error(`${ZONE_NAME} declares no no-restricted-imports patterns`);
+    throw new Error(`${name} declares no no-restricted-imports patterns`);
   }
   return patterns.flatMap((pattern: unknown) => readStringArray(pattern, "group"));
 }
@@ -133,5 +135,70 @@ describe("the zone as ESLint resolves it", () => {
 
   it("does not apply to the composition root", async () => {
     expect(await restrictedImportsFor("src/cli.ts")).toBeUndefined();
+  });
+});
+
+describe("tests reach internal modules only through a module's index", () => {
+  it("forbids the internal tree, then negates a module's index and errors.js", () => {
+    const groups = restrictedGroups(TESTS_ZONE_NAME);
+    expect(groups).toContain("**/src/internal/**");
+    // Gitignore-style negations: the two spellings a test may still name.
+    expect(groups).toContain("!**/src/internal/*/index.js");
+    expect(groups).toContain("!**/src/internal/errors.js");
+    // Build output stays unreachable regardless: a test reads source.
+    expect(groups).toContain("**/dist/internal/**");
+  });
+
+  it("scopes that exception to tests/** and nothing else", () => {
+    expect(readStringArray(zone(TESTS_ZONE_NAME), "files")).toEqual(["tests/**/*.ts"]);
+  });
+
+  it("keeps scripts/** on the unconditional form, with no index negation", () => {
+    // Automation is a consumer, and a consumer goes through src/index.ts.
+    const groups = restrictedGroups(SCRIPTS_ZONE_NAME);
+    expect(groups).toContain("**/src/internal/**");
+    expect(groups).toContain("**/dist/internal/**");
+    expect(groups.filter((group) => group.startsWith("!"))).toEqual([]);
+    expect(readStringArray(zone(SCRIPTS_ZONE_NAME), "files")).toEqual([
+      "scripts/**/*.mjs",
+    ]);
+  });
+
+  it("declares no config that switches no-restricted-imports off entirely", () => {
+    // The per-file allowlist this replaced (#24) had grown to name every test
+    // file the rule applied to. A rule switched off wherever it would fire is
+    // a ritual, not a boundary — this is what stops one growing back.
+    const disabling = configs.filter(
+      (entry) => readKey(readKey(entry, "rules"), "no-restricted-imports") === "off",
+    );
+    expect(disabling).toEqual([]);
+  });
+});
+
+describe("the tests zone as ESLint resolves it", () => {
+  const eslint = new ESLint({ cwd: repoRoot });
+
+  async function groupsFor(relative: string): Promise<readonly string[]> {
+    const config: unknown = await eslint.calculateConfigForFile(
+      path.join(repoRoot, relative),
+    );
+    const setting = readKey(readKey(config, "rules"), "no-restricted-imports");
+    const patterns = readKey(readKey(setting, "1"), "patterns");
+    if (!Array.isArray(patterns)) {
+      throw new Error(`no no-restricted-imports patterns resolved for ${relative}`);
+    }
+    return patterns.flatMap((pattern: unknown) => readStringArray(pattern, "group"));
+  }
+
+  it("resolves the index negations for a test file", async () => {
+    expect(await groupsFor("tests/settings.test.ts")).toContain(
+      "!**/src/internal/*/index.js",
+    );
+  });
+
+  it("resolves no negation at all for repository automation", async () => {
+    const groups = await groupsFor("scripts/check-package.mjs");
+    expect(groups).toContain("**/src/internal/**");
+    expect(groups.filter((group) => group.startsWith("!"))).toEqual([]);
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -13,17 +13,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { isMain, main, runCli, type CliDeps } from "../src/cli.js";
-import { createUnimplementedSpawner } from "../src/internal/exec/spawner.js";
-import type { Spawner, SpawnRequest } from "../src/internal/exec/spawner.js";
+import { createUnimplementedSpawner } from "../src/internal/exec/index.js";
+import type { Spawner, SpawnRequest } from "../src/internal/exec/index.js";
 import type { ExecOutcome } from "../src/types.js";
-
-// Reaching src/internal/exec/spawner.ts directly (rather than through
-// src/index.ts's exports, per the writing-tests skill) is a deliberate,
-// narrowly scoped exception: explain's zero-spawn guarantee can only be
-// proven by injecting a real `Spawner` implementation into its dependency
-// graph, and that interface has no public surface — see
-// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
-// reasoning.
 
 const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/cli/", import.meta.url));
 const PROJECT_WITH_HOOKS_DIR = path.join(FIXTURES_DIR, "project-with-hooks");

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -70,11 +70,12 @@ interface SpecLike {
 
 /**
  * The real spec, read as plain JSON -- never through `loadSpecFile`
- * (`src/internal/spec/index.js`), which is off limits here: `tests/conformance
- * .test.ts` is not in eslint.config.mjs's `tests/static-layer-unit-tests`
- * allowlist, matching the design's black-box constraint (this issue treats
+ * (`src/internal/spec/index.js`). Lint would now permit that import, since a
+ * test may reach a module through its own index; the constraint here is the
+ * design's, not the linter's. This suite is black-box on purpose: it treats
  * the spec the same way scripts/conformance.mjs itself does -- as data, not
- * as an import).
+ * as an import -- so a bug in the loader cannot hide a conformance failure by
+ * being on both sides of the comparison.
  */
 const REAL_SPEC = JSON.parse(readFileSync(SPEC_PATH, "utf8")) as SpecLike;
 

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -17,15 +17,9 @@ import type { EventSpec, Spec } from "../src/internal/spec/index.js";
 import { loadSpecFile } from "../src/internal/spec/index.js";
 import type { Decision, EventName, ExecOutcome, UnknownReason } from "../src/types.js";
 
-// Reaching src/internal/decision/ and src/internal/spec/ directly (rather
-// than through src/index.ts's exports, per the writing-tests skill) is a
-// deliberate, narrowly scoped exception: neither module has a public runtime
-// surface in this issue and won't have one until a later executor issue's
-// composition root wires them in — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning. The
-// *published types* (`Decision`, `UnknownReason`, `ExecOutcome`) are already
-// part of the public contract, so those come from "../src/types.js" like any
-// other type test's imports.
+// The *published types* (`Decision`, `UnknownReason`, `ExecOutcome`) are part
+// of the public contract, so those come from "../src/types.js" like any other
+// type test's imports.
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -27,14 +27,6 @@ import { resolveDecision } from "../src/internal/decision/index.js";
 import { loadSpecFile } from "../src/internal/spec/index.js";
 import type { EventName, ExecOutcome, Provenance, ResolvedHook } from "../src/types.js";
 
-// Reaching src/internal/exec/, src/internal/fixture/, src/internal/decision/
-// and src/internal/spec/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: the executor has no public surface in this issue and won't have
-// one until a later test-cmd issue's composition root wires it in — see
-// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
-// reasoning.
-
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const REAL_SPEC = loadSpecFile(REAL_SPEC_PATH);

--- a/tests/fixture.test.ts
+++ b/tests/fixture.test.ts
@@ -20,12 +20,6 @@ import {
 } from "../src/internal/fixture/index.js";
 import { loadSpecFile } from "../src/internal/spec/index.js";
 
-// Reaching src/internal/fixture/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: this module has no public surface in this issue and never will
-// have one for its own plumbing types — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning.
-
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const SCHEMA_PATH = path.join(REPO_ROOT, "schema", "fixture.schema.json");

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -26,13 +26,6 @@ import type { SettingsSource } from "../src/internal/settings/index.js";
 import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
 import type { Spec } from "../src/internal/spec/index.js";
 
-// Reaching src/internal/lint/, src/internal/spec/, src/internal/matcher/,
-// and src/internal/settings/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: none of these modules has a public surface in this issue and
-// never will one for their own plumbing types — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning.
-
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const REAL_SPEC: Spec = loadSpecFile(REAL_SPEC_PATH);

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -9,13 +9,6 @@ import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js"
 import type { Spec } from "../src/internal/spec/index.js";
 import type { EventName, Provenance, ResolvedHook } from "../src/types.js";
 
-// Reaching src/internal/matcher/ and src/internal/spec/ directly (rather
-// than through src/index.ts's exports, per the writing-tests skill) is a
-// deliberate, narrowly scoped exception: this module has no public surface
-// in this issue and never will one for its own plumbing types — see
-// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
-// reasoning.
-
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 

--- a/tests/record.test.ts
+++ b/tests/record.test.ts
@@ -26,11 +26,14 @@ import {
   loadSourceHooks,
   mergeSources,
 } from "../src/internal/settings/index.js";
-import { insertCaptureHook, removeCaptureHook } from "../src/internal/settings/edit.js";
-import type { CapturePlan } from "../src/internal/settings/edit.js";
+import {
+  insertCaptureHook,
+  removeCaptureHook,
+} from "../src/internal/settings/index.js";
+import type { CapturePlan } from "../src/internal/settings/index.js";
 import { matchHooks } from "../src/internal/matcher/index.js";
 import { loadSpecFile } from "../src/internal/spec/index.js";
-import { buildCaptureScript } from "../src/internal/record/capture.js";
+import { buildCaptureScript } from "../src/internal/record/index.js";
 import {
   defaultCaptureDir,
   hookassertDir,
@@ -40,19 +43,12 @@ import {
   sessionFilePath,
   startRecordSession,
   stopRecordSession,
-} from "../src/internal/record/session.js";
-import type { SettingsSource } from "../src/internal/settings/types.js";
+} from "../src/internal/record/index.js";
+import type { SettingsSource } from "../src/internal/settings/index.js";
 
-// Reaching src/internal/settings/, src/internal/record/, src/internal/matcher/
-// and src/internal/spec/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: none of this issue's own plumbing (CapturePlan, CaptureAnchors,
-// the record session bookkeeping) has a public surface, or ever will — see
-// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
-// reasoning. This file does real filesystem work under mkdtemp and spawns
-// the generated capture script as a real process, which is why it joins
-// vitest.config.ts's automationTests list rather than the default unit
-// project.
+// This file does real filesystem work under mkdtemp and spawns the generated
+// capture script as a real process, which is why it joins vitest.config.ts's
+// automationTests list rather than the default unit project.
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -5,13 +5,6 @@ import { buildReportHeader, renderPretty } from "../src/internal/report/index.js
 import type { ExplainReport } from "../src/internal/report/index.js";
 import type { Provenance, ResolvedHook } from "../src/types.js";
 
-// Reaching src/internal/report/ and src/internal/matcher/ directly (rather
-// than through src/index.ts's exports, per the writing-tests skill) is a
-// deliberate, narrowly scoped exception: neither module has a public surface
-// in this issue and never will one for its own plumbing types — see
-// eslint.config.mjs's "tests/static-layer-unit-tests" block for the full
-// reasoning.
-
 function makeProvenance(overrides: Partial<Provenance> = {}): Provenance {
   return {
     file: "/abs/project/.claude/settings.json",

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import { runCli } from "../src/cli.js";
 import { UsageError } from "../src/internal/errors.js";
-import { createUnimplementedSpawner } from "../src/internal/exec/spawner.js";
+import { createUnimplementedSpawner } from "../src/internal/exec/index.js";
 import type { MatcherOutcome } from "../src/internal/matcher/index.js";
 import {
   isReportFormat,
@@ -25,14 +25,6 @@ import {
 } from "../src/internal/report/index.js";
 import { hooksForEvent, loadSettings } from "../src/internal/settings/index.js";
 import type { Provenance, ResolvedHook } from "../src/types.js";
-
-// Reaching src/internal/report/, src/internal/matcher/,
-// src/internal/settings/ and src/internal/exec/ directly (rather than through
-// src/index.ts's exports, per the writing-tests skill) is a deliberate,
-// narrowly scoped
-// exception: none of these modules has a public surface in this issue and
-// never will one for its own plumbing types — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning.
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const SCHEMA_PATH = path.join(REPO_ROOT, "schema", "report.schema.json");

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -15,15 +15,8 @@ import type {
   RawHook,
   ResolvedSettings,
   SettingsSource,
-} from "../src/internal/settings/types.js";
+} from "../src/internal/settings/index.js";
 import type { EventName, SettingsLayer } from "../src/types.js";
-
-// Reaching src/internal/settings/ directly (rather than through
-// src/index.ts's exports, per the writing-tests skill) is a deliberate,
-// narrowly scoped exception: this module has no public surface in this
-// issue and never will one for its own plumbing types (SettingsSource,
-// ResolvedSettings) — see eslint.config.mjs's "tests/static-layer-unit-tests"
-// block for the full reasoning.
 
 const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/settings/", import.meta.url));
 

--- a/tests/spec.test.ts
+++ b/tests/spec.test.ts
@@ -17,12 +17,6 @@ import {
 } from "../src/internal/spec/index.js";
 import type { EventName } from "../src/types.js";
 
-// Reaching src/internal/spec/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception: this module has no public surface in this issue and never will
-// one for its own plumbing types — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning.
-
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const SCHEMA_PATH = path.join(REPO_ROOT, "schema", "spec.schema.json");

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -7,17 +7,9 @@ import { fileURLToPath } from "node:url";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { runCli, type CliDeps } from "../src/cli.js";
-import { NodeSpawner } from "../src/internal/exec/spawner.js";
-import type { Spawner, SpawnRequest } from "../src/internal/exec/spawner.js";
+import { NodeSpawner } from "../src/internal/exec/index.js";
+import type { Spawner, SpawnRequest } from "../src/internal/exec/index.js";
 import type { ExecOutcome } from "../src/types.js";
-
-// Reaching src/internal/exec/spawner.ts directly (rather than through
-// src/index.ts's exports, per the writing-tests skill) is a deliberate,
-// narrowly scoped exception, the same one tests/cli.test.ts and
-// tests/executor.test.ts already take: `Spawner` has no public surface, and
-// this file's whole point is proving `test`'s consent gate and spawn plan
-// mechanically through an injected one — see eslint.config.mjs's
-// "tests/static-layer-unit-tests" block for the full reasoning.
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const HOOKS_DIR = fileURLToPath(new URL("./fixtures/hooks/", import.meta.url));

--- a/tests/troubleshooting-map.test.ts
+++ b/tests/troubleshooting-map.test.ts
@@ -5,13 +5,6 @@ import { describe, expect, it } from "vitest";
 
 import { LINT_RULES } from "../src/internal/lint/index.js";
 
-// Reaching src/internal/lint/ directly (rather than through src/index.ts's
-// exports, per the writing-tests skill) is a deliberate, narrowly scoped
-// exception — see eslint.config.mjs's "tests/static-layer-unit-tests" block,
-// which this file is added to, for the full reasoning: none of the static
-// layer has a public surface to reach through, and never will one for its
-// own plumbing types.
-
 const DOC_PATH = fileURLToPath(
   new URL("../docs/troubleshooting-map.md", import.meta.url),
 );


### PR DESCRIPTION
`boundaries/internal-is-not-importable` forbade `tests/**` from importing `src/internal/**`, on the stated grounds that a test "reaches it through the public surface in `src/index.ts`". But `src/index.ts` can never re-export anything under `src/internal/` (`public-api/internal-stays-private` enforces that), and every static-layer module is built and TDD'd before the CLI issue that wires it up — so the premise was false, and the repository routed around it with a `tests/static-layer-unit-tests` per-file allowlist that had grown to name all 14 test files the rule applied to. A rule switched off wherever it would fire is a ritual, not a boundary.

Closes #24

## The gate change, stated explicitly

The single zone splits by audience. Neither half is a relaxation of what was actually being enforced — the allowlist meant `tests/**` had **no** restriction at all, and this replaces that with a real one.

- **`scripts/**/*.mjs` — unchanged and unconditional.** Automation is a consumer, and a consumer goes through `src/index.ts`. Nothing under `src/internal/**` or `dist/internal/**` is importable, with no index exception.
- **`tests/**/*.ts` — new, index-only.** A test may import `src/internal/<dir>/index.js` and `src/internal/errors.js`, and nothing beneath them. A symbol that is not on a module's index is one the module has not decided to expose, and a test must not decide for it. `dist/internal/**` stays unreachable: a test reads source, not build output.

The eleven imports that reached past a module index (`exec/spawner.js`, `settings/edit.js`, `settings/types.js`, `record/capture.js`, `record/session.js` across five test files) are rewritten to the module's own index. Every symbol was already re-exported there, so no index gained an export to accommodate a test.

### One correction to the issue's design

The issue specified the patterns as `**/src/internal/**` plus the negations `!**/src/internal/*/index.js` and `!**/src/internal/errors.js`. **That does not work.** Gitignore semantics cannot re-include a path below an excluded *directory*, and `**/src/internal/**` excludes the module directories themselves — written as designed, the rule rejects `settings/index.js` and `errors.js` too, which would block essentially every test in the repository. Verified by hand before settling on the standard re-include idiom now in the config:

```js
"**/src/internal/**",
"!**/src/internal/*",          // re-include the module directories
"**/src/internal/*.js",        // re-exclude bare files under internal/
"!**/src/internal/errors.js",  // …except the shared error vocabulary
"**/src/internal/*/**",        // re-exclude module contents
"!**/src/internal/*/index.js", // …except each module's own index
```

The comment in `eslint.config.mjs` records why the bare `**/src/internal` directory pattern is present in the scripts zone but deliberately absent here.

Release impact: none — no published artifact or type changes. Lint scope, test imports, and two skills only.

## Test plan

- `pnpm check` (the full gate: format, lint, typecheck, coverage, build, docs, pack, publint, attw, consumer smoke) — **exit 0, 38 test files / 1602 tests passing**.
- `pnpm agents:sync && pnpm agents:check` — `.claude/skills/` in sync with the authored `.agents/skills/`.
- `tests/boundaries.test.ts` gains 8 assertions: the `tests/**` zone declares the internal-tree pattern, both index negations and the `dist/internal` exclusion; it is scoped to `tests/**/*.ts` alone; `scripts/**` keeps the unconditional form with **no** negation; no config anywhere sets `no-restricted-imports` to `"off"` (the guard against the allowlist growing back); and two checks resolve the rule through `ESLint#calculateConfigForFile` for a real test file and a real script.

### By-hand rejection check (required by the issue's checklist)

A scratch test importing both an allowed and a forbidden specifier, linted and then removed:

```
tests/zz-probe.test.ts
  3:1  error  '../src/internal/settings/types.js' import is restricted from being used by a pattern…
  4:1  error  '../src/internal/exec/spawner.js' import is restricted from being used by a pattern…

✖ 2 problems (2 errors, 0 warnings)
```

`../src/internal/errors.js` and `../src/internal/settings/index.js` were in the same file and drew no error — the boundary permits exactly the two intended spellings and rejects the two deep ones.

https://claude.ai/code/session_01SL22JTzb3RmoXdnQGKbgLu
