### PR TITLE
fix: validate claudeCodeRange, sinceVersion, and matcher regex patterns at spec load time

### DIFF
--- a/schema/spec.schema.json
+++ b/schema/spec.schema.json
@@ -24,7 +24,8 @@
     "claudeCodeRange": {
       "type": "string",
       "minLength": 1,
-      "description": "The Claude Code version range this file's facts were transcribed against, as a space-separated list of comparator expressions (e.g. \">=2.1.251 <2.2.0\")."
+      "pattern": "^(>=|<=|>|<|=)\\d+\\.\\d+\\.\\d+(?:\\s+(>=|<=|>|<|=)\\d+\\.\\d+\\.\\d+)*$",
+      "description": "The Claude Code version range this file's facts were transcribed against, as a space-separated list of comparator expressions (e.g. \">=2.1.251 <2.2.0\"). Deliberately narrow: no npm range operators (\"^\", \"~\", \"x\", \"||\")."
     },
     "defaults": {
       "type": "object",
@@ -68,12 +69,20 @@
       ],
       "properties": {
         "caseSensitive": { "type": "boolean" },
-        "exactListPattern": { "type": "string", "minLength": 1 },
+        "exactListPattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Must also compile as a JavaScript regular expression. This schema cannot express that check (JSON Schema draft-07 has no `format: \"regex\"` without the `ajv-formats` dependency, which this repository deliberately does not add) — `validateSpec` (guards.ts) enforces it instead."
+        },
         "narrowExactMatchEvents": {
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         },
-        "narrowExactListPattern": { "type": "string", "minLength": 1 },
+        "narrowExactListPattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Must also compile as a JavaScript regular expression. This schema cannot express that check (JSON Schema draft-07 has no `format: \"regex\"` without the `ajv-formats` dependency, which this repository deliberately does not add) — `validateSpec` (guards.ts) enforces it instead."
+        },
         "rules": {
           "type": "array",
           "items": {
@@ -82,7 +91,11 @@
             "required": ["id", "sinceVersion"],
             "properties": {
               "id": { "type": "string", "minLength": 1 },
-              "sinceVersion": { "type": "string", "minLength": 1 }
+              "sinceVersion": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\d+\\.\\d+\\.\\d+$"
+              }
             }
           }
         }
@@ -221,7 +234,8 @@
           "items": { "type": "string" }
         },
         "sinceVersion": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
         }
       }
     }

--- a/src/internal/matcher/classify.ts
+++ b/src/internal/matcher/classify.ts
@@ -21,6 +21,11 @@
  * `findCatastrophicConstruct` before it is ever handed to `new RegExp` —
  * see that module's own remarks for why a nested unbounded quantifier
  * degrades to `"unknown"` here instead of being compiled and run.
+ *
+ * `exactListPattern` and `narrowExactListPattern` themselves are compiled
+ * with `new RegExp` below without a try/catch: `spec/guards.ts`'s
+ * `validateSpec` already rejects an uncompilable pattern at load time, so a
+ * `Spec` reaching this module is guaranteed to carry one that compiles.
  */
 
 import type { EventName } from "../../types.js";

--- a/src/internal/spec/guards.ts
+++ b/src/internal/spec/guards.ts
@@ -13,6 +13,8 @@
  * `isValidSpec` is the boolean type guard built on top of it.
  */
 
+import { CLAUDE_CODE_RANGE_PATTERN, CLAUDE_VERSION_PATTERN } from "./version.js";
+
 import type { ExitCodeEffectKind, Spec, StderrDestination } from "./types.js";
 
 const EXIT_CODE_EFFECT_KINDS: readonly ExitCodeEffectKind[] = [
@@ -105,6 +107,53 @@ function checkObjectShape(
     violations.add(path, `unrecognized property "${key}"`);
   }
   return true;
+}
+
+/**
+ * Flags a `major.minor.patch`-shaped field (`sinceVersion`) that fails
+ * {@link CLAUDE_VERSION_PATTERN}. No-op when `value` is not already a non-empty
+ * string — that shape violation is reported by the caller.
+ */
+function checkVersionPattern(
+  violations: Violations,
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || value.length === 0) {
+    return;
+  }
+  if (!CLAUDE_VERSION_PATTERN.test(value)) {
+    violations.add(path, "must be a major.minor.patch Claude Code version");
+  }
+}
+
+/**
+ * Flags a matcher-syntax pattern field (`exactListPattern`,
+ * `narrowExactListPattern`) that does not compile as a JavaScript regular
+ * expression.
+ *
+ * @remarks
+ * JSON Schema draft-07 cannot express this without `format: "regex"`, which
+ * would require the `ajv-formats` dependency this repository deliberately
+ * does not add (see `managing-dependencies`) — so `schema/spec.schema.json`
+ * cannot check this, and this guard is deliberately stricter than the schema
+ * here. No-op when `value` is not already a non-empty string — that shape
+ * violation is reported by the caller.
+ */
+function checkCompilableRegex(
+  violations: Violations,
+  path: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" || value.length === 0) {
+    return;
+  }
+  try {
+    new RegExp(value);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    violations.add(path, `must be a valid JavaScript regular expression: ${reason}`);
+  }
 }
 
 function checkMatcherTargets(
@@ -272,6 +321,8 @@ function checkMatcherRule(violations: Violations, path: string, value: unknown):
   }
   if (typeof value["sinceVersion"] !== "string" || value["sinceVersion"].length === 0) {
     violations.add(`${path}.sinceVersion`, "must be a non-empty string");
+  } else {
+    checkVersionPattern(violations, `${path}.sinceVersion`, value["sinceVersion"]);
   }
 }
 
@@ -299,6 +350,12 @@ function checkMatcherSyntax(
     value["exactListPattern"].length === 0
   ) {
     violations.add(`${path}.exactListPattern`, "must be a non-empty string");
+  } else {
+    checkCompilableRegex(
+      violations,
+      `${path}.exactListPattern`,
+      value["exactListPattern"],
+    );
   }
   if (!isNonEmptyStringArray(value["narrowExactMatchEvents"])) {
     violations.add(
@@ -311,6 +368,12 @@ function checkMatcherSyntax(
     value["narrowExactListPattern"].length === 0
   ) {
     violations.add(`${path}.narrowExactListPattern`, "must be a non-empty string");
+  } else {
+    checkCompilableRegex(
+      violations,
+      `${path}.narrowExactListPattern`,
+      value["narrowExactListPattern"],
+    );
   }
   const rules = value["rules"];
   if (!Array.isArray(rules)) {
@@ -398,6 +461,8 @@ function checkMatcherTableRow(
   const sinceVersion = value["sinceVersion"];
   if (sinceVersion !== null && typeof sinceVersion !== "string") {
     violations.add(`${path}.sinceVersion`, "must be a string or null");
+  } else if (typeof sinceVersion === "string") {
+    checkVersionPattern(violations, `${path}.sinceVersion`, sinceVersion);
   }
 }
 
@@ -431,6 +496,12 @@ export function validateSpec(value: unknown): readonly string[] {
     value["claudeCodeRange"].length === 0
   ) {
     violations.add("$.claudeCodeRange", "must be a non-empty string");
+  } else if (!CLAUDE_CODE_RANGE_PATTERN.test(value["claudeCodeRange"])) {
+    violations.add(
+      "$.claudeCodeRange",
+      "must be a space-separated list of (>=|<=|>|<|=)major.minor.patch clauses " +
+        '(the npm range operators "^", "~", "x", and "||" are not supported)',
+    );
   }
   checkDefaults(violations, "$.defaults", value["defaults"]);
   checkHookEnv(violations, "$.hookEnv", value["hookEnv"]);

--- a/src/internal/spec/index.ts
+++ b/src/internal/spec/index.ts
@@ -24,5 +24,11 @@ export type {
   StderrDestination,
 } from "./types.js";
 export { loadSpec, loadSpecFile } from "./load.js";
-export { isInDeclaredRange, meetsSinceVersion, parseClaudeVersion } from "./version.js";
+export {
+  CLAUDE_CODE_RANGE_PATTERN,
+  CLAUDE_VERSION_PATTERN,
+  isInDeclaredRange,
+  meetsSinceVersion,
+  parseClaudeVersion,
+} from "./version.js";
 export type { ClaudeVersion } from "./version.js";

--- a/src/internal/spec/version.ts
+++ b/src/internal/spec/version.ts
@@ -19,6 +19,44 @@ export interface ClaudeVersion {
   readonly patch: number;
 }
 
+/**
+ * An alias for `RegExp`, used only to annotate {@link CLAUDE_VERSION_PATTERN} and
+ * {@link CLAUDE_CODE_RANGE_PATTERN}.
+ *
+ * @remarks
+ * `tsconfig.build.json`'s `isolatedDeclarations` requires an explicit type on an
+ * exported `RegExp` constant, but `@typescript-eslint/no-inferrable-types` then
+ * rejects that exact annotation as redundant — the two gates disagree on a literal
+ * `: RegExp`. Annotating with this structurally-identical alias instead satisfies
+ * both: `no-inferrable-types` only matches the literal `RegExp` keyword, so an
+ * alias is not "trivially inferred" to it in the same way.
+ */
+type Pattern = RegExp;
+
+/**
+ * Matches a bare `major.minor.patch` Claude Code version — `parseClaudeVersion`'s
+ * grammar, and a `MatcherRule.sinceVersion` / `MatcherTableRow.sinceVersion`'s.
+ *
+ * @remarks
+ * The single source of truth for this grammar: `guards.ts` applies this pattern at
+ * spec-load time, and `schema/spec.schema.json`'s matching `pattern` strings are
+ * asserted (in `tests/spec.test.ts`) to be byte-identical to this pattern's `.source`.
+ */
+export const CLAUDE_VERSION_PATTERN: Pattern = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Matches `claudeCodeRange`: a space-separated list of `(>=|<=|>|<|=)major.minor.patch`
+ * comparator clauses — the only range grammar this package understands. The npm range
+ * operators `^`, `~`, `x`, and `||` are deliberately unsupported; see this module's own
+ * doc comment for why.
+ *
+ * @remarks
+ * The single source of truth for this grammar — see {@link CLAUDE_VERSION_PATTERN}'s
+ * remarks for how `guards.ts` and the schema stay in sync with it.
+ */
+export const CLAUDE_CODE_RANGE_PATTERN: Pattern =
+  /^(>=|<=|>|<|=)\d+\.\d+\.\d+(?:\s+(>=|<=|>|<|=)\d+\.\d+\.\d+)*$/;
+
 const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
 
 /**
@@ -68,28 +106,32 @@ interface RangeClause {
 const RANGE_CLAUSE_PATTERN = /^(>=|<=|>|<|=)(\d+\.\d+\.\d+)$/;
 
 function parseRange(range: string): readonly RangeClause[] {
-  return range
-    .trim()
-    .split(/\s+/)
-    .map((clause) => {
-      const match = RANGE_CLAUSE_PATTERN.exec(clause);
-      if (match === null) {
-        throw new TypeError(
-          `"${clause}" is not a valid claudeCodeRange comparator clause`,
-        );
-      }
-      const [, comparatorText, versionText] = match;
-      if (
-        comparatorText === undefined ||
-        versionText === undefined ||
-        !isComparator(comparatorText)
-      ) {
-        throw new TypeError(
-          `"${clause}" is not a valid claudeCodeRange comparator clause`,
-        );
-      }
-      return { comparator: comparatorText, version: parseClaudeVersion(versionText) };
-    });
+  const trimmed = range.trim();
+  if (!CLAUDE_CODE_RANGE_PATTERN.test(trimmed)) {
+    throw new TypeError(
+      `"${range}" is not a valid claudeCodeRange: expected a space-separated list of ` +
+        `(>=|<=|>|<|=)major.minor.patch clauses`,
+    );
+  }
+  return trimmed.split(/\s+/).map((clause) => {
+    const match = RANGE_CLAUSE_PATTERN.exec(clause);
+    if (match === null) {
+      throw new TypeError(
+        `"${clause}" is not a valid claudeCodeRange comparator clause`,
+      );
+    }
+    const [, comparatorText, versionText] = match;
+    if (
+      comparatorText === undefined ||
+      versionText === undefined ||
+      !isComparator(comparatorText)
+    ) {
+      throw new TypeError(
+        `"${clause}" is not a valid claudeCodeRange comparator clause`,
+      );
+    }
+    return { comparator: comparatorText, version: parseClaudeVersion(versionText) };
+  });
 }
 
 function satisfiesClause(version: ClaudeVersion, clause: RangeClause): boolean {

--- a/tests/fixtures/spec/bad-claude-code-range.json
+++ b/tests/fixtures/spec/bad-claude-code-range.json
@@ -1,0 +1,162 @@
+{
+  "specVersion": "1",
+  "claudeCodeRange": "^2.1.0",
+  "defaults": {
+    "hookTimeoutMs": 600000,
+    "promptHookTimeoutMs": 30000,
+    "agentHookTimeoutMs": 60000,
+    "reducedTimeoutMs": {
+      "UserPromptSubmit": 30000,
+      "PreModelSwitch": 30000,
+      "PostModelSwitch": 30000,
+      "MessageDisplay": 10000,
+      "SessionEnd": 1500
+    }
+  },
+  "hookEnv": {
+    "provided": [
+      "CLAUDE_PROJECT_DIR",
+      "CLAUDE_PLUGIN_ROOT",
+      "CLAUDE_PLUGIN_DATA",
+      "CLAUDE_CODE_REMOTE",
+      "CLAUDE_CODE_BRIDGE_SESSION_ID",
+      "CLAUDE_EFFORT"
+    ]
+  },
+  "matcherSyntax": {
+    "caseSensitive": true,
+    "exactListPattern": "^[A-Za-z0-9_\\- ,|]+$",
+    "narrowExactMatchEvents": [
+      "FileChanged",
+      "StopFailure"
+    ],
+    "narrowExactListPattern": "^[A-Za-z0-9_|]+$",
+    "rules": [
+      {
+        "id": "comma-separated-list",
+        "sinceVersion": "2.1.191"
+      },
+      {
+        "id": "hyphen-exact-match",
+        "sinceVersion": "2.1.195"
+      }
+    ]
+  },
+  "knownTools": [
+    "Bash",
+    "PowerShell",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Agent",
+    "Workflow",
+    "AskUserQuestion",
+    "ExitPlanMode",
+    "NotebookEdit"
+  ],
+  "events": {
+    "SessionStart": {
+      "matcherTargets": {
+        "kind": "enum",
+        "field": "source",
+        "values": [
+          "startup",
+          "resume",
+          "clear",
+          "compact",
+          "fork"
+        ]
+      },
+      "blockable": false,
+      "honorsExit2": false,
+      "jsonDecisions": [],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "transcript_path",
+          "source"
+        ]
+      }
+    },
+    "PreToolUse": {
+      "matcherTargets": {
+        "kind": "tool-name"
+      },
+      "blockable": true,
+      "honorsExit2": true,
+      "jsonDecisions": [
+        "allow",
+        "deny",
+        "ask",
+        "defer"
+      ],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "block",
+          "stderrTo": "claude"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "tool_name",
+          "tool_input",
+          "tool_use_id"
+        ]
+      }
+    }
+  },
+  "matcherTable": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "matches": [
+        "Bash"
+      ],
+      "doesNotMatch": [
+        "PowerShell"
+      ],
+      "sinceVersion": null
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "matches": [
+        "Edit",
+        "Write"
+      ],
+      "doesNotMatch": [
+        "NotebookEdit"
+      ],
+      "sinceVersion": null
+    }
+  ]
+}

--- a/tests/fixtures/spec/bad-exact-list-pattern.json
+++ b/tests/fixtures/spec/bad-exact-list-pattern.json
@@ -1,0 +1,162 @@
+{
+  "specVersion": "1",
+  "claudeCodeRange": ">=2.1.251 <2.2.0",
+  "defaults": {
+    "hookTimeoutMs": 600000,
+    "promptHookTimeoutMs": 30000,
+    "agentHookTimeoutMs": 60000,
+    "reducedTimeoutMs": {
+      "UserPromptSubmit": 30000,
+      "PreModelSwitch": 30000,
+      "PostModelSwitch": 30000,
+      "MessageDisplay": 10000,
+      "SessionEnd": 1500
+    }
+  },
+  "hookEnv": {
+    "provided": [
+      "CLAUDE_PROJECT_DIR",
+      "CLAUDE_PLUGIN_ROOT",
+      "CLAUDE_PLUGIN_DATA",
+      "CLAUDE_CODE_REMOTE",
+      "CLAUDE_CODE_BRIDGE_SESSION_ID",
+      "CLAUDE_EFFORT"
+    ]
+  },
+  "matcherSyntax": {
+    "caseSensitive": true,
+    "exactListPattern": "[",
+    "narrowExactMatchEvents": [
+      "FileChanged",
+      "StopFailure"
+    ],
+    "narrowExactListPattern": "^[A-Za-z0-9_|]+$",
+    "rules": [
+      {
+        "id": "comma-separated-list",
+        "sinceVersion": "2.1.191"
+      },
+      {
+        "id": "hyphen-exact-match",
+        "sinceVersion": "2.1.195"
+      }
+    ]
+  },
+  "knownTools": [
+    "Bash",
+    "PowerShell",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Agent",
+    "Workflow",
+    "AskUserQuestion",
+    "ExitPlanMode",
+    "NotebookEdit"
+  ],
+  "events": {
+    "SessionStart": {
+      "matcherTargets": {
+        "kind": "enum",
+        "field": "source",
+        "values": [
+          "startup",
+          "resume",
+          "clear",
+          "compact",
+          "fork"
+        ]
+      },
+      "blockable": false,
+      "honorsExit2": false,
+      "jsonDecisions": [],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "transcript_path",
+          "source"
+        ]
+      }
+    },
+    "PreToolUse": {
+      "matcherTargets": {
+        "kind": "tool-name"
+      },
+      "blockable": true,
+      "honorsExit2": true,
+      "jsonDecisions": [
+        "allow",
+        "deny",
+        "ask",
+        "defer"
+      ],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "block",
+          "stderrTo": "claude"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "tool_name",
+          "tool_input",
+          "tool_use_id"
+        ]
+      }
+    }
+  },
+  "matcherTable": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "matches": [
+        "Bash"
+      ],
+      "doesNotMatch": [
+        "PowerShell"
+      ],
+      "sinceVersion": null
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "matches": [
+        "Edit",
+        "Write"
+      ],
+      "doesNotMatch": [
+        "NotebookEdit"
+      ],
+      "sinceVersion": null
+    }
+  ]
+}

--- a/tests/fixtures/spec/bad-since-version.json
+++ b/tests/fixtures/spec/bad-since-version.json
@@ -1,0 +1,162 @@
+{
+  "specVersion": "1",
+  "claudeCodeRange": ">=2.1.251 <2.2.0",
+  "defaults": {
+    "hookTimeoutMs": 600000,
+    "promptHookTimeoutMs": 30000,
+    "agentHookTimeoutMs": 60000,
+    "reducedTimeoutMs": {
+      "UserPromptSubmit": 30000,
+      "PreModelSwitch": 30000,
+      "PostModelSwitch": 30000,
+      "MessageDisplay": 10000,
+      "SessionEnd": 1500
+    }
+  },
+  "hookEnv": {
+    "provided": [
+      "CLAUDE_PROJECT_DIR",
+      "CLAUDE_PLUGIN_ROOT",
+      "CLAUDE_PLUGIN_DATA",
+      "CLAUDE_CODE_REMOTE",
+      "CLAUDE_CODE_BRIDGE_SESSION_ID",
+      "CLAUDE_EFFORT"
+    ]
+  },
+  "matcherSyntax": {
+    "caseSensitive": true,
+    "exactListPattern": "^[A-Za-z0-9_\\- ,|]+$",
+    "narrowExactMatchEvents": [
+      "FileChanged",
+      "StopFailure"
+    ],
+    "narrowExactListPattern": "^[A-Za-z0-9_|]+$",
+    "rules": [
+      {
+        "id": "comma-separated-list",
+        "sinceVersion": "2.1"
+      },
+      {
+        "id": "hyphen-exact-match",
+        "sinceVersion": "2.1.195"
+      }
+    ]
+  },
+  "knownTools": [
+    "Bash",
+    "PowerShell",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Agent",
+    "Workflow",
+    "AskUserQuestion",
+    "ExitPlanMode",
+    "NotebookEdit"
+  ],
+  "events": {
+    "SessionStart": {
+      "matcherTargets": {
+        "kind": "enum",
+        "field": "source",
+        "values": [
+          "startup",
+          "resume",
+          "clear",
+          "compact",
+          "fork"
+        ]
+      },
+      "blockable": false,
+      "honorsExit2": false,
+      "jsonDecisions": [],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "transcript_path",
+          "source"
+        ]
+      }
+    },
+    "PreToolUse": {
+      "matcherTargets": {
+        "kind": "tool-name"
+      },
+      "blockable": true,
+      "honorsExit2": true,
+      "jsonDecisions": [
+        "allow",
+        "deny",
+        "ask",
+        "defer"
+      ],
+      "exitCodeEffects": [
+        {
+          "exitCode": 2,
+          "effect": "block",
+          "stderrTo": "claude"
+        },
+        {
+          "exitCode": 1,
+          "effect": "non-blocking-error",
+          "stderrTo": "user"
+        }
+      ],
+      "payloadShape": {
+        "verified": false,
+        "requiredKeys": [
+          "session_id",
+          "cwd",
+          "hook_event_name",
+          "tool_name",
+          "tool_input",
+          "tool_use_id"
+        ]
+      }
+    }
+  },
+  "matcherTable": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "matches": [
+        "Bash"
+      ],
+      "doesNotMatch": [
+        "PowerShell"
+      ],
+      "sinceVersion": null
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "matches": [
+        "Edit",
+        "Write"
+      ],
+      "doesNotMatch": [
+        "NotebookEdit"
+      ],
+      "sinceVersion": null
+    }
+  ]
+}

--- a/tests/spec.test.ts
+++ b/tests/spec.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 
 import { SpecNotFoundError, SpecSchemaError } from "../src/internal/errors.js";
 import {
+  CLAUDE_CODE_RANGE_PATTERN,
+  CLAUDE_VERSION_PATTERN,
   isInDeclaredRange,
   isValidSpec,
   loadSpec,
@@ -15,6 +17,7 @@ import {
   parseClaudeVersion,
   validateSpec,
 } from "../src/internal/spec/index.js";
+import type { Spec } from "../src/internal/spec/index.js";
 import type { EventName } from "../src/types.js";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -95,6 +98,39 @@ describe("loadSpecFile: the real shipped spec", () => {
     expect(error.code).toBe("ERR_SPEC_NOT_FOUND");
     expect(error.exitCode).toBe(5);
     expect(error.file).toBe(missing);
+  });
+});
+
+describe("the schema's pattern strings match version.ts's exported patterns", () => {
+  const schema = readJson(SCHEMA_PATH) as {
+    properties: {
+      claudeCodeRange: { pattern: string };
+      matcherSyntax: {
+        properties: {
+          rules: { items: { properties: { sinceVersion: { pattern: string } } } };
+        };
+      };
+    };
+    $defs: { matcherTableRow: { properties: { sinceVersion: { pattern: string } } } };
+  };
+
+  it("claudeCodeRange's pattern is byte-identical to CLAUDE_CODE_RANGE_PATTERN.source", () => {
+    expect(schema.properties.claudeCodeRange.pattern).toBe(
+      CLAUDE_CODE_RANGE_PATTERN.source,
+    );
+  });
+
+  it("matcherSyntax.rules[].sinceVersion's pattern is byte-identical to CLAUDE_VERSION_PATTERN.source", () => {
+    expect(
+      schema.properties.matcherSyntax.properties.rules.items.properties.sinceVersion
+        .pattern,
+    ).toBe(CLAUDE_VERSION_PATTERN.source);
+  });
+
+  it("matcherTableRow.sinceVersion's pattern is byte-identical to CLAUDE_VERSION_PATTERN.source", () => {
+    expect(schema.$defs.matcherTableRow.properties.sinceVersion.pattern).toBe(
+      CLAUDE_VERSION_PATTERN.source,
+    );
   });
 });
 
@@ -208,6 +244,8 @@ describe("schema and hand-written guards agree", () => {
     "bad-matcher-targets-kind.json",
     "verified-missing-fields.json",
     "empty-events.json",
+    "bad-claude-code-range.json",
+    "bad-since-version.json",
   ];
 
   it(`schema and hand-written guards agree on ${String(
@@ -231,6 +269,19 @@ describe("schema and hand-written guards agree", () => {
 
     expect(validateWithAjv(raw), "ajv should accept the shipped spec").toBe(true);
     expect(isValidSpec(raw), "guards should accept the shipped spec").toBe(true);
+  });
+
+  // exactListPattern's compile check is guard-only, on purpose: JSON Schema
+  // draft-07 cannot express "must compile as a JavaScript regular
+  // expression" without `format: "regex"`, which needs the `ajv-formats`
+  // dependency this repository deliberately does not add. This fixture's
+  // "[" is a non-empty string the schema's `minLength: 1` happily accepts,
+  // so ajv and the guards disagree here by design rather than by drift.
+  it("guard-only: rejects an uncompilable exactListPattern the schema cannot catch", () => {
+    const raw = readJson(fixturePath("bad-exact-list-pattern.json"));
+
+    expect(validateWithAjv(raw), "ajv cannot express a regex-compile check").toBe(true);
+    expect(isValidSpec(raw), "guards compile-check exactListPattern").toBe(false);
   });
 
   // The guards are a hand-written mirror of the schema, so every constraint
@@ -354,10 +405,18 @@ describe("isInDeclaredRange and meetsSinceVersion: every comparator", () => {
     );
   });
 
-  it("rejects a range whose comparator clause cannot be parsed", () => {
-    expect(() =>
-      isInDeclaredRange(specWithRange("not-a-range"), parseClaudeVersion("2.1.0")),
-    ).toThrow(TypeError);
+  // `validateSpec` now rejects a malformed claudeCodeRange at load time (see
+  // "loadSpec: claudeCodeRange, sinceVersion, and regex pattern validation"
+  // below), so `specWithRange` can no longer be used to reach `isInDeclaredRange`
+  // with one — this instead calls it directly with a hand-built, unvalidated
+  // `Spec` to prove `parseRange`/`parseClaudeVersion` remain the
+  // TypeError-throwing primitives design decision #2 says they stay.
+  it("still throws TypeError when isInDeclaredRange is called directly with an unvalidated range", () => {
+    const spec = { claudeCodeRange: "not-a-range" } as unknown as Spec;
+
+    expect(() => isInDeclaredRange(spec, parseClaudeVersion("2.1.0"))).toThrow(
+      TypeError,
+    );
   });
 
   it("meetsSinceVersion throws when sinceVersion itself is malformed", () => {
@@ -365,6 +424,49 @@ describe("isInDeclaredRange and meetsSinceVersion: every comparator", () => {
       meetsSinceVersion(parseClaudeVersion("2.1.0"), "not-a-version"),
     ).toThrow(TypeError);
   });
+});
+
+describe("loadSpec: claudeCodeRange, sinceVersion, and regex pattern validation", () => {
+  const loadRejectionCases: readonly [
+    string,
+    (spec: Record<string, unknown>) => void,
+  ][] = [
+    ["an npm-style caret range (^2.1.0)", (s) => (s["claudeCodeRange"] = "^2.1.0")],
+    ["an npm-style tilde range (~2.1)", (s) => (s["claudeCodeRange"] = "~2.1")],
+    [
+      "a matcherSyntax.rules[].sinceVersion that is not major.minor.patch (2.1)",
+      (s) =>
+        (asRecord(s["matcherSyntax"])["rules"] = [
+          { id: "comma-separated-list", sinceVersion: "2.1" },
+        ]),
+    ],
+    [
+      "an uncompilable exactListPattern ([)",
+      (s) => (asRecord(s["matcherSyntax"])["exactListPattern"] = "["),
+    ],
+  ];
+
+  it.each(loadRejectionCases)(
+    "rejects %s as SpecSchemaError (exit 5)",
+    (_name, mutate) => {
+      const raw = readJson(fixturePath("valid-minimal.json")) as Record<
+        string,
+        unknown
+      >;
+      mutate(raw);
+
+      let caught: unknown;
+      try {
+        loadSpec(raw, "synthetic");
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(SpecSchemaError);
+      expect((caught as SpecSchemaError).code).toBe("ERR_SPEC_SCHEMA");
+      expect((caught as SpecSchemaError).exitCode).toBe(5);
+    },
+  );
 });
 
 describe("loadSpecFile: filesystem edge cases", () => {
@@ -422,6 +524,8 @@ describe("validateSpec: every structural violation guards.ts checks", () => {
   const cases: readonly [string, (spec: Record<string, unknown>) => void][] = [
     ["claudeCodeRange wrong type", (s) => (s["claudeCodeRange"] = 1)],
     ["claudeCodeRange empty string", (s) => (s["claudeCodeRange"] = "")],
+    ["claudeCodeRange npm caret range", (s) => (s["claudeCodeRange"] = "^2.1.0")],
+    ["claudeCodeRange npm tilde range", (s) => (s["claudeCodeRange"] = "~2.1")],
     ["knownTools not a string array", (s) => (s["knownTools"] = [1, 2])],
     ["matcherTable not an array", (s) => (s["matcherTable"] = "nope")],
     ["events not a record", (s) => (s["events"] = ["nope"])],
@@ -460,12 +564,20 @@ describe("validateSpec: every structural violation guards.ts checks", () => {
       (s) => (asObject(s["matcherSyntax"])["exactListPattern"] = ""),
     ],
     [
+      "matcherSyntax.exactListPattern uncompilable",
+      (s) => (asObject(s["matcherSyntax"])["exactListPattern"] = "["),
+    ],
+    [
       "matcherSyntax.narrowExactMatchEvents wrong type",
       (s) => (asObject(s["matcherSyntax"])["narrowExactMatchEvents"] = [1]),
     ],
     [
       "matcherSyntax.narrowExactListPattern empty",
       (s) => (asObject(s["matcherSyntax"])["narrowExactListPattern"] = ""),
+    ],
+    [
+      "matcherSyntax.narrowExactListPattern uncompilable",
+      (s) => (asObject(s["matcherSyntax"])["narrowExactListPattern"] = "("),
     ],
     [
       "matcherSyntax.rules not an array",
@@ -479,6 +591,11 @@ describe("validateSpec: every structural violation guards.ts checks", () => {
     [
       "matcherSyntax.rules[0].sinceVersion empty",
       (s) => (asObject(s["matcherSyntax"])["rules"] = [{ id: "x", sinceVersion: "" }]),
+    ],
+    [
+      "matcherSyntax.rules[0].sinceVersion not major.minor.patch",
+      (s) =>
+        (asObject(s["matcherSyntax"])["rules"] = [{ id: "x", sinceVersion: "2.1" }]),
     ],
 
     [
@@ -554,6 +671,10 @@ describe("validateSpec: every structural violation guards.ts checks", () => {
       "matcherTable[0].event wrong type",
       (s) => (asObject((s["matcherTable"] as unknown[])[0])["event"] = 1),
     ],
+    [
+      "matcherTable[0].sinceVersion not major.minor.patch",
+      (s) => (asObject((s["matcherTable"] as unknown[])[0])["sinceVersion"] = "2.1"),
+    ],
   ];
 
   it.each(cases)("flags: %s", (_name, mutate) => {
@@ -576,6 +697,13 @@ describe("validateSpec: every structural violation guards.ts checks", () => {
     const payloadShape = asObject(preToolUse(spec)["payloadShape"]);
     payloadShape["verifiedAt"] = "2026-08-20";
     payloadShape["againstVersion"] = "2.1.251";
+
+    expect(validateSpec(spec)).toEqual([]);
+  });
+
+  it("accepts a well-formed matcherTable[].sinceVersion string", () => {
+    const spec = base();
+    asObject((spec["matcherTable"] as unknown[])[0])["sinceVersion"] = "2.1.191";
 
     expect(validateSpec(spec)).toEqual([]);
   });


### PR DESCRIPTION
A spec declaring an unsupported `claudeCodeRange` / `sinceVersion` (npm-style `^`, `~`, `x`, `||`) or an uncompilable `exactListPattern` / `narrowExactListPattern` previously passed schema validation, loaded cleanly through `loadSpecFile`, and detonated later as a raw `TypeError` / `SyntaxError` — no `ERR_*` code, no exit 5 — the first time a caller actually parsed or compiled it.

Rejection now happens at load time, so a validated `Spec` stays safe to use: `version.ts` exports `CLAUDE_VERSION_PATTERN` and `CLAUDE_CODE_RANGE_PATTERN` as the single source of the grammar, `guards.ts` applies them plus a `new RegExp` compile check, and `schema/spec.schema.json`'s `pattern` strings are asserted byte-identical to those patterns' `.source` so the two cannot drift. Every rejection surfaces as the existing `SpecSchemaError` (`ERR_SPEC_SCHEMA`, exit 5).

`parseClaudeVersion` stays a `TypeError`-throwing primitive, as the issue's design decided — its callers already translate failures into the error vocabulary.

Closes #27

Release impact: no — the new exports (`CLAUDE_VERSION_PATTERN`, `CLAUDE_CODE_RANGE_PATTERN`) live in `src/internal/spec/index.ts`, which is never re-exported from `src/index.ts`; the published surface and the existing `SpecSchemaError` / `ERR_SPEC_SCHEMA` contract are unchanged, only stricter input rejection at load time.

## Test plan

```
pnpm check
```

Green: format, lint, typecheck, coverage-gated tests (39 files / 1665 tests), build, docs:build, package:verify.

`tests/spec.test.ts` covers:

- the schema's `pattern` strings being byte-identical to `version.ts`'s exported `.source`;
- `loadSpec` throwing `SpecSchemaError` / exit 5 for `^2.1.0`, `~2.1`, a `rules[].sinceVersion` of `2.1`, and an `exactListPattern` of `[`;
- the ajv-vs-guards fixture sweep extended with `bad-claude-code-range.json` and `bad-since-version.json` (both validators reject), plus an explicit guard-only case for `bad-exact-list-pattern.json` (ajv accepts, guards reject — documented as intentional, since draft-07 cannot express regex-compilability without `ajv-formats`, which this repo deliberately does not add);
- `parseClaudeVersion`'s existing `TypeError` pins, unchanged;
- `isInDeclaredRange` still throwing `TypeError` when called directly with an unvalidated range.

## Note for the reviewer

`CLAUDE_VERSION_PATTERN` / `CLAUDE_CODE_RANGE_PATTERN` are annotated with a local `type Pattern = RegExp` alias rather than a literal `: RegExp`. That is not stylistic: `isolatedDeclarations` requires an explicit type on the exported constant, and `@typescript-eslint/no-inferrable-types` rejects the literal `: RegExp` annotation on a regex literal ("Type RegExp trivially inferred from a RegExp literal"). The two gates disagree; the alias satisfies both without changing any config. This was verified by trying the literal annotation and reading the resulting lint failure. The reasoning is recorded inline in `version.ts`.

https://claude.ai/code/session_012my4Lq3svoxq6fF2FoyuXB
