### PR TITLE
feat: implement explain --emit-fixtures, turning captured payloads into fixtures (#16)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,8 @@ import {
 } from "./internal/fixture/index.js";
 import { buildLintContext, LINT_RULES } from "./internal/lint/index.js";
 import {
+  defaultCaptureDir,
+  emitFixtures,
   isRecordSessionActive,
   startRecordSession,
   stopRecordSession,
@@ -353,14 +355,81 @@ function resolveVersionContext(
   }
 }
 
-/** `explain`'s own option table: `common` plus `--emit-fixtures`. */
+/** `explain`'s own option table: `common` plus `--emit-fixtures` and `--capture-dir`. */
 const EXPLAIN_OPTIONS = {
   settings: { type: "string", multiple: true },
   "claude-version": { type: "string" },
   format: { type: "string" },
   "emit-fixtures": { type: "string" },
+  "capture-dir": { type: "string" },
   help: { type: "boolean", short: "h" },
 } as const;
+
+/**
+ * Read every captured payload envelope and write one fixture YAML file per
+ * envelope into `--emit-fixtures`' own directory argument.
+ *
+ * @remarks
+ * A standalone mode of `explain`, the same way `record --stop` is a
+ * standalone mode of `record`: it takes no `<event>`/`[tool]` and none of
+ * `--settings`/`--claude-version`/`--format`, because it never matches hooks
+ * or renders an `ExplainReport` at all — it only reads `record`'s own
+ * captured envelopes and writes fixture files, so an option that means
+ * something for that other mode would silently do nothing here. Only
+ * `--capture-dir` (the source directory to read envelopes from, defaulting
+ * to `record`'s own {@link defaultCaptureDir}, mirroring `record`'s own flag
+ * of the same name) applies alongside it.
+ *
+ * @throws {UsageError} a positional argument, or one of
+ * `--settings`/`--claude-version`/`--format`, was given alongside
+ * `--emit-fixtures`.
+ * (Also propagates `RecordNoCapturesError` from `emitFixtures` when the
+ * capture directory holds no readable envelopes.)
+ */
+function runExplainEmitFixtures(
+  parsed: ReturnType<typeof parseArgsForExplain>,
+  deps: CliDeps,
+  emitFixturesDir: string,
+): CliResult {
+  if (
+    parsed.positionals.length > 0 ||
+    parsed.values.settings !== undefined ||
+    parsed.values["claude-version"] !== undefined ||
+    parsed.values.format !== undefined
+  ) {
+    throw new UsageError(
+      "explain --emit-fixtures takes no <event>/[tool] argument and none of " +
+        "--settings/--claude-version/--format: it only reads captured payload " +
+        "envelopes and writes fixture files, and none of those options change " +
+        "that. Pass --capture-dir to read envelopes from a location other " +
+        "than record's own default.",
+    );
+  }
+
+  const outputDir = path.resolve(deps.cwd, emitFixturesDir);
+  const captureDir =
+    parsed.values["capture-dir"] === undefined
+      ? defaultCaptureDir(deps.cwd)
+      : path.resolve(deps.cwd, parsed.values["capture-dir"]);
+
+  const result = emitFixtures({ captureDir, outputDir });
+
+  const stdout =
+    `Wrote ${String(result.files.length)} fixture file(s) to ${result.outputDir}:\n` +
+    result.files.map((file) => `  ${file}\n`).join("");
+
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+/** `parseArgs({strict:true})` result shape for `EXPLAIN_OPTIONS`, named so `runExplainEmitFixtures` can share it with `runExplain`. */
+function parseArgsForExplain(args: readonly string[]) {
+  return parseArgs({
+    args,
+    strict: true,
+    allowPositionals: true,
+    options: EXPLAIN_OPTIONS,
+  });
+}
 
 /**
  * `parseArgs({ strict: true })` throws on an unknown option, a missing
@@ -370,15 +439,15 @@ const EXPLAIN_OPTIONS = {
 function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   let parsed;
   try {
-    parsed = parseArgs({
-      args,
-      strict: true,
-      allowPositionals: true,
-      options: EXPLAIN_OPTIONS,
-    });
+    parsed = parseArgsForExplain(args);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new UsageError(`invalid options for explain: ${reason}`);
+  }
+
+  const emitFixturesDir = parsed.values["emit-fixtures"];
+  if (emitFixturesDir !== undefined) {
+    return runExplainEmitFixtures(parsed, deps, emitFixturesDir);
   }
 
   const [event, tool] = parsed.positionals;
@@ -400,10 +469,6 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
       `unrecognized event ${JSON.stringify(event)}. ` +
         `Expected one of the documented Claude Code hook events.`,
     );
-  }
-
-  if (parsed.values["emit-fixtures"] !== undefined) {
-    throw new UsageError("the --emit-fixtures option is not implemented yet.");
   }
 
   // Validated here, before any I/O (version resolution, spec loading, the

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -418,3 +418,37 @@ export class RecordRestoreError extends HookassertError {
     this.sessionFile = sessionFile;
   }
 }
+
+/**
+ * Thrown when `explain --emit-fixtures` finds no captured payload envelopes
+ * to generate fixtures from.
+ *
+ * @remarks
+ * A stateful precondition this operation depends on — at least one envelope
+ * file written by a previous `record` session — could not be satisfied, the
+ * same class of failure {@link RecordNoSessionError} reports for "no active
+ * session to stop": nothing was found to act on, so this is a load-time-
+ * adjacent failure (exit `5`) rather than a run that produced zero fixtures.
+ */
+export class RecordNoCapturesError extends HookassertError {
+  /** Stable discriminator, unchanged across non-breaking releases. */
+  readonly code = "ERR_RECORD_NO_CAPTURES" as const;
+
+  /** No-captures failures always exit 5 (load error). */
+  readonly exitCode = 5;
+
+  /** Absolute path of the capture directory that held no envelope files. */
+  readonly captureDir: string;
+
+  /**
+   * @param captureDir - Absolute path of the capture directory that was searched.
+   */
+  constructor(captureDir: string) {
+    super(
+      `explain --emit-fixtures found no captured payload envelopes in ${captureDir}. ` +
+        "Run `hookassert record` (and generate some hook activity) before emitting fixtures.",
+    );
+    this.name = "RecordNoCapturesError";
+    this.captureDir = captureDir;
+  }
+}

--- a/src/internal/fixture/generate.ts
+++ b/src/internal/fixture/generate.ts
@@ -1,0 +1,190 @@
+/**
+ * Turns captured payload envelopes (`record`'s own output, see
+ * `src/internal/record/capture.ts`) into fixture-file-shaped values that
+ * `load.ts`'s `loadFixtures` can read back unchanged.
+ *
+ * @remarks
+ * Static layer: reads envelope files from a capture directory and returns
+ * plain data — a generated fixture's file name and full YAML text — but
+ * never writes anything itself. `src/internal/record/emit.ts` (dynamic
+ * layer) is the only module that calls {@link generateFixtureFile} and
+ * writes its result to disk, per this issue's design: the read-and-group
+ * logic is static and pure, the write is dynamic.
+ *
+ * One case per envelope, per the design's explicit choice not to invent a
+ * richer grouping heuristic than the captured data can actually support: a
+ * "session" is not a concept an envelope file carries on its own, so nothing
+ * here tries to cluster envelopes into one file by session or by event.
+ *
+ * `expect` is always exactly `{ fires: true }` — never a guessed `decision`,
+ * `exitCode`, or output expectation. A guessed expectation that turns out
+ * wrong is worse than none at all, since it would silently assert something
+ * the user never reviewed; see this issue's own design note.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { stringify as stringifyYaml } from "yaml";
+
+import type { RawFixtureCase, RawFixtureFile } from "./types.js";
+
+/**
+ * The exact first line every generated fixture file starts with — the same
+ * line `#8`'s hand-authored example uses, so a generated and a hand-written
+ * fixture look identical to an editor. Not computed relative to the output
+ * directory: it names the path a real consumer's own `node_modules` resolves
+ * to once `hookassert` is installed, which has nothing to do with where this
+ * particular fixture file happens to be written.
+ */
+export const YAML_SCHEMA_COMMENT =
+  "# yaml-language-server: $schema=./node_modules/hookassert/schema/fixture.schema.json";
+
+/** One captured payload envelope, read off disk, with just what generation needs. */
+export interface CapturedEnvelope {
+  /** Absolute path of the envelope file this was read from. */
+  readonly envelopePath: string;
+
+  /** The envelope's own `event` field. Not yet checked against `EventName` — `load.ts` does that once the generated fixture is loaded back. */
+  readonly event: string;
+
+  /** The envelope's own captured payload, replayed verbatim as the generated case's `input`. */
+  readonly payload: unknown;
+}
+
+/** One fixture file `generateFixtureFile` produced, ready to be written to disk. */
+export interface GeneratedFixture {
+  /** File name (no directory) to write this fixture under — distinct per envelope, so emitting never collides with another generated file or an unrelated hand-authored one. */
+  readonly fileName: string;
+
+  /** Full YAML file text, `YAML_SCHEMA_COMMENT` included as its first line. */
+  readonly text: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEnoent(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+/**
+ * Read every captured payload envelope in `captureDir`, in filename order —
+ * which, per `capture.ts`'s own naming (`capture-<iso-with-dashes>-<suffix>.json`),
+ * is also capture order.
+ *
+ * @remarks
+ * A missing capture directory reads as "nothing captured yet" (an empty
+ * array), the same way `settings/load.ts` maps a missing settings file to
+ * zero hooks, rather than as an error — `record` may simply never have been
+ * run. A file that is not valid JSON, or is valid JSON missing a non-empty
+ * `event` string or its `payload` key entirely, is skipped rather than
+ * failing the whole read: it is not a shape `capture.ts`'s own script ever
+ * writes, so it can only be a file something else put there, or a capture
+ * that failed partway through a write.
+ */
+export function readCapturedEnvelopes(captureDir: string): readonly CapturedEnvelope[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(captureDir).filter((name) => name.endsWith(".json"));
+  } catch (error) {
+    if (isEnoent(error)) {
+      return [];
+    }
+    throw error;
+  }
+  entries.sort();
+
+  const envelopes: CapturedEnvelope[] = [];
+  for (const name of entries) {
+    const envelopePath = path.join(captureDir, name);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(envelopePath, "utf8")) as unknown;
+    } catch {
+      continue;
+    }
+
+    if (
+      !isRecord(parsed) ||
+      typeof parsed["event"] !== "string" ||
+      parsed["event"].length === 0 ||
+      !("payload" in parsed)
+    ) {
+      continue;
+    }
+
+    envelopes.push({
+      envelopePath,
+      event: parsed["event"],
+      payload: parsed["payload"],
+    });
+  }
+
+  return envelopes;
+}
+
+/** The envelope's own `payload.tool_name`, when it names one as a non-empty string. */
+function extractToolName(payload: unknown): string | undefined {
+  if (!isRecord(payload) || typeof payload["tool_name"] !== "string") {
+    return undefined;
+  }
+  return payload["tool_name"].length > 0 ? payload["tool_name"] : undefined;
+}
+
+/**
+ * A generated fixture file's name: the envelope's own file name (already
+ * unique per capture, per `capture.ts`'s random suffix) with `.json`
+ * replaced by `.fixture.yaml` — so two runs of `explain --emit-fixtures`
+ * against the same capture directory regenerate the same files rather than
+ * accumulating duplicates, and neither collides with an unrelated,
+ * hand-authored fixture file already in the output directory.
+ */
+function fixtureFileName(envelopePath: string): string {
+  const stem = path.basename(envelopePath, ".json");
+  return `${stem}.fixture.yaml`;
+}
+
+/** Posix-style relative path from `outputDir` to `targetPath`, for `origin.recorded`. */
+function relativeOrigin(outputDir: string, targetPath: string): string {
+  return path.relative(outputDir, targetPath).split(path.sep).join("/");
+}
+
+/**
+ * Generate one fixture file from one captured envelope: exactly one case,
+ * `origin.recorded` pointing back at the envelope, `input` replaying its
+ * captured payload verbatim, and `expect` prefilled with nothing but
+ * `{ fires: true }`.
+ *
+ * @param envelope - The captured envelope to generate a fixture from.
+ * @param outputDir - Absolute path of the directory the caller is about to
+ * write the result into — used only to compute `origin.recorded`'s relative
+ * path back to {@link CapturedEnvelope.envelopePath}.
+ */
+export function generateFixtureFile(
+  envelope: CapturedEnvelope,
+  outputDir: string,
+): GeneratedFixture {
+  const tool = extractToolName(envelope.payload);
+
+  const rawCase: RawFixtureCase = {
+    event: envelope.event,
+    ...(tool === undefined ? {} : { tool }),
+    input: envelope.payload,
+    origin: { recorded: relativeOrigin(outputDir, envelope.envelopePath) },
+    expect: { fires: true },
+  };
+
+  const rawFile: RawFixtureFile = { cases: [rawCase] };
+
+  const text = `${YAML_SCHEMA_COMMENT}\n${stringifyYaml(rawFile)}`;
+
+  return { fileName: fixtureFileName(envelope.envelopePath), text };
+}

--- a/src/internal/fixture/index.ts
+++ b/src/internal/fixture/index.ts
@@ -8,6 +8,12 @@
  * not just by convention.
  */
 
+export {
+  generateFixtureFile,
+  readCapturedEnvelopes,
+  YAML_SCHEMA_COMMENT,
+} from "./generate.js";
+export type { CapturedEnvelope, GeneratedFixture } from "./generate.js";
 export { isValidRawFixtureFile, validateFixture } from "./guards.js";
 export { loadFixture, loadFixtureFile, loadFixtures } from "./load.js";
 export type {

--- a/src/internal/record/emit.ts
+++ b/src/internal/record/emit.ts
@@ -1,0 +1,68 @@
+/**
+ * `explain --emit-fixtures`'s write-side wrapper: reads captured payload
+ * envelopes and writes them out as fixture YAML files.
+ *
+ * @remarks
+ * Dynamic layer: this is the only place in `record/` that writes fixture
+ * files to disk. The read-and-group logic itself — deciding what each
+ * generated file's content is — lives in `src/internal/fixture/generate.ts`
+ * (static layer, pure data in, pure data out); this module only calls it and
+ * performs the actual `mkdirSync`/`writeFileSync`, per this issue's own
+ * split between the two layers.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { generateFixtureFile, readCapturedEnvelopes } from "../fixture/index.js";
+import { RecordNoCapturesError } from "../errors.js";
+
+/** What `emitFixtures` needs to read captured envelopes and write fixtures for them. */
+export interface EmitFixturesOptions {
+  /** Absolute path of the directory captured payload envelopes are read from. */
+  readonly captureDir: string;
+
+  /** Absolute path of the directory generated fixture files are written into; created if it does not exist. */
+  readonly outputDir: string;
+}
+
+/** What `emitFixtures` reports back, for `explain`'s own stdout. */
+export interface EmitFixturesResult {
+  /** Absolute path of the directory fixture files were written into. */
+  readonly outputDir: string;
+
+  /** Absolute path of every fixture file written, one per captured envelope, in capture order. */
+  readonly files: readonly string[];
+}
+
+/**
+ * Read every captured payload envelope in `options.captureDir` and write one
+ * fixture YAML file per envelope into `options.outputDir`.
+ *
+ * @remarks
+ * Each generated file's name is derived from its envelope's own file name
+ * (see `generate.ts`'s `fixtureFileName`), so a second run against the same
+ * capture directory regenerates the same files rather than duplicating them,
+ * and neither can collide with an unrelated, hand-authored fixture file
+ * already in `options.outputDir` — that file's content is left untouched.
+ *
+ * @throws {RecordNoCapturesError} `options.captureDir` holds no readable
+ * captured payload envelopes.
+ */
+export function emitFixtures(options: EmitFixturesOptions): EmitFixturesResult {
+  const envelopes = readCapturedEnvelopes(options.captureDir);
+  if (envelopes.length === 0) {
+    throw new RecordNoCapturesError(options.captureDir);
+  }
+
+  mkdirSync(options.outputDir, { recursive: true });
+
+  const files = envelopes.map((envelope) => {
+    const generated = generateFixtureFile(envelope, options.outputDir);
+    const filePath = path.join(options.outputDir, generated.fileName);
+    writeFileSync(filePath, generated.text, "utf8");
+    return filePath;
+  });
+
+  return { outputDir: options.outputDir, files };
+}

--- a/src/internal/record/index.ts
+++ b/src/internal/record/index.ts
@@ -10,6 +10,8 @@
 
 export { buildCaptureScript, CAPTURE_SCRIPT_FILENAME } from "./capture.js";
 export type { CaptureScriptOptions } from "./capture.js";
+export { emitFixtures } from "./emit.js";
+export type { EmitFixturesOptions, EmitFixturesResult } from "./emit.js";
 export {
   defaultCaptureDir,
   hookassertDir,

--- a/tests/emit.test.ts
+++ b/tests/emit.test.ts
@@ -1,0 +1,371 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+import { runCli } from "../src/cli.js";
+import { RecordNoCapturesError } from "../src/internal/errors.js";
+import {
+  generateFixtureFile,
+  loadFixtures,
+  readCapturedEnvelopes,
+  YAML_SCHEMA_COMMENT,
+} from "../src/internal/fixture/index.js";
+import { emitFixtures } from "../src/internal/record/index.js";
+import { loadSpecFile } from "../src/internal/spec/index.js";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const REAL_SPEC = loadSpecFile(
+  path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json"),
+);
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "hookassert-emit-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Write one captured payload envelope of the shape `record`'s own capture
+ * script produces (see `src/internal/record/capture.ts`), so these tests
+ * exercise the real envelope contract rather than a shape invented here.
+ */
+function writeEnvelope(
+  captureDir: string,
+  fileName: string,
+  overrides: Record<string, unknown> = {},
+): string {
+  mkdirSync(captureDir, { recursive: true });
+  const envelopePath = path.join(captureDir, fileName);
+  const envelope = {
+    capturedAt: "2026-09-01T12:00:00.000Z",
+    event: "PreToolUse",
+    claudeVersion: "2.1.251",
+    sourceFile: path.join(captureDir, fileName),
+    payload: {
+      session_id: "abc123",
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "echo hi" },
+    },
+    ...overrides,
+  };
+  writeFileSync(envelopePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf8");
+  return envelopePath;
+}
+
+describe("readCapturedEnvelopes", () => {
+  it("reads every envelope in the capture directory, in capture order", () => {
+    const captureDir = makeTempDir();
+    writeEnvelope(captureDir, "capture-2026-09-01T12-00-00-000Z-bbb.json");
+    writeEnvelope(captureDir, "capture-2026-09-01T11-00-00-000Z-aaa.json");
+
+    const envelopes = readCapturedEnvelopes(captureDir);
+
+    expect(envelopes).toHaveLength(2);
+    // capture.ts names files by ISO timestamp, so filename order is capture order.
+    expect(path.basename(envelopes[0]?.envelopePath ?? "")).toContain("11-00-00");
+    expect(path.basename(envelopes[1]?.envelopePath ?? "")).toContain("12-00-00");
+  });
+
+  it("reads a capture directory that does not exist as nothing captured yet", () => {
+    const root = makeTempDir();
+
+    expect(readCapturedEnvelopes(path.join(root, "never-recorded"))).toEqual([]);
+  });
+
+  it("skips a file that is not valid JSON rather than failing the whole read", () => {
+    const captureDir = makeTempDir();
+    writeEnvelope(captureDir, "capture-good.json");
+    writeFileSync(path.join(captureDir, "capture-broken.json"), "{ not json", "utf8");
+
+    expect(readCapturedEnvelopes(captureDir)).toHaveLength(1);
+  });
+
+  it.each([
+    ["no event", { event: undefined }],
+    ["an empty event", { event: "" }],
+  ])("skips an envelope with %s", (_label, overrides) => {
+    const captureDir = makeTempDir();
+    const envelope = {
+      capturedAt: "2026-09-01T12:00:00.000Z",
+      payload: {},
+      ...overrides,
+    };
+    mkdirSync(captureDir, { recursive: true });
+    writeFileSync(
+      path.join(captureDir, "capture-odd.json"),
+      JSON.stringify(envelope),
+      "utf8",
+    );
+
+    expect(readCapturedEnvelopes(captureDir)).toEqual([]);
+  });
+});
+
+describe("generateFixtureFile", () => {
+  it("emits one fixture case per captured envelope with origin.recorded pointing at that envelope", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    const outputDir = path.join(root, "fixtures");
+    const envelopePath = writeEnvelope(captureDir, "capture-one.json");
+
+    const [envelope] = readCapturedEnvelopes(captureDir);
+    if (envelope === undefined) {
+      throw new Error("expected one envelope");
+    }
+    const generated = generateFixtureFile(envelope, outputDir);
+
+    // One case, and its origin resolves back to the envelope it came from.
+    expect(generated.text).toContain("cases:");
+    expect(generated.text).toContain("event: PreToolUse");
+    const recorded = /recorded: (?<value>\S+)/u.exec(generated.text)?.groups?.["value"];
+    expect(recorded).toBeDefined();
+    expect(path.resolve(outputDir, recorded ?? "")).toBe(envelopePath);
+  });
+
+  it("the emitted expect is exactly { fires: true } — no invented decision, exitCode, or output expectations", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    // An envelope carrying an outcome a "smarter" generator might be tempted to
+    // assert from. Nothing here may reach `expect`.
+    writeEnvelope(captureDir, "capture-tempting.json", {
+      payload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        permission_decision: "deny",
+        exit_code: 2,
+        stdout: "blocked by policy",
+      },
+    });
+
+    const [envelope] = readCapturedEnvelopes(captureDir);
+    if (envelope === undefined) {
+      throw new Error("expected one envelope");
+    }
+    const { text } = generateFixtureFile(envelope, path.join(root, "fixtures"));
+
+    // Asserted on the parsed `expect` block, not by substring over the whole
+    // file: the captured payload is echoed back verbatim as `input`, so a
+    // payload key like `permission_decision` legitimately puts "decision:" in
+    // the text without any expectation having been invented.
+    const parsed = parseYaml(text) as { cases: { expect: unknown }[] };
+    expect(parsed.cases).toHaveLength(1);
+    expect(parsed.cases[0]?.expect).toEqual({ fires: true });
+  });
+
+  it("the emitted YAML file's first line is the yaml-language-server $schema line", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    const [envelope] = readCapturedEnvelopes(captureDir);
+    if (envelope === undefined) {
+      throw new Error("expected one envelope");
+    }
+    const { text } = generateFixtureFile(envelope, path.join(root, "fixtures"));
+
+    expect(text.split("\n")[0]).toBe(YAML_SCHEMA_COMMENT);
+  });
+
+  it("carries the payload's tool_name onto the case, and omits tool when the payload names none", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    writeEnvelope(captureDir, "capture-a-tool.json");
+    writeEnvelope(captureDir, "capture-b-none.json", {
+      event: "SessionStart",
+      payload: { hook_event_name: "SessionStart" },
+    });
+
+    const envelopes = readCapturedEnvelopes(captureDir);
+    const outputDir = path.join(root, "fixtures");
+    const withTool = envelopes[0];
+    const withoutTool = envelopes[1];
+    if (withTool === undefined || withoutTool === undefined) {
+      throw new Error("expected two envelopes");
+    }
+
+    expect(generateFixtureFile(withTool, outputDir).text).toContain("tool: Bash");
+    expect(generateFixtureFile(withoutTool, outputDir).text).not.toContain("tool:");
+  });
+});
+
+describe("emitFixtures", () => {
+  it("writes one fixture file per envelope into the output directory", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    const outputDir = path.join(root, "fixtures");
+    writeEnvelope(captureDir, "capture-one.json");
+    writeEnvelope(captureDir, "capture-two.json");
+
+    const result = emitFixtures({ captureDir, outputDir });
+
+    expect(result.files).toHaveLength(2);
+    expect(readdirSync(outputDir).sort()).toEqual([
+      "capture-one.fixture.yaml",
+      "capture-two.fixture.yaml",
+    ]);
+  });
+
+  it("creates an output directory that does not exist yet", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    const outputDir = path.join(root, "deep", "nested", "fixtures");
+    emitFixtures({ captureDir, outputDir });
+
+    expect(readdirSync(outputDir)).toEqual(["capture-one.fixture.yaml"]);
+  });
+
+  it("emitting into a directory that already has fixture files does not overwrite or corrupt them", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    const outputDir = path.join(root, "fixtures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    // A hand-authored fixture that happens to live in the output directory.
+    mkdirSync(outputDir, { recursive: true });
+    const handAuthored = path.join(outputDir, "my-own.fixture.yaml");
+    const handAuthoredText =
+      "cases:\n  - event: SessionStart\n    expect:\n      fires: false\n";
+    writeFileSync(handAuthored, handAuthoredText, "utf8");
+
+    emitFixtures({ captureDir, outputDir });
+
+    // The collision policy is a distinct filename per envelope, derived from
+    // the envelope's own already-unique name — so nothing else is touched.
+    expect(readFileSync(handAuthored, "utf8")).toBe(handAuthoredText);
+    expect(readdirSync(outputDir).sort()).toEqual([
+      "capture-one.fixture.yaml",
+      "my-own.fixture.yaml",
+    ]);
+  });
+
+  it("regenerates the same file rather than accumulating duplicates on a second run", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    const outputDir = path.join(root, "fixtures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    emitFixtures({ captureDir, outputDir });
+    const first = readFileSync(
+      path.join(outputDir, "capture-one.fixture.yaml"),
+      "utf8",
+    );
+    emitFixtures({ captureDir, outputDir });
+
+    expect(readdirSync(outputDir)).toEqual(["capture-one.fixture.yaml"]);
+    expect(readFileSync(path.join(outputDir, "capture-one.fixture.yaml"), "utf8")).toBe(
+      first,
+    );
+  });
+
+  it("rejects a capture directory holding no readable envelopes", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    mkdirSync(captureDir, { recursive: true });
+
+    try {
+      emitFixtures({ captureDir, outputDir: path.join(root, "fixtures") });
+      expect.unreachable("emitFixtures should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(RecordNoCapturesError);
+      expect((error as RecordNoCapturesError).code).toBe("ERR_RECORD_NO_CAPTURES");
+      expect((error as RecordNoCapturesError).exitCode).toBe(5);
+    }
+  });
+
+  it("a fixture generated from captured payloads loads through loadFixtures unchanged", () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    const outputDir = path.join(root, "fixtures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    const result = emitFixtures({ captureDir, outputDir });
+    const loaded = loadFixtures(result.files, REAL_SPEC);
+
+    expect(loaded.files).toHaveLength(1);
+    const file = loaded.files[0];
+    expect(file?.file.cases).toHaveLength(1);
+    const testCase = file?.file.cases[0];
+    expect(testCase?.event).toBe("PreToolUse");
+    expect(testCase?.tool).toBe("Bash");
+    expect(testCase?.expect).toEqual({ fires: true });
+    // origin.recorded resolved back to the envelope, so the loader read it.
+    expect(testCase?.origin.kind).toBe("recorded");
+  });
+});
+
+describe("explain --emit-fixtures", () => {
+  it("writes fixtures and reports what it wrote", async () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    writeEnvelope(captureDir, "capture-one.json");
+
+    const result = await runCli(
+      ["explain", "--emit-fixtures", "fixtures", "--capture-dir", captureDir],
+      "hookassert",
+      { cwd: root },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("capture-one.fixture.yaml");
+    expect(readdirSync(path.join(root, "fixtures"))).toEqual([
+      "capture-one.fixture.yaml",
+    ]);
+  });
+
+  it.each([
+    ["a positional event", ["explain", "--emit-fixtures", "out", "PreToolUse"]],
+    ["--format", ["explain", "--emit-fixtures", "out", "--format", "json"]],
+    ["--settings", ["explain", "--emit-fixtures", "out", "--settings", "s.json"]],
+    [
+      "--claude-version",
+      ["explain", "--emit-fixtures", "out", "--claude-version", "2.1.251"],
+    ],
+  ])("rejects %s alongside --emit-fixtures", async (_label, argv) => {
+    const root = makeTempDir();
+
+    const result = await runCli(argv, "hookassert", { cwd: root });
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain("--emit-fixtures");
+  });
+
+  it("reports the no-captures failure through the CLI rather than throwing", async () => {
+    const root = makeTempDir();
+    const captureDir = path.join(root, "captures");
+    mkdirSync(captureDir, { recursive: true });
+
+    const result = await runCli(
+      ["explain", "--emit-fixtures", "fixtures", "--capture-dir", captureDir],
+      "hookassert",
+      { cwd: root },
+    );
+
+    expect(result.exitCode).toBe(5);
+    expect(result.stderr).toContain("ERR_RECORD_NO_CAPTURES");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ const automationTests = [
   "tests/clean.test.ts",
   "tests/conformance.test.ts",
   "tests/docs.test.ts",
+  "tests/emit.test.ts",
   "tests/executor.test.ts",
   "tests/git-env.test.ts",
   "tests/is-main.test.ts",


### PR DESCRIPTION
`explain --emit-fixtures <dir>` was declared in `explain`'s option table but threw `the --emit-fixtures option is not implemented yet`. It now reads the payload envelopes `record` captured and writes one fixture YAML file per envelope, closing the loop from "capture a real payload" to "have a runnable, editable test case" without hand-authoring YAML from scratch.

Closes #16

## Design

**The layer split is the point.** Deciding what a generated fixture contains is pure logic; writing it to the user's filesystem is not. So `src/internal/fixture/generate.ts` (static) takes envelopes and returns a file name plus YAML text and never writes anything, and `src/internal/record/emit.ts` (dynamic) is the only module that touches the disk. `src/cli.ts`, the composition root, wires them together.

**`expect` is exactly `{ fires: true }`.** Never a guessed `decision`, `exitCode`, or output expectation, even when the captured payload plainly carries one. A guessed expectation that turns out wrong is worse than no expectation at all, because it silently asserts something the user never reviewed — which would defeat the whole point of grounding fixtures in real payloads. There is a dedicated regression test for this.

**One case per envelope**, per the issue's explicit instruction not to invent a grouping heuristic the captured data cannot support.

**Collision policy:** a generated file is named after its envelope (`capture-….json` → `capture-….fixture.yaml`), which `record` already makes unique per capture. So a second run regenerates the same files rather than accumulating duplicates, and a hand-authored fixture already sitting in the output directory is never touched. Both are asserted.

`--capture-dir` is added to `explain` alongside `--emit-fixtures`, mirroring `record`'s flag of the same name and defaulting to `record`'s own `defaultCaptureDir`. `--emit-fixtures` is a standalone mode: passing a positional `<event>` or any of `--settings`/`--claude-version`/`--format` with it is a `UsageError`, since none of them mean anything for a run that never matches a hook.

A new `RecordNoCapturesError` (`ERR_RECORD_NO_CAPTURES`, exit 5) reports an empty capture directory, matching `RecordNoSessionError`'s treatment of the same class of unmet stateful precondition.

Release impact: none — no change to `src/index.ts` or any published type. `explain`'s CLI surface gains behavior that previously errored, and the new modules are internal.

## Test plan

- `pnpm check:quick` — **exit 0, 39 test files / 1623 tests passing**, coverage floors included.
- `pnpm exec vitest run tests/emit.test.ts` — exit 0, 21 tests.
- `tests/emit.test.ts` is new and joins `vitest.config.ts`'s `automationTests`: it writes real files under `mkdtemp`, matching where `tests/record.test.ts` sits for the same reason.

Covering, per the issue's TDD plan:

- one fixture case per envelope, with `origin.recorded` resolving back to the envelope it came from;
- **the emitted `expect` is exactly `{ fires: true }`** — asserted against the *parsed* `expect` block rather than by substring over the file, since the captured payload is echoed back verbatim as `input` and a payload key such as `permission_decision` would otherwise trip a naive "contains `decision:`" check;
- the first line is the `# yaml-language-server: $schema=…` line;
- **a generated fixture loads through `loadFixtures` unchanged**, resolving its `origin.recorded` envelope — the end-to-end tie back to the loader;
- emitting into a directory holding a hand-authored fixture leaves it byte-identical, and a second run does not duplicate;
- envelope reading skips malformed JSON and envelopes missing a non-empty `event`, and treats a missing capture directory as "nothing captured yet";
- the CLI surface: a successful emit, the four rejected option combinations, and `ERR_RECORD_NO_CAPTURES` surfacing as exit 5.

https://claude.ai/code/session_01SL22JTzb3RmoXdnQGKbgLu
