### PR TITLE
fix: screen matcher regexes for nested unbounded quantifiers instead of running them

### DIFF
--- a/docs/troubleshooting-map.md
+++ b/docs/troubleshooting-map.md
@@ -52,10 +52,11 @@ go re-read the live page, not as a substitute for it.
 
 ## Not in this table
 
-`matcher-is-array`, `matcher-comma-version`, `matcher-hyphen-version`, and
-`matcher-unanchored` catch mistakes the fetched troubleshooting guidance does not name
-as their own symptom — a matcher declared as a JSON array; comma- or hyphen-notation
-gated behind a Claude Code version too old to support it; an unanchored regex matcher
-that over-matches beyond the tool it was written for. None of these has a distinct row
-in the page as fetched (2026-09-01); see "How to read this table" above for why the map
-does not force one.
+`matcher-is-array`, `matcher-comma-version`, `matcher-hyphen-version`,
+`matcher-unanchored`, and `matcher-catastrophic` catch mistakes the fetched
+troubleshooting guidance does not name as their own symptom — a matcher declared as a
+JSON array; comma- or hyphen-notation gated behind a Claude Code version too old to
+support it; an unanchored regex matcher that over-matches beyond the tool it was written
+for; a matcher whose pattern contains a nested unbounded quantifier and can hang instead
+of matching. None of these has a distinct row in the page as fetched (2026-09-01); see
+"How to read this table" above for why the map does not force one.

--- a/src/internal/lint/registry.ts
+++ b/src/internal/lint/registry.ts
@@ -2,7 +2,7 @@
  * The active `LintRule`s the `lint` subcommand iterates.
  *
  * @remarks
- * Five matcher rules, plus six command/exit-code rules (`command-not-found`,
+ * Six matcher rules, plus six command/exit-code rules (`command-not-found`,
  * `missing-shebang`, `not-executable`, `unquoted-var`, `exit-1-policy`,
  * `exit-2-overrides-allow`). `docs/troubleshooting-map.md` maps official
  * Claude Code troubleshooting symptoms to a subset of these rule ids;
@@ -14,6 +14,7 @@ import { commandNotFoundRule } from "./rules/commandNotFound.js";
 import { exit1PolicyRule } from "./rules/exit1Policy.js";
 import { exit2OverridesAllowRule } from "./rules/exit2OverridesAllow.js";
 import { matcherCaseRule } from "./rules/matcherCase.js";
+import { matcherCatastrophicRule } from "./rules/matcherCatastrophic.js";
 import { matcherCommaVersionRule } from "./rules/matcherCommaVersion.js";
 import { matcherDeadRule } from "./rules/matcherDead.js";
 import { matcherHyphenVersionRule } from "./rules/matcherHyphenVersion.js";
@@ -32,6 +33,7 @@ export const LINT_RULES: readonly LintRule[] = [
   matcherHyphenVersionRule,
   matcherDeadRule,
   matcherUnanchoredRule,
+  matcherCatastrophicRule,
   commandNotFoundRule,
   missingShebangRule,
   notExecutableRule,

--- a/src/internal/lint/rules/matcherCatastrophic.ts
+++ b/src/internal/lint/rules/matcherCatastrophic.ts
@@ -1,0 +1,50 @@
+/**
+ * `matcher-catastrophic`: a string matcher whose pattern contains a nested
+ * unbounded quantifier — the shape that makes `new RegExp(matcher).test(...)`
+ * backtrack exponentially and can hang `explain`, `lint`, or `test`.
+ *
+ * @remarks
+ * Calls the same `matcher/safety.ts`'s `findCatastrophicConstruct`
+ * `matcher/classify.ts` consults on the regex path. That module's own
+ * screen is what keeps `explain`/`test` from ever compiling such a pattern,
+ * independent of whether `lint` ran; this rule is where the diagnosis
+ * belongs — naming the file/line and a concrete rewrite.
+ *
+ * Applies to every string matcher regardless of `event`'s
+ * `matcherTargets.kind`: a catastrophic pattern is dangerous to compile no
+ * matter what value it would eventually be tested against, so this rule
+ * does not gate on `isToolNameEvent` the way the other matcher rules do.
+ */
+
+import { findCatastrophicConstruct } from "../../matcher/index.js";
+import type { Finding, LintContext, LintRule } from "../types.js";
+
+export const matcherCatastrophicRule: LintRule = {
+  id: "matcher-catastrophic",
+
+  run(ctx: LintContext): readonly Finding[] {
+    const findings: Finding[] = [];
+    for (const group of ctx.groups) {
+      if (group.matcher.kind !== "string") {
+        continue;
+      }
+      const matcher = group.matcher.value;
+      const construct = findCatastrophicConstruct(matcher);
+      if (construct === undefined) {
+        continue;
+      }
+
+      findings.push({
+        file: group.file,
+        line: group.line,
+        ruleId: "matcher-catastrophic",
+        message: `Matcher "${matcher}" contains a ${construct}, which can hang instead of matching.`,
+        suggestion:
+          `Rewrite the pattern without a nested quantifier — for example, ` +
+          `"a+" instead of "(a+)+" — or use an exact-match list naming the ` +
+          "intended tool(s) instead.",
+      });
+    }
+    return findings;
+  },
+};

--- a/src/internal/matcher/classify.ts
+++ b/src/internal/matcher/classify.ts
@@ -16,11 +16,17 @@
  * `match.ts` fires every hook under such an event, matcher ignored, before
  * ever calling `classifyMatcher` — so this module's classification is
  * purely syntactic and never needs an `"unsupported"` verdict.
+ *
+ * A matcher on the regex path is screened by `safety.ts`'s
+ * `findCatastrophicConstruct` before it is ever handed to `new RegExp` —
+ * see that module's own remarks for why a nested unbounded quantifier
+ * degrades to `"unknown"` here instead of being compiled and run.
  */
 
 import type { EventName } from "../../types.js";
 import { isInDeclaredRange, meetsSinceVersion } from "../spec/index.js";
 import type { Spec } from "../spec/index.js";
+import { findCatastrophicConstruct } from "./safety.js";
 import type { ClassifyResult, MatcherKind, VersionContext } from "./types.js";
 
 /**
@@ -100,12 +106,16 @@ function hasUnsatisfiedNotationRule(
  *    every matcher against this run, not only version-dependent notation.
  * 3. Otherwise, `matcher` is tested against the event's exact-list character
  *    set (`narrowExactListPattern` for `narrowExactMatchEvents`,
- *    `exactListPattern` for every other event). A match that also relies on
- *    a version-gated notation (a comma or a hyphen, and only for a
- *    `"tool-name"` target — see {@link RULE_CHARACTERS}) whose
- *    `sinceVersion` the version cannot be confirmed to meet — including an
- *    undetermined version — degrades to `"unknown"` rather than silently
- *    passing as supported or failing as unsupported.
+ *    `exactListPattern` for every other event). A non-match puts `matcher`
+ *    on the regex path, where a nested unbounded quantifier — see
+ *    `safety.ts`'s `findCatastrophicConstruct` — degrades it to
+ *    `"unknown"` before it is ever compiled.
+ * 4. An exact-list match that also relies on a version-gated notation (a
+ *    comma or a hyphen, and only for a `"tool-name"` target — see
+ *    {@link RULE_CHARACTERS}) whose `sinceVersion` the version cannot be
+ *    confirmed to meet — including an undetermined version — degrades to
+ *    `"unknown"` rather than silently passing as supported or failing as
+ *    unsupported.
  */
 function classify(
   spec: Spec,
@@ -133,6 +143,13 @@ function classify(
     : spec.matcherSyntax.exactListPattern;
 
   if (!new RegExp(exactListPattern).test(matcher)) {
+    const construct = findCatastrophicConstruct(matcher);
+    if (construct !== undefined) {
+      return {
+        kind: "unknown",
+        reason: `this matcher cannot be evaluated safely: ${construct}; rewrite it without a nested quantifier`,
+      };
+    }
     return { kind: "unanchored-regex" };
   }
 

--- a/src/internal/matcher/index.ts
+++ b/src/internal/matcher/index.ts
@@ -10,6 +10,7 @@
 
 export { classifyMatcher } from "./classify.js";
 export { matchHooks } from "./match.js";
+export { findCatastrophicConstruct } from "./safety.js";
 export type {
   MatcherKind,
   MatcherOutcome,

--- a/src/internal/matcher/safety.ts
+++ b/src/internal/matcher/safety.ts
@@ -23,7 +23,15 @@
  * itself given an unbounded quantifier. When a group closes and is
  * *itself* immediately followed by an unbounded quantifier, that memory is
  * exactly the answer to "does this group contain an unbounded quantifier
- * inside it" — no backtracking, no automaton, one pass.
+ * inside it" — no backtracking, no automaton, one pass. That memory does
+ * not stop at the closing paren, either: whatever the closing group is (or
+ * is not) followed by, its "contains an unbounded quantifier" flag is
+ * carried into the enclosing frame, the same way a plain atom's own
+ * unbounded quantifier is. A wrapper group with no quantifier of its own
+ * (`((a+))+`) or a bounded one (`((a+)?)+`) still carries the inner
+ * unbounded repetition outward, so it is caught the moment some group
+ * further out is itself given an unbounded quantifier — no matter how many
+ * quantifier-less or boundedly-quantified wrapper groups sit in between.
  *
  * Deliberately conservative in two directions:
  *
@@ -189,23 +197,23 @@ export function findCatastrophicConstruct(pattern: string): string | undefined {
       }
 
       const quantifier = matchQuantifier(pattern, afterGroup);
-      if (quantifier === undefined) {
-        i = afterGroup;
-        continue;
-      }
 
-      if (quantifier.unbounded && frame.hasInnerUnbounded) {
+      if (quantifier !== undefined && quantifier.unbounded && frame.hasInnerUnbounded) {
         const construct = pattern.slice(frame.start, quantifier.end);
         return `nested unbounded quantifier at offset ${String(frame.start)}: ${JSON.stringify(construct)}`;
       }
 
-      if (quantifier.unbounded) {
-        const enclosing = stack[stack.length - 1];
-        if (enclosing !== undefined) {
-          enclosing.hasInnerUnbounded = true;
-        }
+      // Propagate to the enclosing frame regardless of what (if anything)
+      // follows this group — see this file's remarks on why the memory
+      // must survive a quantifier-less or boundedly-quantified wrapper.
+      const enclosing = stack[stack.length - 1];
+      if (
+        enclosing !== undefined &&
+        (frame.hasInnerUnbounded || quantifier?.unbounded === true)
+      ) {
+        enclosing.hasInnerUnbounded = true;
       }
-      i = quantifier.end;
+      i = quantifier === undefined ? afterGroup : quantifier.end;
       continue;
     }
 

--- a/src/internal/matcher/safety.ts
+++ b/src/internal/matcher/safety.ts
@@ -1,0 +1,224 @@
+/**
+ * Screens a matcher pattern for the one construct that makes
+ * `new RegExp(pattern).test(target)` backtrack exponentially: an unbounded
+ * quantifier (`*`, `+`, `{n,}`) applied to a group that itself contains an
+ * unbounded quantifier — `(a+)+`, `(a*)*`, `((ab)*)*`.
+ *
+ * @remarks
+ * Static layer: a pure string scan, no compilation, no I/O. `matcher/` is
+ * safe to run over any settings tree — see `AGENTS.md`'s architecture
+ * section — and the usual remedy for a runaway regex, evaluating it in a
+ * worker or child process under a timeout, is unavailable here: this module
+ * may not spawn, and `matchHooks` is synchronous. Screening the pattern
+ * before it is ever compiled is the only option left, so
+ * {@link findCatastrophicConstruct} is consulted before `classify.ts` ever
+ * reaches for `new RegExp(matcher)`.
+ *
+ * The scan tracks three things in a single left-to-right pass: escape pairs
+ * (`\x`, so an escaped `(` or `)` is a literal character, never a group
+ * boundary), character classes (`[...]`, whose contents — including a
+ * literal `(`, `)`, or `+` — are never parsed as their own constructs), and
+ * a stack of open groups. Each open group remembers whether anything
+ * scanned inside it (a literal, a character class, or a nested group) was
+ * itself given an unbounded quantifier. When a group closes and is
+ * *itself* immediately followed by an unbounded quantifier, that memory is
+ * exactly the answer to "does this group contain an unbounded quantifier
+ * inside it" — no backtracking, no automaton, one pass.
+ *
+ * Deliberately conservative in two directions:
+ *
+ * - **Ambiguous alternation with no nested quantifier** (`(a|aa)+$`,
+ *   `(x|x)*y`) is out of scope. It is polynomial at the lengths a tool name
+ *   or field value reaches, and telling it apart from a harmless
+ *   alternation like `(Bash|Edit)+` needs an automaton analysis this
+ *   repository will not carry — see the issue this module was built for.
+ * - A `|` inside a group does not reset the group's own "contains an
+ *   unbounded quantifier" memory: `(a+|b)+` is flagged even though only one
+ *   branch is dangerous, because a matcher that is safe on every branch
+ *   but one is still a hang waiting for the right target string. A false
+ *   positive here costs an `"unknown"` classification with a reason and a
+ *   lint suggestion; a false negative costs a hang.
+ *
+ * Never asked whether `pattern` is a syntactically valid `RegExp` — an
+ * unbalanced paren or bracket is `match.ts`'s and `lint`'s own concern, not
+ * this scan's. An unmatched `)` is treated as an ordinary character so the
+ * scan always terminates instead of throwing on a malformed pattern.
+ */
+
+/** One currently open group: where it started, and whether an unbounded quantifier has been seen anywhere directly inside it. */
+interface GroupFrame {
+  readonly start: number;
+  hasInnerUnbounded: boolean;
+}
+
+/** Whether a quantifier starts at `pattern[index]`, and — when it does — where it ends and whether it is unbounded. */
+interface QuantifierMatch {
+  readonly end: number;
+  readonly unbounded: boolean;
+}
+
+const BRACE_QUANTIFIER = /^\{(\d+)(,(\d*))?\}/;
+
+/**
+ * The quantifier (if any) starting at `pattern[index]` — `*`, `+`, `?`, or a
+ * `{...}` repetition, each optionally followed by the lazy-modifier `?`.
+ *
+ * @remarks
+ * `?` alone is bounded (0 or 1): it never contributes to catastrophic
+ * backtracking on its own. `{n}` and `{n,m}` are bounded (a fixed or capped
+ * repeat count); only `{n,}` — a comma with no upper bound — is unbounded,
+ * the same as `*` and `+`. A `{` that is not a well-formed repetition
+ * (`{foo}`, an unclosed `{2,`) is not a quantifier at all under `RegExp`
+ * semantics — it is a literal `{` — so `undefined` is returned and the
+ * caller treats it as an ordinary character with no quantifier attached.
+ */
+function matchQuantifier(pattern: string, index: number): QuantifierMatch | undefined {
+  const char = pattern[index];
+
+  if (char === "*" || char === "+") {
+    const lazy = pattern[index + 1] === "?";
+    return { end: index + (lazy ? 2 : 1), unbounded: true };
+  }
+
+  if (char === "?") {
+    const lazy = pattern[index + 1] === "?";
+    return { end: index + (lazy ? 2 : 1), unbounded: false };
+  }
+
+  if (char === "{") {
+    const match = BRACE_QUANTIFIER.exec(pattern.slice(index));
+    const whole = match?.[0];
+    if (whole === undefined) {
+      return undefined;
+    }
+    const comma = match?.[2];
+    const max = match?.[3];
+    const braceEnd = index + whole.length;
+    const lazy = pattern[braceEnd] === "?";
+    const unbounded = comma !== undefined && (max === undefined || max.length === 0);
+    return { end: lazy ? braceEnd + 1 : braceEnd, unbounded };
+  }
+
+  return undefined;
+}
+
+/** The index just past the `[...]` character class starting at `pattern[start]`. */
+function findClassEnd(pattern: string, start: number): number {
+  let i = start + 1;
+  if (pattern[i] === "^") {
+    i += 1;
+  }
+  // A `]` immediately after `[` or `[^` is a literal member of the class,
+  // not its closing bracket.
+  if (pattern[i] === "]") {
+    i += 1;
+  }
+  while (i < pattern.length && pattern[i] !== "]") {
+    i += pattern[i] === "\\" ? 2 : 1;
+  }
+  return i < pattern.length ? i + 1 : i;
+}
+
+/**
+ * Consume the quantifier (if any) at `pattern[index]`, marking `stack`'s
+ * innermost open group as containing an unbounded quantifier when it is
+ * one. Returns the index just past the quantifier, or `index` unchanged
+ * when there is none.
+ */
+function applyQuantifier(
+  pattern: string,
+  index: number,
+  stack: readonly GroupFrame[],
+): number {
+  const quantifier = matchQuantifier(pattern, index);
+  if (quantifier === undefined) {
+    return index;
+  }
+  if (quantifier.unbounded) {
+    const enclosing = stack[stack.length - 1];
+    if (enclosing !== undefined) {
+      enclosing.hasInnerUnbounded = true;
+    }
+  }
+  return quantifier.end;
+}
+
+/**
+ * The first nested unbounded quantifier in `pattern`, described for a
+ * human, or `undefined` when none is found.
+ *
+ * @remarks
+ * See this file's own remarks for the scan's design and its deliberate
+ * scope limits. The returned description names the offset the flagged
+ * group starts at and quotes the group plus the quantifier that makes it
+ * dangerous, e.g. `nested unbounded quantifier at offset 4: "(a+)+"` for a
+ * pattern such as `"^abc(a+)+$"`.
+ */
+export function findCatastrophicConstruct(pattern: string): string | undefined {
+  const stack: GroupFrame[] = [];
+  let i = 0;
+
+  while (i < pattern.length) {
+    const char = pattern[i];
+
+    if (char === "\\") {
+      i = applyQuantifier(pattern, i + 2, stack);
+      continue;
+    }
+
+    if (char === "[") {
+      i = applyQuantifier(pattern, findClassEnd(pattern, i), stack);
+      continue;
+    }
+
+    if (char === "(") {
+      stack.push({ start: i, hasInnerUnbounded: false });
+      i += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      const frame = stack.pop();
+      const afterGroup = i + 1;
+      if (frame === undefined) {
+        // Unmatched closing paren in a pattern this scan never assumes is
+        // valid `RegExp` syntax — treat it as an ordinary character rather
+        // than throwing.
+        i = applyQuantifier(pattern, afterGroup, stack);
+        continue;
+      }
+
+      const quantifier = matchQuantifier(pattern, afterGroup);
+      if (quantifier === undefined) {
+        i = afterGroup;
+        continue;
+      }
+
+      if (quantifier.unbounded && frame.hasInnerUnbounded) {
+        const construct = pattern.slice(frame.start, quantifier.end);
+        return `nested unbounded quantifier at offset ${String(frame.start)}: ${JSON.stringify(construct)}`;
+      }
+
+      if (quantifier.unbounded) {
+        const enclosing = stack[stack.length - 1];
+        if (enclosing !== undefined) {
+          enclosing.hasInnerUnbounded = true;
+        }
+      }
+      i = quantifier.end;
+      continue;
+    }
+
+    if (char === "|") {
+      i += 1;
+      continue;
+    }
+
+    // An ordinary literal atom (or a bare, unattached quantifier character
+    // in a pattern this scan never assumes compiles) — check for a
+    // quantifier right after it, the same as every other atom kind above.
+    i = applyQuantifier(pattern, i + 1, stack);
+  }
+
+  return undefined;
+}

--- a/tests/fixtures/lint/matcher-catastrophic/clean.json
+++ b/tests/fixtures/lint/matcher-catastrophic/clean.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lint/matcher-catastrophic/guard.sh
+++ b/tests/fixtures/lint/matcher-catastrophic/guard.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo ok

--- a/tests/fixtures/lint/matcher-catastrophic/violating.json
+++ b/tests/fixtures/lint/matcher-catastrophic/violating.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "(a+)+$",
+        "hooks": [{ "type": "command", "command": "./guard.sh" }]
+      }
+    ]
+  }
+}

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -171,7 +171,7 @@ function commandContext(
   };
 }
 
-/** The five matcher rules a prior issue ships, in `LINT_RULES`'s own order. */
+/** The six matcher rules, in `LINT_RULES`'s own order. */
 const RULE_IDS = [
   "matcher-is-array",
   "matcher-case",
@@ -179,6 +179,7 @@ const RULE_IDS = [
   "matcher-hyphen-version",
   "matcher-dead",
   "matcher-unanchored",
+  "matcher-catastrophic",
 ] as const;
 
 /** The six command/exit-code rules this issue ships, in `LINT_RULES`'s own order. */
@@ -192,7 +193,7 @@ const COMMAND_RULE_IDS = [
 ] as const;
 
 describe("LINT_RULES: the registry", () => {
-  it("registers exactly the five matcher rules and the six command/exit-code rules", () => {
+  it("registers exactly the six matcher rules and the six command/exit-code rules", () => {
     expect(LINT_RULES.map((rule) => rule.id)).toEqual([
       ...RULE_IDS,
       ...COMMAND_RULE_IDS,
@@ -446,6 +447,56 @@ describe("matcher-unanchored", () => {
     const [finding] = rule.run(unanchoredCtx("Edit|Write.*"));
 
     expect(finding?.suggestion).toContain('"^(?:Edit|Write.*)$"');
+  });
+});
+
+describe("matcher-catastrophic", () => {
+  it("names the flagged construct in its message", () => {
+    const source = ruleFixtureSource("matcher-catastrophic", "violating.json");
+    const [finding] = ruleById("matcher-catastrophic").run(contextFor(source));
+
+    expect(finding?.message).toContain('"(a+)+$"');
+    expect(finding?.message).toContain("nested unbounded quantifier");
+    expect(finding?.message).toContain('"(a+)+"');
+  });
+
+  it("suggests rewriting without a nested quantifier, not a restatement of the message", () => {
+    const source = ruleFixtureSource("matcher-catastrophic", "violating.json");
+    const [finding] = ruleById("matcher-catastrophic").run(contextFor(source));
+
+    expect(finding?.suggestion).toContain("nested quantifier");
+    expect(finding?.suggestion).not.toBe(finding?.message);
+  });
+
+  it("never flags a matcher whose regex-path pattern has no nested unbounded quantifier", () => {
+    const source = ruleFixtureSource("matcher-catastrophic", "clean.json");
+    expect(ruleById("matcher-catastrophic").run(contextFor(source))).toEqual([]);
+  });
+
+  it("applies regardless of the event's matcherTargets.kind, unlike matcher-unanchored", () => {
+    const ctx: LintContext = {
+      spec: REAL_SPEC,
+      versionContext: UNDETERMINED,
+      // Stop's matcherTargets.kind is "none" — a target-based rule such as
+      // matcher-unanchored has no reason to run there, but a catastrophic
+      // pattern is still dangerous to compile regardless of what it would
+      // be tested against.
+      groups: [
+        {
+          file: ruleFixtureSource("matcher-catastrophic", "violating.json").path,
+          layer: "project",
+          event: "Stop",
+          line: 1,
+          matcher: { kind: "string", value: "(a+)+$" },
+        },
+      ],
+      commands: [],
+      projectRoot: REPO_ROOT,
+      pathEnv: undefined,
+      homeDir: undefined,
+    };
+    const findings = ruleById("matcher-catastrophic").run(ctx);
+    expect(findings).toHaveLength(1);
   });
 });
 

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -3,7 +3,11 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { classifyMatcher, matchHooks } from "../src/internal/matcher/index.js";
+import {
+  classifyMatcher,
+  findCatastrophicConstruct,
+  matchHooks,
+} from "../src/internal/matcher/index.js";
 import type { MatchRequest, VersionContext } from "../src/internal/matcher/index.js";
 import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
 import type { Spec } from "../src/internal/spec/index.js";
@@ -552,5 +556,99 @@ describe("matcherTargets.kind: none", () => {
 
     expect(result.firing).toEqual([hook]);
     expect(result.matcherIgnored).toEqual([]);
+  });
+});
+
+describe("findCatastrophicConstruct: screening nested unbounded quantifiers", () => {
+  const POSITIVES: readonly string[] = ["(a+)+$", "(a*)*b", "((ab)*)*", "(x+x+)+y"];
+
+  it.each(POSITIVES)("flags %s as a nested unbounded quantifier", (pattern) => {
+    const construct = findCatastrophicConstruct(pattern);
+    expect(construct).toBeDefined();
+    expect(construct).toContain("nested unbounded quantifier at offset");
+  });
+
+  it("names the offset and quotes the exact flagged construct for (a+)+$", () => {
+    expect(findCatastrophicConstruct("(a+)+$")).toBe(
+      'nested unbounded quantifier at offset 0: "(a+)+"',
+    );
+  });
+
+  const NEGATIVES: readonly string[] = [
+    "Edit|Write",
+    "Notebook.*",
+    "^mcp__[a-z]+__.*$",
+    "a{2,5}",
+    "\\(a+\\)+",
+    "[(+]+",
+    // Ambiguous alternation with no nested quantifier is deliberately out
+    // of scope — see safety.ts's own remarks and this issue's design.
+    "(a|aa)+$",
+  ];
+
+  it.each(NEGATIVES)("does not flag %s", (pattern) => {
+    expect(findCatastrophicConstruct(pattern)).toBeUndefined();
+  });
+});
+
+describe("a catastrophic matcher: screened rather than compiled and run", () => {
+  // (a+)+$ against a target with no trailing match is the textbook
+  // catastrophic-backtracking case: absent a screen, `new
+  // RegExp("(a+)+$").test("a".repeat(40) + "b")` never returns in any
+  // practical time. These tests exist to prove the screen actually keeps
+  // that regex from ever being compiled — a test that only checks the
+  // classifier's return value would pass even if match.ts still called
+  // `new RegExp` on the pattern before discarding the result.
+  const PATTERN = "(a+)+$";
+  const TARGET = `${"a".repeat(40)}b`;
+
+  it("classifyMatcher classifies it as unknown, not unanchored-regex", () => {
+    expect(classifyMatcher(REAL_SPEC, IN_RANGE_VERSION, "PreToolUse", PATTERN)).toBe(
+      "unknown",
+    );
+  });
+
+  it("matchHooks rejects it as unknown, naming the construct in the reason, well within the test's own timeout", () => {
+    const hook = makeHook("PreToolUse", PATTERN);
+    const result = matchHooks(
+      REAL_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, TARGET),
+    );
+
+    expect(result.firing).toEqual([]);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]?.kind).toBe("unknown");
+    expect(result.rejected[0]?.reason).toBe(
+      'this matcher cannot be evaluated safely: nested unbounded quantifier at offset 0: "(a+)+"; rewrite it without a nested quantifier',
+    );
+  });
+
+  it("never even constructs a RegExp from the catastrophic pattern — proof it is screened, not merely discarded after a fast failure", () => {
+    const OriginalRegExp = globalThis.RegExp;
+    const constructedWith: unknown[] = [];
+
+    class SpyRegExp extends OriginalRegExp {
+      constructor(pattern?: string | RegExp, flags?: string) {
+        constructedWith.push(pattern);
+        super(pattern as string, flags);
+      }
+    }
+    globalThis.RegExp = SpyRegExp as unknown as RegExpConstructor;
+
+    try {
+      const hook = makeHook("PreToolUse", PATTERN);
+      const result = matchHooks(
+        REAL_SPEC,
+        IN_RANGE_VERSION,
+        requestFor("PreToolUse", hook, TARGET),
+      );
+      expect(result.rejected).toHaveLength(1);
+      expect(result.rejected[0]?.kind).toBe("unknown");
+    } finally {
+      globalThis.RegExp = OriginalRegExp;
+    }
+
+    expect(constructedWith).not.toContain(PATTERN);
   });
 });

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -560,7 +560,17 @@ describe("matcherTargets.kind: none", () => {
 });
 
 describe("findCatastrophicConstruct: screening nested unbounded quantifiers", () => {
-  const POSITIVES: readonly string[] = ["(a+)+$", "(a*)*b", "((ab)*)*", "(x+x+)+y"];
+  const POSITIVES: readonly string[] = [
+    "(a+)+$",
+    "(a*)*b",
+    "((ab)*)*",
+    "(x+x+)+y",
+    // A nested unbounded quantifier sitting one quantifier-less wrapper
+    // group deeper — see issue #28's F1 finding.
+    "((a+))+",
+    // Same, but the wrapper carries its own bounded quantifier.
+    "((a+)?)+",
+  ];
 
   it.each(POSITIVES)("flags %s as a nested unbounded quantifier", (pattern) => {
     const construct = findCatastrophicConstruct(pattern);
@@ -621,6 +631,64 @@ describe("a catastrophic matcher: screened rather than compiled and run", () => 
     expect(result.rejected[0]?.kind).toBe("unknown");
     expect(result.rejected[0]?.reason).toBe(
       'this matcher cannot be evaluated safely: nested unbounded quantifier at offset 0: "(a+)+"; rewrite it without a nested quantifier',
+    );
+  });
+
+  it("never even constructs a RegExp from the catastrophic pattern — proof it is screened, not merely discarded after a fast failure", () => {
+    const OriginalRegExp = globalThis.RegExp;
+    const constructedWith: unknown[] = [];
+
+    class SpyRegExp extends OriginalRegExp {
+      constructor(pattern?: string | RegExp, flags?: string) {
+        constructedWith.push(pattern);
+        super(pattern as string, flags);
+      }
+    }
+    globalThis.RegExp = SpyRegExp as unknown as RegExpConstructor;
+
+    try {
+      const hook = makeHook("PreToolUse", PATTERN);
+      const result = matchHooks(
+        REAL_SPEC,
+        IN_RANGE_VERSION,
+        requestFor("PreToolUse", hook, TARGET),
+      );
+      expect(result.rejected).toHaveLength(1);
+      expect(result.rejected[0]?.kind).toBe("unknown");
+    } finally {
+      globalThis.RegExp = OriginalRegExp;
+    }
+
+    expect(constructedWith).not.toContain(PATTERN);
+  });
+});
+
+describe("a nested unbounded quantifier behind a wrapper group: screened rather than compiled and run", () => {
+  // ((a+))+ is (a+)+ one quantifier-less wrapper group deeper — the F1
+  // regression for issue #28. Same proof shape as the `(a+)+$` block above:
+  // the screen must catch it before `new RegExp` is ever reached.
+  const PATTERN = "((a+))+$";
+  const TARGET = `${"a".repeat(40)}b`;
+
+  it("classifyMatcher classifies it as unknown, not unanchored-regex", () => {
+    expect(classifyMatcher(REAL_SPEC, IN_RANGE_VERSION, "PreToolUse", PATTERN)).toBe(
+      "unknown",
+    );
+  });
+
+  it("matchHooks rejects it as unknown, naming the construct in the reason, well within the test's own timeout", () => {
+    const hook = makeHook("PreToolUse", PATTERN);
+    const result = matchHooks(
+      REAL_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, TARGET),
+    );
+
+    expect(result.firing).toEqual([]);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]?.kind).toBe("unknown");
+    expect(result.rejected[0]?.reason).toBe(
+      'this matcher cannot be evaluated safely: nested unbounded quantifier at offset 0: "((a+))+"; rewrite it without a nested quantifier',
     );
   });
 


### PR DESCRIPTION
`matcher/classify.ts` compiled a settings matcher with `new RegExp(matcher).test(target)` with no complexity guard, so a pattern like `(a+)+$` could hang `explain`, `lint`, and `test` through catastrophic backtracking with no output and no way to attribute the hang to a hook. AGENTS.md promises the static layer is safe to run over any settings tree; an unbounded regex broke that promise.

Implements the issue's decided design — **screen, do not bound**. A new `findCatastrophicConstruct` in `src/internal/matcher/safety.ts` is a pure single-pass scanner (no worker, no child process, no runtime dependency — `matcher/` is static and may not spawn) that detects an unbounded quantifier applied to a group that itself contains one. `classify.ts` degrades such a matcher to `"unknown"` before it is ever compiled, and a new `matcher-catastrophic` lint rule reports it as a `Finding` with a rewrite suggestion.

Closes #28

Release impact: yes — MINOR. Adds a `matcher-catastrophic` lint rule and a new matcher classification path, both observable in the shipped CLI's output; no change to `src/index.ts`'s exported surface.

## Test plan

- `pnpm check:quick` — format, lint, typecheck, full suite (1650 tests) green.
- `tests/matcher.test.ts` — an `it.each` positive/negative table for `findCatastrophicConstruct`, covering the issue's own examples, the wrapper-group forms `((a+))+` and `((a+)?)+`, and the explicitly out-of-scope `(a|aa)+$` as a negative.
- Regression tests prove the pathological pattern is never *compiled*, not merely classified: a `RegExp`-constructor spy asserts `matchHooks` with `(a+)+$` and `((a+))+$` against a 40-character target returns `"unknown"` naming the construct without constructing the `RegExp`.
- `tests/lint.test.ts` — `matcher-catastrophic` violating/clean fixtures wired into the shared matcher-rule tables, plus checks on the message, the suggestion, and that it fires regardless of `matcherTargets.kind`.

## Review

`/code-review low` found that the scanner dropped a popped group's "contains an unbounded quantifier" memory whenever that group carried no quantifier or a bounded one, so `((a+))+` and `((a+)?)+` still reached `new RegExp`. Fixed at the cause: the flag now propagates to the enclosing frame on every group close. Both patterns are pinned as tests.

https://claude.ai/code/session_01SL22JTzb3RmoXdnQGKbgLu
