### PR TITLE
ci: prove lint --format github annotations land on the broken line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,42 @@ jobs:
       # floor has.
       - name: Consume the packed artifact at the published Node floor
         run: node scripts/package-smoke.mjs --pack-dir .smoke
+
+  ci-annotation-proof:
+    name: GitHub annotation proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      # Runs the built CLI's `lint --format github` against #13's own
+      # matcher-is-array violating fixture and greps the job's own stdout for
+      # the exact `::error file=…,line=…,title=…::` line that fixture
+      # produces. GitHub Actions renders any `::error` line written to stdout
+      # as an annotation automatically — this step only proves the line is
+      # produced; whether it actually renders as a visible annotation on the
+      # right diff line is a human, PR-review-time check (see this issue's
+      # PR body). Piping through `grep -F` rather than trusting the lint
+      # command's own exit code is deliberate: `lint` already exits 1 on any
+      # finding, which would make this job "pass" (fail) even if the
+      # annotation format regressed or the fixture stopped matching — grep
+      # failing when the exact line is absent is what keeps this job from
+      # passing vacuously.
+      - name: Verify the lint --format github annotation line
+        run: pnpm run ci:annotation-proof

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "repo:labels": "node scripts/sync-labels.mjs",
     "check:staged": "node scripts/check-staged.mjs",
     "conformance": "node scripts/conformance.mjs",
+    "ci:annotation-proof": "node dist/cli.js lint --format github --settings tests/fixtures/lint/matcher-is-array/violating.json | grep -F '::error file=tests/fixtures/lint/matcher-is-array/violating.json,line=5,title=matcher-is-array::'",
     "check:quick": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test",
     "check:source": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:coverage && pnpm run build && pnpm run docs:build",
     "check": "pnpm run check:source && node scripts/clean.mjs .package && pnpm pack --pack-destination .package && pnpm run package:verify -- --pack-dir .package && node scripts/clean.mjs .package",

--- a/tests/ci-annotations.test.ts
+++ b/tests/ci-annotations.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The mechanical proof behind the CI job `.github/workflows/ci.yml`'s
+ * `ci-annotation-proof` job runs: `lint --format github` against #13's own
+ * `matcher-is-array` violating fixture emits the exact GitHub Actions
+ * `::error file=…,line=…,title=…::<message>` line that job greps its own
+ * output for.
+ *
+ * @remarks
+ * This is the "mechanical" half of #18's acceptance criteria — it runs on
+ * every future PR and fails the moment the annotation's exact shape
+ * regresses. The other half — that the line actually renders as a visible
+ * annotation on the correct diff line of a real GitHub Actions run — is a
+ * human, PR-review-time observation only the PR that introduced this job
+ * can make; see that PR's own body for the reviewer checklist item.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { runCli, type CliDeps } from "../src/cli.js";
+import { createUnimplementedSpawner } from "../src/internal/exec/index.js";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const VIOLATING_FIXTURE = fileURLToPath(
+  new URL("./fixtures/lint/matcher-is-array/violating.json", import.meta.url),
+);
+
+/** The shipped spec path, resolved the same way `src/cli.ts` resolves its own default. */
+const SPEC_PATH = fileURLToPath(
+  new URL("../spec/claude-code-2.1.251-2.2.0.json", import.meta.url),
+);
+
+/**
+ * The fixture's own `"matcher"` line, found by a plain text search rather
+ * than through the same JSON-position parser `src/internal/lint/parse.ts`
+ * uses to compute `Finding.line` — an independent derivation, not a restated
+ * implementation. This is what keeps the line number pinned below from
+ * silently rotting if the fixture's own formatting ever changes: it is read
+ * off the fixture itself, not hand-copied from a one-time inspection of it.
+ */
+function matcherLineNumber(fixturePath: string): number {
+  const lines = readFileSync(fixturePath, "utf8").split("\n");
+  const index = lines.findIndex((line) => line.trim().startsWith('"matcher"'));
+  if (index === -1) {
+    throw new Error(`no line starting with "matcher" found in ${fixturePath}`);
+  }
+  return index + 1;
+}
+
+/** `lint`'s own default deps, with no explicit settings/version/spawner — mirrors `explainDeps` in `tests/cli.test.ts`. */
+function lintDeps(overrides: Partial<CliDeps> = {}): CliDeps {
+  return {
+    cwd: overrides.cwd ?? REPO_ROOT,
+    home: overrides.home ?? path.join(REPO_ROOT, "tests", "fixtures", "no-such-home"),
+    env: overrides.env ?? {},
+    spawner: overrides.spawner ?? createUnimplementedSpawner(),
+    specPath: overrides.specPath ?? SPEC_PATH,
+    isTTY: overrides.isTTY ?? false,
+    confirm: overrides.confirm ?? (() => Promise.resolve(false)),
+  };
+}
+
+describe("lint --format github: the CI annotation proof's mechanical half", () => {
+  it("emits the exact expected ::error file=…,line=…,title=…::<message> line for the known broken fixture", async () => {
+    const result = await runCli(
+      ["lint", "--format", "github", "--settings", VIOLATING_FIXTURE],
+      "hookassert",
+      lintDeps(),
+    );
+
+    const relativePath = path
+      .relative(REPO_ROOT, VIOLATING_FIXTURE)
+      .split(path.sep)
+      .join("/");
+    const line = matcherLineNumber(VIOLATING_FIXTURE);
+
+    // Golden, exact-line assertion — not a substring/prefix check. Hand
+    // transcribed from `src/internal/lint/rules/matcherIsArray.ts`'s own
+    // message and suggestion text, and from `renderLintGithub`'s "Suggestion:
+    // " fold, so a change to either shows up here as a failing diff rather
+    // than an unnoticed drift.
+    const expectedLine =
+      `::error file=${relativePath},line=${String(line)},title=matcher-is-array::` +
+      `The "PreToolUse" hook's matcher is a JSON array, not a string. ` +
+      `Claude Code's settings schema rejects this, which disables every hook ` +
+      `declared in this entire settings file — not just this one hook. ` +
+      `Suggestion: Change the matcher to the string "Edit,Write" instead of a JSON array.`;
+
+    expect(result.stdout.split("\n")).toContain(expectedLine);
+  });
+
+  it("renders the annotation's file path relative to the repository/workspace root, not an unresolvable absolute path", async () => {
+    const result = await runCli(
+      ["lint", "--format", "github", "--settings", VIOLATING_FIXTURE],
+      "hookassert",
+      lintDeps({ cwd: REPO_ROOT }),
+    );
+
+    const relativePath = path
+      .relative(REPO_ROOT, VIOLATING_FIXTURE)
+      .split(path.sep)
+      .join("/");
+
+    expect(result.stdout).toContain(`file=${relativePath},`);
+    // The trap #12 left a note about: GitHub Actions resolves `file=` against
+    // the checkout root, so an absolute path never matches any line in the
+    // PR diff and the annotation silently fails to attach.
+    expect(result.stdout).not.toContain(VIOLATING_FIXTURE);
+  });
+});


### PR DESCRIPTION
Adds a `ci-annotation-proof` CI job that builds hookassert and runs `lint --format github` against #13's `matcher-is-array` violating fixture, then greps the job's own stdout for the exact `::error file=…,line=…,title=…::` line that fixture produces.

Grepping the output rather than trusting `lint`'s exit code is deliberate: `lint` already exits 1 on any finding, so an exit-code check would still "pass" if the annotation format regressed or the fixture stopped being broken. `grep` failing when the exact line is absent is what keeps the job from passing vacuously.

`tests/ci-annotations.test.ts` pins that same line as an exact-match assertion — with the fixture's line number derived from the fixture's own text rather than hardcoded — and separately proves the annotation's file path renders workspace-relative rather than as an unresolvable absolute path.

Closes #18

Release impact: no — this only adds a CI job, a package script, and a test; `src/index.ts`'s exported surface is unchanged.

## Test plan

```
pnpm exec vitest run tests/ci-annotations.test.ts
pnpm check:quick
```

Both pass locally: 40 test files / 1652 tests green, plus `tests/workflows.test.ts`'s 88 assertions covering the new job's mechanical shape (SHA-pinned actions, job timeout, `permissions: contents: read`, `persist-credentials: false`, frozen install, pnpm-before-setup-node ordering).

## Reviewer checklist — this PR only

The mechanical test above proves the `::error` line is *produced*. It cannot prove GitHub *renders* it. So, on this PR's own CI run:

- [ ] Confirm the `GitHub annotation proof` job's output renders `::error file=tests/fixtures/lint/matcher-is-array/violating.json,line=5,title=matcher-is-array::…` as a **visible annotation** (Checks tab / Files changed view), not merely that the job passed.

https://claude.ai/code/session_012my4Lq3svoxq6fF2FoyuXB
