### PR TITLE
feat: ship JSON Schemas for test and lint reports, alongside explain's

### DIFF
--- a/schema/explain-report.schema.json
+++ b/schema/explain-report.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/tomada1114/hookassert/schema/report.schema.json",
-  "title": "hookassert JSON report",
-  "description": "Schema for the `json` reporter's output (src/internal/report/json.ts): the fixed, versioned contract downstream CI tooling may parse directly.",
+  "$id": "https://github.com/tomada1114/hookassert/schema/explain-report.schema.json",
+  "title": "hookassert explain JSON report",
+  "description": "Schema for `explain --format json`'s output (src/internal/report/json.ts): the fixed, versioned contract downstream CI tooling may parse directly. `reportVersion` is versioned independently of `schema/test-report.schema.json` and `schema/lint-report.schema.json` — see `src/internal/report/format.ts`'s `renderInFormat` remark for the rule governing all three.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schema/lint-report.schema.json
+++ b/schema/lint-report.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/tomada1114/hookassert/schema/lint-report.schema.json",
+  "title": "hookassert lint JSON report",
+  "description": "Schema for `lint --format json`'s output (src/internal/report/lintReport.ts): the fixed, versioned contract downstream CI tooling may parse directly. `reportVersion` is versioned independently of `schema/explain-report.schema.json` and `schema/test-report.schema.json` — see `src/internal/report/format.ts`'s `renderInFormat` remark for the rule governing all three.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["reportVersion", "reportType", "header", "findings"],
+  "properties": {
+    "reportVersion": {
+      "const": "1",
+      "description": "Version of this report shape, independent of the package's own semver."
+    },
+    "reportType": {
+      "const": "lint",
+      "description": "Discriminates this shape from other hookassert JSON report shapes (`explain`'s, `test`'s), which reuse `reportVersion: \"1\"` for their own, independently versioned shapes."
+    },
+    "header": { "$ref": "#/$defs/header" },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claudeVersion", "specRange", "notices"],
+      "properties": {
+        "claudeVersion": { "type": "string", "minLength": 1 },
+        "specRange": { "type": "string", "minLength": 1 },
+        "notices": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "line", "ruleId", "message", "suggestion"],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 1 },
+        "ruleId": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "suggestion": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schema/test-report.schema.json
+++ b/schema/test-report.schema.json
@@ -1,0 +1,434 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/tomada1114/hookassert/schema/test-report.schema.json",
+  "title": "hookassert test JSON report",
+  "description": "Schema for `test --format json`'s output (src/internal/report/testReport.ts): the fixed, versioned contract downstream CI tooling may parse directly. `reportVersion` is versioned independently of `schema/explain-report.schema.json` and `schema/lint-report.schema.json` — see `src/internal/report/format.ts`'s `renderInFormat` remark for the rule governing all three.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["reportVersion", "reportType", "header", "cases", "summary"],
+  "properties": {
+    "reportVersion": {
+      "const": "1",
+      "description": "Version of this report shape, independent of the package's own semver."
+    },
+    "reportType": {
+      "const": "test",
+      "description": "Discriminates this shape from other hookassert JSON report shapes (`explain`'s, `lint`'s), which reuse `reportVersion: \"1\"` for their own, independently versioned shapes."
+    },
+    "header": { "$ref": "#/$defs/header" },
+    "cases": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/testCaseReport" }
+    },
+    "summary": { "$ref": "#/$defs/summary" }
+  },
+  "$defs": {
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claudeVersion", "specRange", "notices"],
+      "properties": {
+        "claudeVersion": { "type": "string", "minLength": 1 },
+        "specRange": { "type": "string", "minLength": 1 },
+        "notices": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "layer", "line", "col", "offset"],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "layer": {
+          "type": "string",
+          "enum": ["user", "project", "local", "explicit"]
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "col": { "type": "integer", "minimum": 1 },
+        "offset": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "hook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event",
+        "matcher",
+        "command",
+        "args",
+        "timeoutMs",
+        "dedupeKey",
+        "provenance"
+      ],
+      "properties": {
+        "event": { "type": "string", "minLength": 1 },
+        "matcher": { "type": ["string", "null"] },
+        "command": { "type": "string", "minLength": 1 },
+        "args": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "timeoutMs": { "type": ["number", "null"] },
+        "dedupeKey": { "type": "string", "minLength": 1 },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      }
+    },
+    "rejectedMatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hook", "reason"],
+      "properties": {
+        "hook": { "$ref": "#/$defs/hook" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind", "source", "exitCode"],
+          "properties": {
+            "kind": { "const": "deny" },
+            "source": {
+              "type": "string",
+              "enum": ["exit-code", "permission-decision"]
+            },
+            "exitCode": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "exitCode"],
+          "properties": {
+            "kind": { "const": "allow" },
+            "exitCode": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "exitCode"],
+          "properties": {
+            "kind": { "const": "pass" },
+            "exitCode": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "exitCode", "cause"],
+          "properties": {
+            "kind": { "const": "error" },
+            "exitCode": { "type": "number" },
+            "cause": {
+              "type": "string",
+              "enum": ["nonzero-exit-without-json", "invalid-json", "schema-violation"]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "reasons"],
+          "properties": {
+            "kind": { "const": "unknown" },
+            "reasons": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/unknownReason" }
+            }
+          }
+        }
+      ]
+    },
+    "decidingHook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hook", "decision"],
+      "properties": {
+        "hook": { "$ref": "#/$defs/hook" },
+        "decision": { "$ref": "#/$defs/decision" }
+      }
+    },
+    "unknownReason": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind", "detected", "specRange"],
+          "properties": {
+            "kind": { "const": "version-out-of-spec-range" },
+            "detected": { "type": "string", "minLength": 1 },
+            "specRange": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "triedSources"],
+          "properties": {
+            "kind": { "const": "version-undetermined" },
+            "triedSources": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["cli-flag", "environment-variable", "package-manifest"]
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "event", "specVersion"],
+          "properties": {
+            "kind": { "const": "payload-shape-unverified" },
+            "event": { "type": "string", "minLength": 1 },
+            "specVersion": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "files"],
+          "properties": {
+            "kind": { "const": "plugin-hooks-present" },
+            "files": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "path"],
+          "properties": {
+            "kind": { "const": "managed-settings-assumed" },
+            "path": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "event", "specVersion"],
+          "properties": {
+            "kind": { "const": "event-not-in-spec" },
+            "event": { "type": "string", "minLength": 1 },
+            "specVersion": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "event", "exitCode"],
+          "properties": {
+            "kind": { "const": "contradictory-exit-code-effect" },
+            "event": { "type": "string", "minLength": 1 },
+            "exitCode": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "expectationDiff": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedFires", "actualFires"],
+          "properties": {
+            "field": { "const": "fires" },
+            "expectedFires": { "type": "boolean" },
+            "actualFires": { "type": "boolean" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedDecision", "actualDecision"],
+          "properties": {
+            "field": { "const": "decision" },
+            "expectedDecision": {
+              "type": "string",
+              "enum": ["deny", "allow", "pass", "error", "unknown"]
+            },
+            "actualDecision": {
+              "type": "string",
+              "enum": ["deny", "allow", "pass", "error", "unknown"]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedExitCode", "actualExitCode"],
+          "properties": {
+            "field": { "const": "exitCode" },
+            "expectedExitCode": { "type": "number" },
+            "actualExitCode": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedSubstring", "actualStdout"],
+          "properties": {
+            "field": { "const": "stdoutContains" },
+            "expectedSubstring": { "type": "string" },
+            "actualStdout": { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedSubstring", "actualStderr"],
+          "properties": {
+            "field": { "const": "stderrContains" },
+            "expectedSubstring": { "type": "string" },
+            "actualStderr": { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedTimedOut", "actualTimedOut"],
+          "properties": {
+            "field": { "const": "timedOut" },
+            "expectedTimedOut": { "type": "boolean" },
+            "actualTimedOut": { "type": "boolean" }
+          }
+        }
+      ]
+    },
+    "nonFiringExplanation": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind", "hooks"],
+          "properties": {
+            "kind": { "const": "matcher-did-not-match" },
+            "hooks": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/rejectedMatch" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "event"],
+          "properties": {
+            "kind": { "const": "no-hook-configured" },
+            "event": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "hooks"],
+          "properties": {
+            "kind": { "const": "excluded-settings-layer" },
+            "hooks": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/hook" }
+            }
+          }
+        }
+      ]
+    },
+    "caseResult": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind", "origin", "decidedBy"],
+          "properties": {
+            "kind": { "const": "pass" },
+            "origin": { "$ref": "#/$defs/payloadOrigin" },
+            "decidedBy": {
+              "anyOf": [{ "$ref": "#/$defs/decidingHook" }, { "type": "null" }]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "origin", "diffs", "nonFiring", "decidedBy"],
+          "properties": {
+            "kind": { "const": "fail" },
+            "origin": { "$ref": "#/$defs/payloadOrigin" },
+            "diffs": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/expectationDiff" }
+            },
+            "nonFiring": {
+              "anyOf": [{ "$ref": "#/$defs/nonFiringExplanation" }, { "type": "null" }]
+            },
+            "decidedBy": {
+              "anyOf": [{ "$ref": "#/$defs/decidingHook" }, { "type": "null" }]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "origin", "reasons", "decidedBy"],
+          "properties": {
+            "kind": { "const": "unknown" },
+            "origin": { "$ref": "#/$defs/payloadOrigin" },
+            "reasons": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/unknownReason" }
+            },
+            "decidedBy": {
+              "anyOf": [{ "$ref": "#/$defs/decidingHook" }, { "type": "null" }]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "origin", "reason"],
+          "properties": {
+            "kind": { "const": "skipped" },
+            "origin": { "$ref": "#/$defs/payloadOrigin" },
+            "reason": { "type": "string", "enum": ["dry-run", "stub-only"] }
+          }
+        }
+      ]
+    },
+    "payloadOrigin": {
+      "type": "object",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind", "capturedAt", "sourceFile", "claudeVersion"],
+          "properties": {
+            "kind": { "const": "recorded" },
+            "capturedAt": { "type": "string", "minLength": 1 },
+            "sourceFile": { "type": "string", "minLength": 1 },
+            "claudeVersion": { "type": ["string", "null"] }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind": { "const": "synthetic" }
+          }
+        }
+      ]
+    },
+    "testCaseReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "index", "event", "tool", "result"],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "index": { "type": "integer", "minimum": 0 },
+        "event": { "type": "string", "minLength": 1 },
+        "tool": { "type": ["string", "null"] },
+        "result": { "$ref": "#/$defs/caseResult" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asserted", "fromRecorded", "failed", "unknown", "skipped"],
+      "properties": {
+        "asserted": { "type": "integer", "minimum": 0 },
+        "fromRecorded": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "unknown": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/scripts/lib/conformance/predicted.mjs
+++ b/scripts/lib/conformance/predicted.mjs
@@ -88,7 +88,7 @@ export function firedInExplainReport(explainReport, matcher) {
   if (!Array.isArray(firing)) {
     throw new ReportShapeError(
       "explain --format json report has no `firing` array.\n" +
-        "Expected: JsonExplainReport (schema/report.schema.json).\n" +
+        "Expected: JsonExplainReport (schema/explain-report.schema.json).\n" +
         "Next: run `node dist/cli.js explain <event> <tool> --format json` directly and compare its shape.",
     );
   }

--- a/src/internal/report/format.ts
+++ b/src/internal/report/format.ts
@@ -2,11 +2,20 @@
  * The one place a `--format` value turns into an actual rendering.
  *
  * @remarks
- * Static layer: pure — no I/O, no process, no write. `explain` calls
- * {@link renderInFormat} today; `lint` and `test` route through it unchanged
- * once they exist, each supplying its own {@link FormatRenderers} for its own
- * result shape, so the three subcommands can never drift on which formats
- * exist or silently reimplement the same `switch` three times.
+ * Static layer: pure — no I/O, no process, no write. `explain`, `lint`, and
+ * `test` each call {@link renderInFormat}, supplying their own
+ * {@link FormatRenderers} for their own result shape, so the three
+ * subcommands can never drift on which formats exist or silently reimplement
+ * the same `switch` three times.
+ *
+ * Each of those three shapes' own `reportVersion` (`JsonExplainReport` in
+ * `report/json.ts`, `JsonTestReport` in `report/testReport.ts`,
+ * `JsonLintReport` in `report/lintReport.ts`) is versioned independently, and
+ * so is its own shipped schema — `schema/explain-report.schema.json`,
+ * `schema/test-report.schema.json`, and `schema/lint-report.schema.json`,
+ * respectively. This is the one place that rule is written down: bump a
+ * shape's `reportVersion` and update its schema in the same change. Each
+ * shape's own module points back at this remark rather than restating it.
  */
 
 import { UsageError } from "../errors.js";
@@ -23,8 +32,8 @@ export function isReportFormat(value: string): value is ReportFormat {
 
 /**
  * One renderer per {@link ReportFormat}, all rendering the same report shape
- * `T` — `ExplainReport` for `explain` today, whatever `lint`/`test` produce
- * once they exist.
+ * `T` — `ExplainReport` for `explain`, `TestReport` for `test`, `LintReport`
+ * for `lint`.
  */
 export interface FormatRenderers<T> {
   readonly pretty: (report: T) => string;

--- a/src/internal/report/json.ts
+++ b/src/internal/report/json.ts
@@ -1,9 +1,9 @@
 /**
  * The `json` reporter: a fixed, versioned rendering of an `ExplainReport`,
- * checked against `schema/report.schema.json`.
+ * checked against `schema/explain-report.schema.json`.
  *
  * @remarks
- * Static layer: pure — no I/O, no process, no write. `schema/report.schema.json`
+ * Static layer: pure — no I/O, no process, no write. `schema/explain-report.schema.json`
  * is a shipped public contract from the moment it ships: a later change to
  * this module's output shape needs the same `release-impact` review a
  * `src/index.ts` change would, because downstream CI tooling may parse this
@@ -14,8 +14,19 @@ import type { EventName, Provenance, ResolvedHook } from "../../types.js";
 import type { MatcherKind } from "../matcher/index.js";
 import type { ExplainReport } from "./summary.js";
 
-/** JSON shape of a {@link Provenance}, mirroring `schema/report.schema.json`'s `$defs.provenance`. */
-interface JsonProvenance {
+/**
+ * JSON shape of a {@link Provenance}, mirroring `$defs.provenance` — written
+ * out identically in every one of `schema/explain-report.schema.json`,
+ * `schema/test-report.schema.json`, and `schema/lint-report.schema.json`
+ * that carries one.
+ *
+ * @remarks
+ * Exported only because {@link JsonHook} — itself exported so
+ * `testReport.ts` can reuse {@link toJsonHook} rather than re-deriving the
+ * same `undefined` → `null` substitution a second time — carries this as a
+ * field's type.
+ */
+export interface JsonProvenance {
   readonly file: string;
   readonly layer: string;
   readonly line: number;
@@ -24,7 +35,7 @@ interface JsonProvenance {
 }
 
 /** JSON shape of a {@link ResolvedHook}, without the `matcherIgnored` field only a firing hook carries. */
-interface JsonHook {
+export interface JsonHook {
   readonly event: EventName;
   readonly matcher: string | null;
   readonly command: string;
@@ -47,18 +58,20 @@ interface JsonRejectedOutcome {
 }
 
 /**
- * The shape `renderJson` emits, validated by `schema/report.schema.json`.
+ * The shape `renderJson` emits, validated by `schema/explain-report.schema.json`.
  *
  * @remarks
  * `reportVersion` is this contract's own version, independent of the
- * package's own semver — a later issue reshaping this output bumps
- * `reportVersion` and updates the schema in the same change, per
- * `release-impact`. `reportType` is a separate, narrower discriminator: both
- * this shape and `test`'s own `JsonTestReport` (`testReport.ts`) currently
- * claim `reportVersion: "1"`, since each versions its own shape independently,
- * so `reportType` is what lets a consumer — or `schema/report.schema.json`,
- * which pins `"explain"` — tell the two apart before trusting `reportVersion`
- * to mean this document's shape rather than the other one's.
+ * package's own semver and of `test`'s and `lint`'s own `reportVersion` —
+ * see `renderInFormat`'s remark (`src/internal/report/format.ts`) for the
+ * rule that keeps a reshape of this output, its `reportVersion`, and
+ * `schema/explain-report.schema.json` moving together. `reportType` is a
+ * separate, narrower discriminator: this shape and `test`'s own
+ * `JsonTestReport` (`testReport.ts`) both currently claim `reportVersion:
+ * "1"`, since each versions its own shape independently, so `reportType` is
+ * what lets a consumer — or `schema/explain-report.schema.json`, which pins
+ * `"explain"` — tell the two apart before trusting `reportVersion` to mean
+ * this document's shape rather than the other one's.
  */
 export interface JsonExplainReport {
   readonly reportVersion: "1";
@@ -74,6 +87,7 @@ export interface JsonExplainReport {
   readonly rejected: readonly JsonRejectedOutcome[];
 }
 
+/** Build the {@link JsonProvenance} for one {@link Provenance}. */
 function toJsonProvenance(provenance: Provenance): JsonProvenance {
   return {
     file: provenance.file,
@@ -84,7 +98,8 @@ function toJsonProvenance(provenance: Provenance): JsonProvenance {
   };
 }
 
-function toJsonHook(hook: ResolvedHook): JsonHook {
+/** Build the {@link JsonHook} for one {@link ResolvedHook}. */
+export function toJsonHook(hook: ResolvedHook): JsonHook {
   return {
     event: hook.event,
     matcher: hook.matcher ?? null,
@@ -122,7 +137,7 @@ export function toJsonReport(report: ExplainReport): JsonExplainReport {
 }
 
 /**
- * Render an {@link ExplainReport} as JSON matching `schema/report.schema.json`.
+ * Render an {@link ExplainReport} as JSON matching `schema/explain-report.schema.json`.
  *
  * @remarks
  * The header's `claudeVersion`, `specRange`, and `notices` are carried as

--- a/src/internal/report/lintReport.ts
+++ b/src/internal/report/lintReport.ts
@@ -59,16 +59,16 @@ interface JsonLintFinding {
 }
 
 /**
- * The shape `renderLintJson` emits.
+ * The shape `renderLintJson` emits, validated by `schema/lint-report.schema.json`.
  *
  * @remarks
  * `reportVersion` is versioned independently of `explain`'s own
  * `JsonExplainReport` (`report/json.ts`) and `test`'s own `JsonTestReport`
- * (`testReport.ts`) — each currently claims `reportVersion: "1"` for its
- * own, different shape. `reportType` disambiguates the three: unlike
- * `explain`'s `JsonExplainReport`, this shape has no `schema/*.schema.json`
- * of its own yet — a later issue that wants schema-checked `lint` JSON adds
- * one against this documented shape rather than reshaping it silently.
+ * (`testReport.ts`) — see `renderInFormat`'s remark
+ * (`src/internal/report/format.ts`) for the rule that keeps a reshape of
+ * this output, its `reportVersion`, and the schema moving together.
+ * `reportType` disambiguates the three: each currently claims
+ * `reportVersion: "1"` for its own, different shape.
  */
 export interface JsonLintReport {
   readonly reportVersion: "1";

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -14,6 +14,7 @@
 
 import type {
   CaseResult,
+  Decision,
   DecidingHook,
   EventName,
   ExpectationDiff,
@@ -27,6 +28,7 @@ import {
   renderGithubFinding,
   renderGithubHeader,
 } from "./github.js";
+import { toJsonHook, type JsonHook } from "./json.js";
 import type { ReportHeader } from "./summary.js";
 
 /** One fixture case's result, identified by which file and position it came from. */
@@ -203,50 +205,168 @@ export function renderTestPretty(report: TestReport): string {
 }
 
 /**
- * `CaseResult`, with `decidedBy` normalized to `null` rather than dropped
- * when absent.
+ * JSON shape of a {@link PayloadOrigin}'s `"recorded"` member, with
+ * `claudeVersion` normalized to `null` rather than dropped when the envelope
+ * carried none.
  *
  * @remarks
  * `JSON.stringify` omits an object property whose value is `undefined`
- * rather than emitting `null` for it, so `CaseResult.decidedBy` would
- * silently vanish from a `"pass"`/`"unknown"` result's JSON rather than
- * appearing as the explicit `null` a consumer can rely on being present.
- * `toJsonCaseResult` is the one place that substitution happens.
+ * rather than emitting `null` for it, so a `"recorded"` origin whose envelope
+ * carries no `claudeVersion` would silently drop the key from the JSON
+ * rather than appearing as the explicit `null` `schema/test-report.schema.json`
+ * requires.
+ */
+type JsonPayloadOrigin =
+  | {
+      readonly kind: "recorded";
+      readonly capturedAt: string;
+      readonly sourceFile: string;
+      readonly claudeVersion: string | null;
+    }
+  | {
+      readonly kind: "synthetic";
+    };
+
+/** Build the {@link JsonPayloadOrigin} for one {@link PayloadOrigin}. */
+function toJsonPayloadOrigin(origin: PayloadOrigin): JsonPayloadOrigin {
+  if (origin.kind === "synthetic") {
+    return origin;
+  }
+  return {
+    kind: "recorded",
+    capturedAt: origin.capturedAt,
+    sourceFile: origin.sourceFile,
+    claudeVersion: origin.claudeVersion ?? null,
+  };
+}
+
+/**
+ * JSON shape of a {@link DecidingHook}, with its own `hook` converted through
+ * `json.ts`'s {@link toJsonHook} rather than left as a raw `ResolvedHook` —
+ * whose `matcher`/`args`/`timeoutMs` are `T | undefined`, which
+ * `JSON.stringify` would drop the same way an un-mapped `nonFiring` would.
+ */
+interface JsonDecidingHook {
+  readonly hook: JsonHook;
+  readonly decision: Decision;
+}
+
+/** Build the {@link JsonDecidingHook} for one {@link DecidingHook}. */
+function toJsonDecidingHook(decidedBy: DecidingHook): JsonDecidingHook {
+  return { hook: toJsonHook(decidedBy.hook), decision: decidedBy.decision };
+}
+
+/** `CaseResult`'s `decidedBy`, converted and `undefined` normalized to `null`. */
+function toJsonDecidedBy(decidedBy: DecidingHook | undefined): JsonDecidingHook | null {
+  return decidedBy === undefined ? null : toJsonDecidingHook(decidedBy);
+}
+
+/** JSON shape of a {@link NonFiringExplanation}, with every `ResolvedHook` it carries converted through {@link toJsonHook}. */
+type JsonNonFiringExplanation =
+  | {
+      readonly kind: "matcher-did-not-match";
+      readonly hooks: readonly { readonly hook: JsonHook; readonly reason: string }[];
+    }
+  | {
+      readonly kind: "no-hook-configured";
+      readonly event: EventName;
+    }
+  | {
+      readonly kind: "excluded-settings-layer";
+      readonly hooks: readonly JsonHook[];
+    };
+
+/** Build the {@link JsonNonFiringExplanation} for one {@link NonFiringExplanation}. */
+function toJsonNonFiringExplanation(
+  nonFiring: NonFiringExplanation,
+): JsonNonFiringExplanation {
+  switch (nonFiring.kind) {
+    case "matcher-did-not-match":
+      return {
+        kind: "matcher-did-not-match",
+        hooks: nonFiring.hooks.map((rejected) => ({
+          hook: toJsonHook(rejected.hook),
+          reason: rejected.reason,
+        })),
+      };
+    case "no-hook-configured":
+      return nonFiring;
+    case "excluded-settings-layer":
+      return {
+        kind: "excluded-settings-layer",
+        hooks: nonFiring.hooks.map((hook) => toJsonHook(hook)),
+      };
+  }
+}
+
+/**
+ * `CaseResult`, mapped field by field to the shape
+ * `schema/test-report.schema.json` describes: every value `CaseResult` may
+ * leave absent (`decidedBy`, a `"fail"` result's `nonFiring`, a `"recorded"`
+ * origin's `claudeVersion`, a `decidedBy`/`nonFiring` hook's own `matcher`/
+ * `args`/`timeoutMs`) is written out as an explicit `null` rather than an
+ * omitted key, and `additionalProperties: false` plus a full `required` list
+ * in the schema is honest about what every rendering actually carries.
+ *
+ * @remarks
+ * Deliberately not a `CaseResult` pass-through (`{ ...result, ... }`): a
+ * field added to `CaseResult` later must be considered here and reflected in
+ * the schema in the same change, per `renderInFormat`'s remark
+ * (`src/internal/report/format.ts`), rather than silently reaching the JSON
+ * report — or silently failing to — without anyone noticing.
  */
 type JsonCaseResult =
   | {
       readonly kind: "pass";
-      readonly origin: PayloadOrigin;
-      readonly decidedBy: DecidingHook | null;
+      readonly origin: JsonPayloadOrigin;
+      readonly decidedBy: JsonDecidingHook | null;
     }
   | {
       readonly kind: "fail";
-      readonly origin: PayloadOrigin;
+      readonly origin: JsonPayloadOrigin;
       readonly diffs: readonly ExpectationDiff[];
-      readonly nonFiring: NonFiringExplanation | undefined;
-      readonly decidedBy: DecidingHook | null;
+      readonly nonFiring: JsonNonFiringExplanation | null;
+      readonly decidedBy: JsonDecidingHook | null;
     }
   | {
       readonly kind: "unknown";
-      readonly origin: PayloadOrigin;
+      readonly origin: JsonPayloadOrigin;
       readonly reasons: readonly [UnknownReason, ...UnknownReason[]];
-      readonly decidedBy: DecidingHook | null;
+      readonly decidedBy: JsonDecidingHook | null;
     }
   | {
       readonly kind: "skipped";
-      readonly origin: PayloadOrigin;
+      readonly origin: JsonPayloadOrigin;
       readonly reason: "dry-run" | "stub-only";
     };
 
 /** Build the {@link JsonCaseResult} `renderTestJson` emits for one `CaseResult`. */
 function toJsonCaseResult(result: CaseResult): JsonCaseResult {
-  if (result.kind === "skipped") {
-    return result;
+  const origin = toJsonPayloadOrigin(result.origin);
+  switch (result.kind) {
+    case "pass":
+      return { kind: "pass", origin, decidedBy: toJsonDecidedBy(result.decidedBy) };
+    case "fail":
+      return {
+        kind: "fail",
+        origin,
+        diffs: result.diffs,
+        nonFiring:
+          result.nonFiring === undefined
+            ? null
+            : toJsonNonFiringExplanation(result.nonFiring),
+        decidedBy: toJsonDecidedBy(result.decidedBy),
+      };
+    case "unknown":
+      return {
+        kind: "unknown",
+        origin,
+        reasons: result.reasons,
+        decidedBy: toJsonDecidedBy(result.decidedBy),
+      };
+    case "skipped":
+      return { kind: "skipped", origin, reason: result.reason };
   }
-  // Spread rather than rebuild field by field: a field added to `CaseResult`
-  // later then reaches the JSON report on its own, instead of silently
-  // vanishing from it until someone notices this function was not updated.
-  return { ...result, decidedBy: result.decidedBy ?? null };
 }
 
 /** JSON-serializable shape one {@link TestCaseReport} renders to. */
@@ -259,15 +379,17 @@ interface JsonTestCaseReport {
 }
 
 /**
- * The shape `renderTestJson` emits.
+ * The shape `renderTestJson` emits, validated by `schema/test-report.schema.json`.
  *
  * @remarks
  * `reportVersion` is versioned independently of `explain`'s own
- * `JsonExplainReport` (`report/json.ts`) — both currently claim
- * `reportVersion: "1"` for their own, different shapes. `reportType`
- * disambiguates the two: `schema/report.schema.json`, the one shipped schema
- * so far, pins its `reportType` to `"explain"` and would reject this shape,
- * which is deliberate — this shape has no schema of its own yet.
+ * `JsonExplainReport` (`report/json.ts`) and `lint`'s own `JsonLintReport`
+ * (`lintReport.ts`) — all three currently claim `reportVersion: "1"` for
+ * their own, different shapes; see `renderInFormat`'s remark
+ * (`src/internal/report/format.ts`) for the rule that keeps each shape's
+ * schema in lockstep with it. `reportType` disambiguates the three:
+ * `schema/explain-report.schema.json` pins its `reportType` to `"explain"`
+ * and would reject this shape, and vice versa.
  */
 export interface JsonTestReport {
   readonly reportVersion: "1";

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -1,13 +1,15 @@
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Ajv } from "ajv";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { runCli } from "../src/cli.js";
 import { UsageError } from "../src/internal/errors.js";
 import { createUnimplementedSpawner } from "../src/internal/exec/index.js";
+import type { Spawner, SpawnRequest } from "../src/internal/exec/index.js";
 import type { MatcherOutcome } from "../src/internal/matcher/index.js";
 import {
   isReportFormat,
@@ -24,10 +26,13 @@ import {
   type ReportFinding,
 } from "../src/internal/report/index.js";
 import { hooksForEvent, loadSettings } from "../src/internal/settings/index.js";
-import type { Provenance, ResolvedHook } from "../src/types.js";
+import type { ExecOutcome, Provenance, ResolvedHook } from "../src/types.js";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
-const SCHEMA_PATH = path.join(REPO_ROOT, "schema", "report.schema.json");
+const SCHEMA_DIR = path.join(REPO_ROOT, "schema");
+const EXPLAIN_SCHEMA_PATH = path.join(SCHEMA_DIR, "explain-report.schema.json");
+const TEST_SCHEMA_PATH = path.join(SCHEMA_DIR, "test-report.schema.json");
+const LINT_SCHEMA_PATH = path.join(SCHEMA_DIR, "lint-report.schema.json");
 const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/cli/", import.meta.url));
 const PROJECT_WITH_HOOKS_DIR = path.join(FIXTURES_DIR, "project-with-hooks");
 const PROJECT_SETTINGS_FILE = path.join(
@@ -38,12 +43,29 @@ const PROJECT_SETTINGS_FILE = path.join(
 const SETTINGS_FIXTURES_DIR = fileURLToPath(
   new URL("./fixtures/settings/", import.meta.url),
 );
+const MINIMAL_SPEC_PATH = fileURLToPath(
+  new URL("./fixtures/spec/valid-minimal.json", import.meta.url),
+);
+const LINT_VIOLATING_FIXTURE = fileURLToPath(
+  new URL("./fixtures/lint/matcher-is-array/violating.json", import.meta.url),
+);
 
 /** The shipped spec's own declared range, from `spec/claude-code-2.1.251-2.2.0.json`. */
 const SPEC_RANGE = ">=2.1.251 <2.2.0";
 
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
 function readSchema(): unknown {
-  return JSON.parse(readFileSync(SCHEMA_PATH, "utf8")) as unknown;
+  return readJsonFile(EXPLAIN_SCHEMA_PATH);
+}
+
+/** Compile and validate `document` against the schema at `schemaPath`, returning ajv's own verdict. */
+function validatesAgainstSchema(schemaPath: string, document: unknown): boolean {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(readJsonFile(schemaPath) as object);
+  return validate(document);
 }
 
 function makeProvenance(overrides: Partial<Provenance> = {}): Provenance {
@@ -105,7 +127,7 @@ function requireHookByMatcher(
 // --- renderJson --------------------------------------------------------------
 
 describe("renderJson", () => {
-  it("validates against schema/report.schema.json for a representative report", () => {
+  it("validates against schema/explain-report.schema.json for a representative report", () => {
     const hook = makeHook();
     const rejected: MatcherOutcome = {
       hook: makeHook({ matcher: "Write", command: "./scripts/write-guard.sh" }),
@@ -582,5 +604,345 @@ describe("header content is substantively equivalent across pretty, json, and gi
     expect(renderPretty(report)).toContain("Claude Code version: undetermined");
     expect(toJsonReport(report).header.claudeVersion).toBe("undetermined");
     expect(renderGithub(report)).toContain("Claude Code version: undetermined");
+  });
+});
+
+// --- shared $defs stay identical across the three shipped schemas -----------
+
+describe("the three shipped report schemas", () => {
+  it("carry an identical copy of every $def more than one of them declares", () => {
+    const schemas: Readonly<Record<string, Record<string, unknown>>> = {
+      "explain-report.schema.json": readJsonFile(EXPLAIN_SCHEMA_PATH) as Record<
+        string,
+        unknown
+      >,
+      "test-report.schema.json": readJsonFile(TEST_SCHEMA_PATH) as Record<
+        string,
+        unknown
+      >,
+      "lint-report.schema.json": readJsonFile(LINT_SCHEMA_PATH) as Record<
+        string,
+        unknown
+      >,
+    };
+
+    const defsByFile = Object.entries(schemas).map(
+      ([name, schema]) => [name, schema["$defs"] as Record<string, unknown>] as const,
+    );
+
+    const defNames = new Set(defsByFile.flatMap(([, defs]) => Object.keys(defs)));
+    let comparedAtLeastOneSharedDef = false;
+
+    for (const defName of defNames) {
+      const owners = defsByFile.filter(([, defs]) => defName in defs);
+      if (owners.length < 2) {
+        continue;
+      }
+      comparedAtLeastOneSharedDef = true;
+      const [firstOwnerName, firstOwnerDefs] = owners[0] ?? ["", {}];
+      for (const [ownerName, ownerDefs] of owners.slice(1)) {
+        expect(
+          ownerDefs[defName],
+          `$defs.${defName} in ${ownerName} must match ${firstOwnerName}`,
+        ).toEqual(firstOwnerDefs[defName]);
+      }
+    }
+
+    // `header` is declared by all three; a false-positive pass (nothing
+    // compared because the file names above drifted from the $defs keys
+    // below) would otherwise let this test go green for the wrong reason.
+    expect(comparedAtLeastOneSharedDef).toBe(true);
+    expect(defNames.has("header")).toBe(true);
+  });
+});
+
+// --- test/lint: schema validation against a real rendering ------------------
+
+/** A canned `ExecOutcome` `ScriptedSpawner` resolves to for one configured `command`. */
+interface ScriptedOutcome {
+  readonly exitCode: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly timedOut?: boolean;
+}
+
+/**
+ * Resolves every spawn request from a canned lookup keyed by `req.command`,
+ * without ever actually spawning a process — this suite lives in the fast
+ * unit project and must never launch a real subprocess.
+ */
+class ScriptedSpawner implements Spawner {
+  readonly calls: SpawnRequest[] = [];
+  readonly #byCommand: ReadonlyMap<string, ScriptedOutcome>;
+
+  constructor(byCommand: ReadonlyMap<string, ScriptedOutcome>) {
+    this.#byCommand = byCommand;
+  }
+
+  spawn(req: SpawnRequest): Promise<ExecOutcome> {
+    this.calls.push(req);
+    const outcome = this.#byCommand.get(req.command) ?? { exitCode: 0 };
+    return Promise.resolve({
+      exitCode: outcome.exitCode,
+      stdout: outcome.stdout ?? "",
+      stderr: outcome.stderr ?? "",
+      timedOut: outcome.timedOut ?? false,
+    });
+  }
+}
+
+/** The loosely typed shape this suite reads back out of `renderTestJson`'s output. */
+interface JsonExpectationDiffShape {
+  readonly field: string;
+}
+interface JsonNonFiringExplanationShape {
+  readonly kind: string;
+}
+interface JsonUnknownReasonShape {
+  readonly kind: string;
+}
+interface JsonCaseResultShape {
+  readonly kind: string;
+  readonly diffs?: readonly JsonExpectationDiffShape[];
+  readonly nonFiring?: JsonNonFiringExplanationShape | null;
+  readonly reasons?: readonly JsonUnknownReasonShape[];
+}
+interface JsonTestCaseShape {
+  readonly event: string;
+  readonly tool: string | null;
+  readonly result: JsonCaseResultShape;
+}
+interface JsonTestReportForAssertions {
+  readonly reportVersion: string;
+  readonly reportType: string;
+  readonly cases: readonly JsonTestCaseShape[];
+}
+
+describe("renderTestJson: schema validation against a real rendering", () => {
+  let projectDir: string;
+
+  function commandGroup(matcher: string | undefined, command: string): unknown {
+    return {
+      ...(matcher === undefined ? {} : { matcher }),
+      hooks: [{ type: "command", command }],
+    };
+  }
+
+  const CMD_BASH_PASS = "cmd-bash-pass";
+  const CMD_WRITE_DENY = "cmd-write-deny";
+  const CMD_EDIT_EXIT0 = "cmd-edit-exit0";
+  const CMD_GREP_STDOUT = "cmd-grep-stdout";
+  const CMD_GLOB_STDERR = "cmd-glob-stderr";
+  const CMD_WEBFETCH_TIMEOUT = "cmd-webfetch-timeout";
+  const CMD_NOTIFICATION_NOOP = "cmd-notification-noop";
+  const CMD_STOP_LOCAL_ONLY = "cmd-stop-local-only";
+
+  beforeAll(() => {
+    projectDir = mkdtempSync(path.join(tmpdir(), "hookassert-reporters-test-schema-"));
+    mkdirSync(path.join(projectDir, ".claude"), { recursive: true });
+
+    // The project layer: every hook a case in this suite's fixture asserts
+    // against, except `Stop`'s — declared only in the local layer below, so
+    // a fixture that excludes that layer produces `excluded-settings-layer`.
+    const projectSettings = {
+      hooks: {
+        PreToolUse: [
+          commandGroup("Bash", CMD_BASH_PASS),
+          commandGroup("Write", CMD_WRITE_DENY),
+          commandGroup("Edit", CMD_EDIT_EXIT0),
+          commandGroup("Grep", CMD_GREP_STDOUT),
+          commandGroup("Glob", CMD_GLOB_STDERR),
+          commandGroup("WebFetch", CMD_WEBFETCH_TIMEOUT),
+        ],
+        Notification: [commandGroup(undefined, CMD_NOTIFICATION_NOOP)],
+      },
+    };
+    writeFileSync(
+      path.join(projectDir, ".claude", "settings.json"),
+      JSON.stringify(projectSettings, null, 2),
+    );
+
+    const localSettings = {
+      hooks: {
+        Stop: [commandGroup(undefined, CMD_STOP_LOCAL_ONLY)],
+      },
+    };
+    writeFileSync(
+      path.join(projectDir, ".claude", "settings.local.json"),
+      JSON.stringify(localSettings, null, 2),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("validates every CaseResult.kind, ExpectationDiff.field, NonFiringExplanation.kind, and an unknown reason against schema/test-report.schema.json", async () => {
+    const fixture = {
+      // Restricts candidates to the project layer only: `Stop`'s hook,
+      // declared solely in `.claude/settings.local.json` above, is thereby
+      // excluded rather than merely unmatched.
+      settings: [".claude/settings.json"],
+      cases: [
+        // "pass", decidedBy set.
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          expect: { decision: "pass", exitCode: 0 },
+        },
+        // "fail" via an ExpectationDiff.field: "fires" (something fired
+        // despite `expect.fires: false`).
+        { event: "PreToolUse", tool: "Bash", expect: { fires: false } },
+        // "fail" via field: "decision" (denies via exit 2, expected allow).
+        { event: "PreToolUse", tool: "Write", expect: { decision: "allow" } },
+        // "fail" via field: "exitCode".
+        { event: "PreToolUse", tool: "Edit", expect: { exitCode: 5 } },
+        // "fail" via field: "stdoutContains".
+        {
+          event: "PreToolUse",
+          tool: "Grep",
+          expect: { stdoutContains: "never-printed-marker" },
+        },
+        // "fail" via field: "stderrContains".
+        {
+          event: "PreToolUse",
+          tool: "Glob",
+          expect: { stderrContains: "never-printed-marker" },
+        },
+        // "fail" via field: "timedOut".
+        {
+          event: "PreToolUse",
+          tool: "WebFetch",
+          expect: { timedOut: false },
+        },
+        // "fail" via NonFiringExplanation.kind: "matcher-did-not-match" — six
+        // candidates are declared under PreToolUse, none matches "Read".
+        { event: "PreToolUse", tool: "Read", expect: { fires: true } },
+        // "fail" via NonFiringExplanation.kind: "no-hook-configured" —
+        // nothing is declared under SessionStart anywhere.
+        { event: "SessionStart", expect: { fires: true } },
+        // "fail" via NonFiringExplanation.kind: "excluded-settings-layer" —
+        // Stop's only hook lives in the excluded local layer.
+        { event: "Stop", expect: { fires: true } },
+        // "unknown" via an UnknownReason.kind: "event-not-in-spec" —
+        // Notification has no entry in valid-minimal.json's spec.
+        { event: "Notification", expect: {} },
+        // "skipped", reason "dry-run".
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          dryRun: true,
+          expect: { decision: "pass" },
+        },
+        // "skipped", reason "stub-only".
+        {
+          event: "PreToolUse",
+          tool: "Bash",
+          stub: { [CMD_BASH_PASS]: { exitCode: 0 } },
+          expect: {},
+        },
+      ],
+    };
+    const fixturePath = path.join(projectDir, "schema-coverage.yaml");
+    writeFileSync(fixturePath, JSON.stringify(fixture, null, 2));
+
+    const spawner = new ScriptedSpawner(
+      new Map<string, ScriptedOutcome>([
+        [CMD_BASH_PASS, { exitCode: 0 }],
+        [CMD_WRITE_DENY, { exitCode: 2 }],
+        [CMD_EDIT_EXIT0, { exitCode: 0 }],
+        [CMD_GREP_STDOUT, { exitCode: 0, stdout: "actual-stdout" }],
+        [CMD_GLOB_STDERR, { exitCode: 0, stderr: "actual-stderr" }],
+        [CMD_WEBFETCH_TIMEOUT, { exitCode: -1, timedOut: true }],
+        [CMD_NOTIFICATION_NOOP, { exitCode: 0 }],
+      ]),
+    );
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      {
+        cwd: projectDir,
+        home: path.join(FIXTURES_DIR, "no-such-directory"),
+        env: {},
+        specPath: MINIMAL_SPEC_PATH,
+        spawner,
+      },
+    );
+
+    // 9 of the 13 cases fail — `resolveTestExitCode` returns 1 whenever
+    // `summary.failed > 0`, regardless of `--ci`.
+    expect(result.exitCode).toBe(1);
+    const parsed: unknown = JSON.parse(result.stdout);
+    expect(validatesAgainstSchema(TEST_SCHEMA_PATH, parsed)).toBe(true);
+
+    const report = parsed as JsonTestReportForAssertions;
+    expect(report.reportType).toBe("test");
+
+    const kinds = new Set(report.cases.map((c) => c.result.kind));
+    expect(kinds).toEqual(new Set(["pass", "fail", "unknown", "skipped"]));
+
+    const diffFields = new Set(
+      report.cases.flatMap((c) => (c.result.diffs ?? []).map((d) => d.field)),
+    );
+    expect(diffFields).toEqual(
+      new Set([
+        "fires",
+        "decision",
+        "exitCode",
+        "stdoutContains",
+        "stderrContains",
+        "timedOut",
+      ]),
+    );
+
+    const nonFiringKinds = new Set(
+      report.cases
+        .map((c) => c.result.nonFiring)
+        .filter((n): n is JsonNonFiringExplanationShape => n != null)
+        .map((n) => n.kind),
+    );
+    expect(nonFiringKinds).toEqual(
+      new Set([
+        "matcher-did-not-match",
+        "no-hook-configured",
+        "excluded-settings-layer",
+      ]),
+    );
+
+    const unknownReasonKinds = new Set(
+      report.cases.flatMap((c) => (c.result.reasons ?? []).map((r) => r.kind)),
+    );
+    expect(unknownReasonKinds).toContain("event-not-in-spec");
+
+    // The one case whose failure is a `diffs` mismatch (not `nonFiring`)
+    // must still carry `nonFiring: null`, not an absent key — issue #43's
+    // own completion criterion.
+    const decisionDiffCase = report.cases.find(
+      (c) => c.event === "PreToolUse" && c.tool === "Write",
+    );
+    expect(decisionDiffCase?.result.nonFiring).toBeNull();
+  });
+});
+
+describe("renderLintJson: schema validation against a real rendering", () => {
+  it("validates a real lint finding against schema/lint-report.schema.json", async () => {
+    const result = await runCli(
+      ["lint", "--settings", LINT_VIOLATING_FIXTURE, "--format", "json"],
+      "hookassert",
+      {
+        cwd: PROJECT_WITH_HOOKS_DIR,
+        home: path.join(FIXTURES_DIR, "no-such-directory"),
+        env: {},
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    const parsed: unknown = JSON.parse(result.stdout);
+    expect(validatesAgainstSchema(LINT_SCHEMA_PATH, parsed)).toBe(true);
+
+    const report = parsed as { reportType: string; findings: readonly unknown[] };
+    expect(report.reportType).toBe("lint");
+    expect(report.findings.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
`test --format json` and `lint --format json` emitted documents no shipped JSON Schema described, unlike `explain`'s — nothing failed CI if a field of the document a CI job actually parses was silently renamed or dropped.

`schema/report.schema.json` is renamed to `schema/explain-report.schema.json`, and `schema/test-report.schema.json` / `schema/lint-report.schema.json` ship alongside it — one file per `reportType`, each versioning its own `reportVersion` independently, per a rule now written down once as a remark on `renderInFormat` (the one selector every subcommand goes through).

Building the schema surfaced a real bug it was filed to prevent: `toJsonTestReport` assigned `result: caseReport.result` verbatim, so a hook's absent `matcher`/`args`/`timeoutMs` and a `fail` result's `nonFiring: undefined` vanished under `JSON.stringify` instead of being emitted as `null`. Fixed by mapping every `CaseResult` variant field by field and routing `decidedBy`, `NonFiringExplanation.hooks`, and `RejectedMatch.hook` through `json.ts`'s `toJsonHook`. The schema is `additionalProperties: false` with a full `required` list, which is only honest because of that mapping.

Closes #43

Release impact: no — hookassert has not shipped a release yet (`version` is `0.0.0`; the first release is tracked by #20), so the schema rename and the `CaseResult` JSON mapping fix have no published consumers to break.

## Test plan

```
pnpm check
```

Green: format, lint, typecheck, tests, build, docs:build, and `package:check`/`package:smoke` — the only run that packs a real tarball. The tarball listing confirms all three schema files ship and `schema/report.schema.json` is absent; publint / attw / consumer-smoke green.

Re-verified after merging `main` (which carries #18 and #27): `pnpm check:quick` → 40 test files / 1670 tests pass.

`tests/reporters.test.ts` validates each schema against a **real rendering**, never a hand-typed literal:

- `test --format json` built through `runCli` with a scripted `Spawner` (no real process spawned), covering every `CaseResult.kind`, every `ExpectationDiff.field`, every `NonFiringExplanation.kind`, and an `unknown` reason (`event-not-in-spec`);
- `lint --format json` likewise;
- a check that the `$defs` two or more of the three schemas share stay byte-identical.

## Two judgment calls worth a reviewer's eye

- **`tests/package.test.ts` was not touched.** The issue's plan says to list all three schemas explicitly there, but packaging is wildcard-based throughout (`files: ["schema"]`, `exports: {"./schema/*.json": …}`) with no per-filename enumeration anywhere — verified by inspection. The stale plan detail was skipped in favour of the invariant the issue actually states.
- **`schema/lint-report.schema.json` does not carry the `provenance`/`hook` `$defs`.** A lint `Finding` never carries a hook, so shipping them would be dead schema; design point 5 ("the schema describes exactly what the tool can emit") is read as covering that. The cross-file `$defs`-identity test compares only the `$defs` two or more files actually declare — `header` across all three, `provenance`/`hook` between `explain` and `test`.

https://claude.ai/code/session_012my4Lq3svoxq6fF2FoyuXB
