### PR TITLE
fix: distinguish a hook that never launched from one that ran and exited nonzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,18 @@ hookassert --help
   still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
   variable into every spawned hook's environment by name — a value is never accepted
   here, only a name. When several hooks fire for one case, any deny wins; the report
-  names the hook that decided. A hook that never launches at all — a typo'd `command`, a
-  missing interpreter — resolves to `decision: error` (`cause: launch-failed`) rather
-  than being mistaken for a hook that ran and exited non-zero; every report format shows
-  the OS-reported reason (`spawn pyton3 ENOENT`, say) alongside the hook's own
-  declaration. Exits `0` when every case passes (and, with `--ci`, none is `unknown`
-  either), `1` when at least one fails, and `3` when there are no failures but `--ci`
-  was given and at least one case is `unknown`.
+  names the hook that decided. A hook whose process never starts at all — an exec-form
+  hook (one declaring `args`) naming a command that does not exist, a missing
+  interpreter — resolves to `decision: error` (`cause: launch-failed`) rather than being
+  mistaken for a hook that ran and exited non-zero. A failing case's `pretty` and
+  `github` output then shows the OS-reported reason (`spawn pyton3 ENOENT`, say)
+  alongside the hook's own declaration, and the JSON report carries it as
+  `decidedBy.launchError`. A shell-form hook (no `args`, the shape Claude Code's own
+  docs show) always launches `/bin/sh` successfully, so a typo'd `command` there is
+  reported by the shell itself — usually exit `127` — not as `launch-failed`. Exits `0`
+  when every case passes (and, with `--ci`, none is `unknown` either), `1` when at least
+  one fails, and `3` when there are no failures but `--ci` was given and at least one
+  case is `unknown`.
 
   ```console
   $ hookassert test fixtures/force-push.fixture.yaml --ci

--- a/README.md
+++ b/README.md
@@ -136,9 +136,13 @@ hookassert --help
   still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
   variable into every spawned hook's environment by name — a value is never accepted
   here, only a name. When several hooks fire for one case, any deny wins; the report
-  names the hook that decided. Exits `0` when every case passes (and, with `--ci`, none
-  is `unknown` either), `1` when at least one fails, and `3` when there are no failures
-  but `--ci` was given and at least one case is `unknown`.
+  names the hook that decided. A hook that never launches at all — a typo'd `command`, a
+  missing interpreter — resolves to `decision: error` (`cause: launch-failed`) rather
+  than being mistaken for a hook that ran and exited non-zero; every report format shows
+  the OS-reported reason (`spawn pyton3 ENOENT`, say) alongside the hook's own
+  declaration. Exits `0` when every case passes (and, with `--ci`, none is `unknown`
+  either), `1` when at least one fails, and `3` when there are no failures but `--ci`
+  was given and at least one case is `unknown`.
 
   ```console
   $ hookassert test fixtures/force-push.fixture.yaml --ci

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ hookassert --help
   hook (one declaring `args`) naming a command that does not exist, a missing
   interpreter — resolves to `decision: error` (`cause: launch-failed`) rather than being
   mistaken for a hook that ran and exited non-zero. A failing case's `pretty` and
-  `github` output then shows the OS-reported reason (`spawn pyton3 ENOENT`, say)
+  `github` output then shows the OS-reported reason (`spawn python33 ENOENT`, say)
   alongside the hook's own declaration, and the JSON report carries it as
   `decidedBy.launchError`. A shell-form hook (no `args`, the shape Claude Code's own
   docs show) always launches `/bin/sh` successfully, so a typo'd `command` there is

--- a/schema/test-report.schema.json
+++ b/schema/test-report.schema.json
@@ -124,7 +124,12 @@
             "exitCode": { "type": "number" },
             "cause": {
               "type": "string",
-              "enum": ["nonzero-exit-without-json", "invalid-json", "schema-violation"]
+              "enum": [
+                "nonzero-exit-without-json",
+                "invalid-json",
+                "schema-violation",
+                "launch-failed"
+              ]
             }
           }
         },
@@ -145,10 +150,11 @@
     "decidingHook": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["hook", "decision"],
+      "required": ["hook", "decision", "launchError"],
       "properties": {
         "hook": { "$ref": "#/$defs/hook" },
-        "decision": { "$ref": "#/$defs/decision" }
+        "decision": { "$ref": "#/$defs/decision" },
+        "launchError": { "type": ["string", "null"] }
       }
     },
     "unknownReason": {

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -235,8 +235,12 @@ export function assertCase(
   // noUncheckedIndexedAccess; `fired[0]` is the unreachable-in-practice
   // fallback, itself guaranteed present by the tuple type `fired` narrowed
   // to above.
-  const decidingHook = (fired[combined.index] ?? fired[0]).hook;
-  const decidedBy: DecidingHook = { hook: decidingHook, decision: combined.decision };
+  const decidingHookEntry = fired[combined.index] ?? fired[0];
+  const decidedBy: DecidingHook = {
+    hook: decidingHookEntry.hook,
+    decision: combined.decision,
+    launchError: decidingHookEntry.execOutcome.launchError,
+  };
 
   if (combined.decision.kind === "unknown") {
     return { kind: "unknown", origin, reasons: combined.decision.reasons, decidedBy };

--- a/src/internal/decision/factory.ts
+++ b/src/internal/decision/factory.ts
@@ -34,7 +34,8 @@ export function passed(exitCode: number): Decision {
 /** The outcome could not be turned into a decision at all. */
 export function errored(
   exitCode: number,
-  cause: "nonzero-exit-without-json" | "invalid-json" | "schema-violation",
+  cause:
+    "nonzero-exit-without-json" | "invalid-json" | "schema-violation" | "launch-failed",
 ): Decision {
   return { kind: "error", exitCode, cause };
 }

--- a/src/internal/decision/resolve.ts
+++ b/src/internal/decision/resolve.ts
@@ -6,7 +6,12 @@
  * already obtained (a later executor issue's `Spawner`, or a test's stub),
  * and `resolveDecision` never spawns anything itself.
  *
- * Every branch reads `spec.events[event]`'s own data (`blockable`,
+ * `outcome.launchError !== undefined` is checked before anything else below
+ * it: a process that never started carries no meaningful exit code or
+ * timeout at all, and reads a field rather than a literal — no exit-code
+ * value is reserved for "never launched."
+ *
+ * Every other branch reads `spec.events[event]`'s own data (`blockable`,
  * `jsonDecisions`, `exitCodeEffects`) rather than hard-coding exit-code
  * literals: the shipped spec documents at least one event (`WorktreeCreate`)
  * whose non-`2` exit code also blocks, so "exit 2 means deny" is only true
@@ -175,6 +180,13 @@ function findExitCodeEffect(
  * deny that will not really happen in production is exactly the
  * over-cautious failure mode this project exists to avoid alongside the
  * under-cautious one.
+ *
+ * `outcome.launchError !== undefined` is checked before the timeout check
+ * and before any `exitCodeEffects` lookup — a process that never launched
+ * cannot have timed out or exited with a meaningful code, so nothing below
+ * that check is reachable for it. A launch failure is a case-level `error`
+ * decision, not a run-level load error: it is only discoverable after
+ * consent and after spawning was attempted.
  */
 export function resolveDecision(
   spec: Spec,
@@ -194,6 +206,10 @@ export function resolveDecision(
       event,
       specVersion: spec.specVersion,
     });
+  }
+
+  if (outcome.launchError !== undefined) {
+    return errored(outcome.exitCode, "launch-failed");
   }
 
   if (outcome.timedOut) {

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -346,7 +346,13 @@ function buildSpawnRequest(
 
 /** Build the `ExecOutcome` a stubbed step resolves to, without spawning anything. */
 function stubbedOutcome(stub: FixtureStubEntry): ExecOutcome {
-  return { exitCode: stub.exitCode, stdout: "", stderr: "", timedOut: false };
+  return {
+    exitCode: stub.exitCode,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    launchError: undefined,
+  };
 }
 
 /** One executed step paired with the `ExecOutcome` it produced. */

--- a/src/internal/exec/spawner.ts
+++ b/src/internal/exec/spawner.ts
@@ -156,7 +156,13 @@ export class NodeSpawner implements Spawner {
       const timer = setTimeout(() => {
         timedOut = true;
         killProcessGroup(child);
-        settle({ exitCode: -1, stdout, stderr, timedOut: true });
+        settle({
+          exitCode: -1,
+          stdout,
+          stderr,
+          timedOut: true,
+          launchError: undefined,
+        });
       }, req.timeoutMs);
 
       // `setEncoding` decodes the stream itself rather than each chunk
@@ -176,17 +182,27 @@ export class NodeSpawner implements Spawner {
       // A process killed for a timeout, or one that never starts at all
       // (`ENOENT` on the command itself), reports through "error"/"close"
       // rather than throwing: `Spawner.spawn` promises to always resolve
-      // with an `ExecOutcome`, never to reject.
+      // with an `ExecOutcome`, never to reject. A launch failure carries its
+      // OS-reported message in `launchError` rather than folded into
+      // `stderr` — see `ExecOutcome.launchError`'s own remark in
+      // `src/types.ts` for why the two channels are kept separate.
       child.on("error", (error) => {
         settle({
           exitCode: -1,
           stdout,
-          stderr: stderr + (stderr.length > 0 ? "\n" : "") + error.message,
+          stderr,
           timedOut,
+          launchError: error.message,
         });
       });
       child.on("close", (code) => {
-        settle({ exitCode: code ?? -1, stdout, stderr, timedOut });
+        settle({
+          exitCode: code ?? -1,
+          stdout,
+          stderr,
+          timedOut,
+          launchError: undefined,
+        });
       });
 
       // A hook that exits before consuming its full stdin would otherwise

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -153,19 +153,19 @@ function describeLaunchFailure(
 /**
  * ` — decided by …` suffix for a `FAIL`/`UNKNOWN` line, shown only when more
  * than one hook fired for the case — naming the hook for a single-hook case
- * would just repeat what the line already says. Never shown when the
- * deciding hook's own `launchError` is set: {@link describeLaunchFailure}
- * already names the hook and its location.
+ * would just repeat what the line already says. `detailNamesHook` suppresses
+ * it for the one line whose detail has already named the hook itself, a
+ * `FAIL` rendered by {@link describeLaunchFailure}; an `UNKNOWN` line never
+ * carries that message — a launch failure whose event is missing from the
+ * spec resolves to `unknown` before `launchError` is ever read — so it keeps
+ * the suffix regardless of the deciding hook's `launchError`.
  */
 function decidedBySuffix(
   report: TestCaseReport,
   decidedBy: DecidingHook | undefined,
+  detailNamesHook: boolean,
 ): string {
-  if (
-    decidedBy === undefined ||
-    report.firedCount <= 1 ||
-    decidedBy.launchError !== undefined
-  ) {
+  if (decidedBy === undefined || report.firedCount <= 1 || detailNamesHook) {
     return "";
   }
   return ` — decided by ${describeDecidedBy(decidedBy)}`;
@@ -197,11 +197,14 @@ function renderCaseLine(report: TestCaseReport): string {
       return `SKIP  ${label} (${result.reason})`;
     case "unknown": {
       const reasons = result.reasons.map(describeUnknownReason).join("; ");
-      return `UNKNOWN ${label} — ${reasons}${decidedBySuffix(report, result.decidedBy)}`;
+      return `UNKNOWN ${label} — ${reasons}${decidedBySuffix(report, result.decidedBy, false)}`;
     }
     case "fail": {
       const detail = describeFailDetail(result);
-      return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy)}`;
+      // The launch-failure detail already names the hook and its declaration
+      // site, so the suffix would only repeat it.
+      const detailNamesHook = result.decidedBy?.launchError !== undefined;
+      return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy, detailNamesHook)}`;
     }
   }
 }

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -137,18 +137,53 @@ function describeDecidedBy(decidedBy: DecidingHook): string {
 }
 
 /**
+ * `hook never launched: <OS message> (command "<command>", <file>:<line>)` —
+ * the message every reporter shows for a case whose deciding hook's process
+ * never started at all (`DecidingHook.launchError` set). Already names the
+ * hook and its declaration site, so callers never also append
+ * {@link decidedBySuffix}'s "— decided by …" for the same `DecidingHook`.
+ */
+function describeLaunchFailure(
+  decidedBy: DecidingHook & { launchError: string },
+): string {
+  const { hook, launchError } = decidedBy;
+  return `hook never launched: ${launchError} (command "${hook.command}", ${hook.provenance.file}:${String(hook.provenance.line)})`;
+}
+
+/**
  * ` — decided by …` suffix for a `FAIL`/`UNKNOWN` line, shown only when more
  * than one hook fired for the case — naming the hook for a single-hook case
- * would just repeat what the line already says.
+ * would just repeat what the line already says. Never shown when the
+ * deciding hook's own `launchError` is set: {@link describeLaunchFailure}
+ * already names the hook and its location.
  */
 function decidedBySuffix(
   report: TestCaseReport,
   decidedBy: DecidingHook | undefined,
 ): string {
-  if (decidedBy === undefined || report.firedCount <= 1) {
+  if (
+    decidedBy === undefined ||
+    report.firedCount <= 1 ||
+    decidedBy.launchError !== undefined
+  ) {
     return "";
   }
   return ` — decided by ${describeDecidedBy(decidedBy)}`;
+}
+
+/**
+ * The detail text after a `FAIL` line's label, for a case whose combined
+ * verdict is a `"fail"`: the launch-failure message when the deciding hook
+ * never launched, otherwise the ordinary diff/non-firing explanation.
+ */
+function describeFailDetail(result: Extract<CaseResult, { kind: "fail" }>): string {
+  const { decidedBy } = result;
+  if (decidedBy?.launchError !== undefined) {
+    return describeLaunchFailure({ ...decidedBy, launchError: decidedBy.launchError });
+  }
+  return result.nonFiring === undefined
+    ? result.diffs.map(describeDiff).join("; ")
+    : describeNonFiring(result.nonFiring);
 }
 
 /** One human-readable line per {@link TestCaseReport}, for `renderTestPretty`. */
@@ -165,10 +200,7 @@ function renderCaseLine(report: TestCaseReport): string {
       return `UNKNOWN ${label} — ${reasons}${decidedBySuffix(report, result.decidedBy)}`;
     }
     case "fail": {
-      const detail =
-        result.nonFiring === undefined
-          ? result.diffs.map(describeDiff).join("; ")
-          : describeNonFiring(result.nonFiring);
+      const detail = describeFailDetail(result);
       return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy)}`;
     }
   }
@@ -249,11 +281,16 @@ function toJsonPayloadOrigin(origin: PayloadOrigin): JsonPayloadOrigin {
 interface JsonDecidingHook {
   readonly hook: JsonHook;
   readonly decision: Decision;
+  readonly launchError: string | null;
 }
 
 /** Build the {@link JsonDecidingHook} for one {@link DecidingHook}. */
 function toJsonDecidingHook(decidedBy: DecidingHook): JsonDecidingHook {
-  return { hook: toJsonHook(decidedBy.hook), decision: decidedBy.decision };
+  return {
+    hook: toJsonHook(decidedBy.hook),
+    decision: decidedBy.decision,
+    launchError: decidedBy.launchError ?? null,
+  };
 }
 
 /** `CaseResult`'s `decidedBy`, converted and `undefined` normalized to `null`. */
@@ -466,10 +503,7 @@ export function renderTestGithub(report: TestReport, workspaceRoot: string): str
       continue;
     }
     const { result } = caseReport;
-    const detail =
-      result.nonFiring === undefined
-        ? result.diffs.map(describeDiff).join("; ")
-        : describeNonFiring(result.nonFiring);
+    const detail = describeFailDetail(result);
     const { decidedBy } = result;
     const attachable =
       decidedBy !== undefined &&
@@ -480,8 +514,12 @@ export function renderTestGithub(report: TestReport, workspaceRoot: string): str
           line: decidedBy.hook.provenance.line,
         }
       : { file: caseReport.file, line: 1 };
+    // Never appends "— decided by …" when the hook never launched: `detail`
+    // already names the hook and its declaration site (see
+    // `describeLaunchFailure`), so the annotation would otherwise repeat
+    // itself.
     const message =
-      decidedBy === undefined || attachable
+      decidedBy === undefined || attachable || decidedBy.launchError !== undefined
         ? detail
         : `${detail} — decided by ${describeDecidedBy(decidedBy)}`;
     lines.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,7 +182,7 @@ export interface ExecOutcome {
 
   /**
    * The OS-reported reason the process could not be launched at all (for
-   * example `spawn pyton3 ENOENT`, or `EACCES`), or `undefined` for every
+   * example `spawn python33 ENOENT`, or `EACCES`), or `undefined` for every
    * process that actually started.
    *
    * @remarks

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,18 +146,29 @@ export interface ResolvedHook {
 }
 
 /**
- * A hook's raw exit code, stdout, stderr, and whether it timed out.
+ * A hook's raw exit code, stdout, stderr, whether it timed out, and whether
+ * it ever launched at all.
  *
  * @remarks
  * The input the static decision resolver (`src/internal/decision/`) and the
- * future executor's `Spawner` seam both speak: whatever actually spawns a
- * hook produces one of these, and the decision resolver consumes it without
- * ever spawning anything itself.
+ * executor's `Spawner` seam both speak: whatever actually spawns a hook
+ * produces one of these, and the decision resolver consumes it without ever
+ * spawning anything itself.
  *
  * @public
  */
 export interface ExecOutcome {
-  /** The process's exit status. */
+  /**
+   * The process's exit status, or `-1` for "no exit status" — which of three
+   * situations that is is told apart by {@link ExecOutcome.timedOut} and
+   * {@link ExecOutcome.launchError}, not by a fourth exit-code value:
+   *
+   * - Killed by hookassert's own timeout: `timedOut: true`.
+   * - Killed by a signal (and not a timeout): `timedOut: false`,
+   *   `launchError: undefined`.
+   * - Never started at all (a typo'd command, a missing interpreter):
+   *   `timedOut: false`, `launchError` set to the OS-reported reason.
+   */
   readonly exitCode: number;
 
   /** Everything the hook wrote to stdout. */
@@ -168,6 +179,21 @@ export interface ExecOutcome {
 
   /** Whether the hook was killed for exceeding its deadline. */
   readonly timedOut: boolean;
+
+  /**
+   * The OS-reported reason the process could not be launched at all (for
+   * example `spawn pyton3 ENOENT`, or `EACCES`), or `undefined` for every
+   * process that actually started.
+   *
+   * @remarks
+   * Set only when the child process's `"error"` event fired before a
+   * `"close"` carrying a real exit status — see {@link ExecOutcome.exitCode}'s
+   * own remark for how this, together with `timedOut`, disambiguates every
+   * `-1` outcome. Carrying the OS message here, rather than folding it into
+   * `stderr`, means a consumer never has to fish a launch failure out of a
+   * stream that a hook's own output also writes to.
+   */
+  readonly launchError: string | undefined;
 }
 
 /**
@@ -335,8 +361,16 @@ export type Decision =
        * `"invalid-json"` — stdout looked like JSON and failed to parse.
        * `"schema-violation"` — stdout parsed but its decision value is not
        * one the event documents.
+       * `"launch-failed"` — the process never started at all (see
+       * {@link ExecOutcome.launchError}); a case-level error, not a run-level
+       * load error, since it is only discoverable after consent and after
+       * spawning.
        */
-      readonly cause: "nonzero-exit-without-json" | "invalid-json" | "schema-violation";
+      readonly cause:
+        | "nonzero-exit-without-json"
+        | "invalid-json"
+        | "schema-violation"
+        | "launch-failed";
     }
   | {
       /**
@@ -484,6 +518,15 @@ export interface DecidingHook {
   readonly hook: ResolvedHook;
   /** The case's combined `Decision` — this hook's own, since it is the one that decided. */
   readonly decision: Decision;
+  /**
+   * The deciding hook's own {@link ExecOutcome.launchError}, or `undefined`
+   * when it actually launched.
+   *
+   * @remarks
+   * Carried here so a reporter can print a launch failure's OS-reported
+   * reason without holding the whole `ExecOutcome` alongside a `CaseResult`.
+   */
+  readonly launchError: string | undefined;
 }
 
 /**

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -387,7 +387,7 @@ describe("assertCase: multiple firing hooks", () => {
           decision: { kind: "error", exitCode: -1, cause: "launch-failed" },
           execOutcome: makeExecOutcome({
             exitCode: -1,
-            launchError: "spawn pyton3 ENOENT",
+            launchError: "spawn python33 ENOENT",
           }),
         }),
       ],
@@ -395,7 +395,7 @@ describe("assertCase: multiple firing hooks", () => {
 
     const result = expectPass(assertCase(caseData, observation));
 
-    expect(result.decidedBy?.launchError).toBe("spawn pyton3 ENOENT");
+    expect(result.decidedBy?.launchError).toBe("spawn python33 ENOENT");
   });
 });
 

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -70,7 +70,14 @@ function makeCase(overrides: Partial<FixtureCase> = {}): FixtureCase {
 }
 
 function makeExecOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
-  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
+  return {
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    launchError: undefined,
+    ...overrides,
+  };
 }
 
 function makeFired(overrides: Partial<FiredHook> = {}): FiredHook {
@@ -359,6 +366,36 @@ describe("assertCase: multiple firing hooks", () => {
     const result = expectPass(assertCase(caseData, observation));
 
     expect(result.decidedBy?.hook).toBe(hook);
+  });
+
+  it("decidedBy carries undefined launchError when the deciding hook's own ExecOutcome carries none", () => {
+    const caseData = makeCase();
+    const observation = makeObservation({
+      fired: [makeFired({ execOutcome: makeExecOutcome({ launchError: undefined }) })],
+    });
+
+    const result = expectPass(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.launchError).toBeUndefined();
+  });
+
+  it("decidedBy carries the deciding hook's own launchError (issue #39)", () => {
+    const caseData = makeCase({ expect: makeExpect({ decision: "error" }) });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          decision: { kind: "error", exitCode: -1, cause: "launch-failed" },
+          execOutcome: makeExecOutcome({
+            exitCode: -1,
+            launchError: "spawn pyton3 ENOENT",
+          }),
+        }),
+      ],
+    });
+
+    const result = expectPass(assertCase(caseData, observation));
+
+    expect(result.decidedBy?.launchError).toBe("spawn pyton3 ENOENT");
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -50,7 +50,13 @@ class CountingSpawner implements Spawner {
 
   spawn(req: SpawnRequest): Promise<ExecOutcome> {
     this.calls.push(req);
-    return Promise.resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      launchError: undefined,
+    });
   }
 }
 

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -211,7 +211,7 @@ describe("a launch failure (issue #39) resolves to error/launch-failed before an
     const decision = resolveDecision(
       spec,
       "PreToolUse",
-      makeOutcome({ exitCode: -1, launchError: "spawn pyton3 ENOENT" }),
+      makeOutcome({ exitCode: -1, launchError: "spawn python33 ENOENT" }),
     );
     expect(decision.kind).toBe("error");
     if (decision.kind === "error") {
@@ -227,7 +227,7 @@ describe("a launch failure (issue #39) resolves to error/launch-failed before an
     const decision = resolveDecision(
       spec,
       "PreToolUse",
-      makeOutcome({ exitCode: 2, launchError: "spawn pyton3 ENOENT" }),
+      makeOutcome({ exitCode: 2, launchError: "spawn python33 ENOENT" }),
     );
     expect(decision.kind).toBe("error");
     if (decision.kind === "error") {
@@ -239,7 +239,11 @@ describe("a launch failure (issue #39) resolves to error/launch-failed before an
     const decision = resolveDecision(
       spec,
       "PreToolUse",
-      makeOutcome({ exitCode: -1, timedOut: true, launchError: "spawn pyton3 ENOENT" }),
+      makeOutcome({
+        exitCode: -1,
+        timedOut: true,
+        launchError: "spawn python33 ENOENT",
+      }),
     );
     expect(decision.kind).toBe("error");
     if (decision.kind === "error") {

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -26,7 +26,14 @@ const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.j
 const spec = loadSpecFile(REAL_SPEC_PATH);
 
 function makeOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
-  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, ...overrides };
+  return {
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    launchError: undefined,
+    ...overrides,
+  };
 }
 
 /** `spec` with `event`'s own entry removed entirely, for the "spec/EventName drift" cases. */
@@ -195,6 +202,57 @@ describe("a timed-out PreToolUse hook does not resolve to deny", () => {
       makeOutcome({ exitCode: 2, timedOut: true }),
     );
     expect(decision.kind).not.toBe("deny");
+    expect(decision.kind).toBe("pass");
+  });
+});
+
+describe("a launch failure (issue #39) resolves to error/launch-failed before anything else", () => {
+  it("outcome.launchError set resolves to error/launch-failed", () => {
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: -1, launchError: "spawn pyton3 ENOENT" }),
+    );
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("launch-failed");
+      expect(decision.exitCode).toBe(-1);
+    }
+  });
+
+  it("launch failure outranks a documented block exit code: launchError wins even when exitCode also matches a block row", () => {
+    // exitCode 2 is PreToolUse's own documented block effect — proof that
+    // `resolveDecision` checks `launchError` before any `exitCodeEffects`
+    // lookup, per this issue's design, rather than the exit code winning.
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: 2, launchError: "spawn pyton3 ENOENT" }),
+    );
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("launch-failed");
+    }
+  });
+
+  it("launch failure outranks the timeout check: launchError wins even when timedOut is also true", () => {
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: -1, timedOut: true, launchError: "spawn pyton3 ENOENT" }),
+    );
+    expect(decision.kind).toBe("error");
+    if (decision.kind === "error") {
+      expect(decision.cause).toBe("launch-failed");
+    }
+  });
+
+  it("a timed-out hook with no launchError still resolves to pass, never launch-failed", () => {
+    const decision = resolveDecision(
+      spec,
+      "PreToolUse",
+      makeOutcome({ exitCode: -1, timedOut: true }),
+    );
     expect(decision.kind).toBe("pass");
   });
 });
@@ -530,6 +588,14 @@ describe("factory functions build exactly the Decision shape they name", () => {
       kind: "error",
       exitCode: 127,
       cause: "nonzero-exit-without-json",
+    });
+  });
+
+  it("errored accepts launch-failed as a cause", () => {
+    expect(errored(-1, "launch-failed")).toEqual({
+      kind: "error",
+      exitCode: -1,
+      cause: "launch-failed",
     });
   });
 });

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -38,7 +38,13 @@ class CountingSpawner implements Spawner {
   readonly #outcome: ExecOutcome;
 
   constructor(
-    outcome: ExecOutcome = { exitCode: 0, stdout: "", stderr: "", timedOut: false },
+    outcome: ExecOutcome = {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      launchError: undefined,
+    },
   ) {
     this.#outcome = outcome;
   }
@@ -454,6 +460,7 @@ describe("stub bypass", () => {
       stdout: "",
       stderr: "",
       timedOut: false,
+      launchError: undefined,
     });
     // The regression this test guards: the stubbed command's own name must
     // never show up among what was actually spawned.
@@ -484,7 +491,13 @@ describe("concurrency cap", () => {
       return new Promise((resolve) => {
         this.#pending.push(() => {
           this.#current -= 1;
-          resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+          resolve({
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            launchError: undefined,
+          });
         });
       });
     }
@@ -612,6 +625,7 @@ describe("concurrency cap", () => {
       stdout: "",
       stderr: "",
       timedOut: false,
+      launchError: undefined,
     });
   });
 });
@@ -675,5 +689,32 @@ describe("Spawner never rejects", () => {
     expect(result).toBeDefined();
     expect(result?.outcome.timedOut).toBe(false);
     expect(result?.outcome.exitCode).not.toBe(0);
+  });
+});
+
+describe("launchError (issue #39)", () => {
+  it("exec form: a nonexistent command sets launchError to the OS message and never appends it to stderr", async () => {
+    const hook = makeHook({ command: "/no/such/hookassert-fixture-binary", args: [] });
+    const deps = makeDeps({ spawner: new NodeSpawner() });
+    const [result] = await executeHooks(deps, makePlan([makeStep(hook)]));
+
+    expect(result?.outcome.launchError).toMatch(/ENOENT/);
+    expect(result?.outcome.stderr).toBe("");
+    expect(result?.outcome.timedOut).toBe(false);
+  });
+
+  it("shell form: a nonexistent script exits 127 via the shell itself, with launchError left undefined", async () => {
+    // No `args`: shell form. `/bin/sh` itself launches fine and reports the
+    // missing script the same way Claude Code's own shell form would.
+    const hook = makeHook({
+      command: "/no/such/hookassert-fixture-script.sh",
+      args: undefined,
+    });
+    const deps = makeDeps({ spawner: new NodeSpawner() });
+    const [result] = await executeHooks(deps, makePlan([makeStep(hook)]));
+
+    expect(result?.outcome.exitCode).toBe(127);
+    expect(result?.outcome.launchError).toBeUndefined();
+    expect(result?.outcome.timedOut).toBe(false);
   });
 });

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -677,6 +677,7 @@ interface ScriptedOutcome {
   readonly stdout?: string;
   readonly stderr?: string;
   readonly timedOut?: boolean;
+  readonly launchError?: string;
 }
 
 /**
@@ -700,6 +701,7 @@ class ScriptedSpawner implements Spawner {
       stdout: outcome.stdout ?? "",
       stderr: outcome.stderr ?? "",
       timedOut: outcome.timedOut ?? false,
+      launchError: outcome.launchError,
     });
   }
 }
@@ -714,11 +716,15 @@ interface JsonNonFiringExplanationShape {
 interface JsonUnknownReasonShape {
   readonly kind: string;
 }
+interface JsonDecidingHookShape {
+  readonly launchError: string | null;
+}
 interface JsonCaseResultShape {
   readonly kind: string;
   readonly diffs?: readonly JsonExpectationDiffShape[];
   readonly nonFiring?: JsonNonFiringExplanationShape | null;
   readonly reasons?: readonly JsonUnknownReasonShape[];
+  readonly decidedBy?: JsonDecidingHookShape | null;
 }
 interface JsonTestCaseShape {
   readonly event: string;
@@ -749,6 +755,7 @@ describe("renderTestJson: schema validation against a real rendering", () => {
   const CMD_WEBFETCH_TIMEOUT = "cmd-webfetch-timeout";
   const CMD_NOTIFICATION_NOOP = "cmd-notification-noop";
   const CMD_STOP_LOCAL_ONLY = "cmd-stop-local-only";
+  const CMD_LAUNCH_FAIL = "cmd-launch-fail";
 
   beforeAll(() => {
     projectDir = mkdtempSync(path.join(tmpdir(), "hookassert-reporters-test-schema-"));
@@ -766,6 +773,11 @@ describe("renderTestJson: schema validation against a real rendering", () => {
           commandGroup("Grep", CMD_GREP_STDOUT),
           commandGroup("Glob", CMD_GLOB_STDERR),
           commandGroup("WebFetch", CMD_WEBFETCH_TIMEOUT),
+          // Exec form (`args` present) — issue #39's launch-failure scenario.
+          {
+            matcher: "LaunchFail",
+            hooks: [{ type: "command", command: CMD_LAUNCH_FAIL, args: [] }],
+          },
         ],
         Notification: [commandGroup(undefined, CMD_NOTIFICATION_NOOP)],
       },
@@ -840,6 +852,10 @@ describe("renderTestJson: schema validation against a real rendering", () => {
         // "unknown" via an UnknownReason.kind: "event-not-in-spec" —
         // Notification has no entry in valid-minimal.json's spec.
         { event: "Notification", expect: {} },
+        // "pass" via Decision.error.cause: "launch-failed" (issue #39) — a
+        // fixture that expects the launch failure exactly still passes, and
+        // decidedBy.launchError carries the OS-reported reason.
+        { event: "PreToolUse", tool: "LaunchFail", expect: { decision: "error" } },
         // "skipped", reason "dry-run".
         {
           event: "PreToolUse",
@@ -868,6 +884,10 @@ describe("renderTestJson: schema validation against a real rendering", () => {
         [CMD_GLOB_STDERR, { exitCode: 0, stderr: "actual-stderr" }],
         [CMD_WEBFETCH_TIMEOUT, { exitCode: -1, timedOut: true }],
         [CMD_NOTIFICATION_NOOP, { exitCode: 0 }],
+        [
+          CMD_LAUNCH_FAIL,
+          { exitCode: -1, launchError: "spawn cmd-launch-fail ENOENT" },
+        ],
       ]),
     );
 
@@ -883,7 +903,7 @@ describe("renderTestJson: schema validation against a real rendering", () => {
       },
     );
 
-    // 9 of the 13 cases fail — `resolveTestExitCode` returns 1 whenever
+    // 9 of the 14 cases fail — `resolveTestExitCode` returns 1 whenever
     // `summary.failed > 0`, regardless of `--ci`.
     expect(result.exitCode).toBe(1);
     const parsed: unknown = JSON.parse(result.stdout);
@@ -935,6 +955,17 @@ describe("renderTestJson: schema validation against a real rendering", () => {
       (c) => c.event === "PreToolUse" && c.tool === "Write",
     );
     expect(decisionDiffCase?.result.nonFiring).toBeNull();
+
+    // Issue #39: a launch failure resolves to a "pass" CaseResult when the
+    // fixture expects decision: "error", and decidedBy.launchError carries
+    // the OS-reported reason through to the JSON report.
+    const launchFailedCase = report.cases.find(
+      (c) => c.event === "PreToolUse" && c.tool === "LaunchFail",
+    );
+    expect(launchFailedCase?.result.kind).toBe("pass");
+    expect(launchFailedCase?.result.decidedBy?.launchError).toBe(
+      "spawn cmd-launch-fail ENOENT",
+    );
   });
 });
 

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -47,6 +47,7 @@ interface FakeOutcome {
   readonly exitCode: number;
   readonly stdout?: string;
   readonly stderr?: string;
+  readonly launchError?: string;
 }
 
 /**
@@ -85,6 +86,7 @@ class FakeSpawner implements Spawner {
       stdout: outcome.stdout ?? "",
       stderr: outcome.stderr ?? "",
       timedOut: false,
+      launchError: outcome.launchError,
     });
   }
 }
@@ -275,6 +277,116 @@ describe("the full pipeline", () => {
   });
 });
 
+describe("launch failures (issue #39)", () => {
+  // A dedicated project dir, isolated from the shared `projectDir`'s own
+  // settings.json: this hook's command deliberately does not exist, and the
+  // shared settings file is reused by `lint`-touching tests elsewhere in
+  // this suite that assert zero findings — a nonexistent command would
+  // trip `lint`'s own command-not-found rule there.
+  let launchFailProjectDir: string;
+
+  afterEach(() => {
+    rmSync(launchFailProjectDir, { recursive: true, force: true });
+  });
+
+  function setUpLaunchFailProject(): void {
+    launchFailProjectDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-launch-fail-project-"),
+    );
+    mkdirSync(path.join(launchFailProjectDir, ".claude"), { recursive: true });
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          // Exec form (`args` present) naming a command that does not
+          // exist — the literal command name mirrors this issue's own
+          // illustrative example.
+          {
+            matcher: "LaunchFail",
+            hooks: [{ type: "command", command: "pyton3", args: [] }],
+          },
+        ],
+      },
+    };
+    writeFileSync(
+      path.join(launchFailProjectDir, ".claude", "settings.json"),
+      JSON.stringify(settings, null, 2),
+    );
+  }
+
+  function launchFailFixturePath(fixture: unknown): string {
+    const filePath = path.join(launchFailProjectDir, "fixture.yaml");
+    writeFileSync(filePath, JSON.stringify(fixture, null, 2));
+    return filePath;
+  }
+
+  it("a fixture expecting decision: error passes when the hook never launches", async () => {
+    setUpLaunchFailProject();
+    const spawner = new RecordingSpawner();
+    const fixturePath = launchFailFixturePath({
+      cases: [
+        { event: "PreToolUse", tool: "LaunchFail", expect: { decision: "error" } },
+      ],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ cwd: launchFailProjectDir, spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.summary).toEqual({
+      asserted: 1,
+      fromRecorded: 0,
+      failed: 0,
+      unknown: 0,
+      skipped: 0,
+    });
+    expect(report.cases[0]?.result.kind).toBe("pass");
+  });
+
+  it("pretty prints the launch-failure message and github annotates the hook's own declaration line", async () => {
+    setUpLaunchFailProject();
+    // Expects something a launch failure cannot satisfy, so the case fails
+    // and the launch message — not the raw exitCode/decision diff — is what
+    // both reporters show.
+    const fixturePath = launchFailFixturePath({
+      cases: [{ event: "PreToolUse", tool: "LaunchFail", expect: { exitCode: 0 } }],
+    });
+
+    const pretty = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ cwd: launchFailProjectDir, spawner: new RecordingSpawner() }),
+    );
+    expect(pretty.stdout).toContain("FAIL");
+    expect(pretty.stdout).toContain("hook never launched: spawn pyton3 ENOENT");
+    expect(pretty.stdout).toContain('command "pyton3"');
+    expect(pretty.stdout).toMatch(/settings\.json:\d+\)/);
+    // The launch message already names the hook and its location, so the
+    // "decided by" suffix (only relevant for multi-hook cases anyway) never
+    // doubles up on it.
+    expect(pretty.stdout).not.toContain("decided by");
+
+    const github = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "github",
+      ],
+      "hookassert",
+      testDeps({ cwd: launchFailProjectDir, spawner: new RecordingSpawner() }),
+    );
+    expect(github.stdout).toMatch(/::error file=\.claude\/settings\.json,line=\d+/);
+    expect(github.stdout).toContain("hook never launched: spawn pyton3 ENOENT");
+  });
+});
+
 describe("combining more than one firing hook (issue #42)", () => {
   // A dedicated project/home pair per test, isolated from the shared
   // projectDir's own settings.json: two hooks (one per settings layer) fire
@@ -412,7 +524,13 @@ describe("combining more than one firing hook (issue #42)", () => {
       spawn(req: SpawnRequest): Promise<ExecOutcome> {
         this.calls.push(req);
         const timedOut = this.calls.length > 1;
-        return Promise.resolve({ exitCode: 0, stdout: "", stderr: "", timedOut });
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          timedOut,
+          launchError: undefined,
+        });
       }
     }
     const spawner = new TimeoutOnSecondSpawner();
@@ -958,7 +1076,13 @@ describe("cross-file concurrency cap (issue #40)", () => {
       return new Promise((resolve) => {
         this.#pending.push(() => {
           this.#current -= 1;
-          resolve({ exitCode: 0, stdout: "", stderr: "", timedOut: false });
+          resolve({
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            launchError: undefined,
+          });
         });
       });
     }

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -302,7 +302,7 @@ describe("launch failures (issue #39)", () => {
           // illustrative example.
           {
             matcher: "LaunchFail",
-            hooks: [{ type: "command", command: "pyton3", args: [] }],
+            hooks: [{ type: "command", command: "python33", args: [] }],
           },
         ],
       },
@@ -361,8 +361,8 @@ describe("launch failures (issue #39)", () => {
       testDeps({ cwd: launchFailProjectDir, spawner: new RecordingSpawner() }),
     );
     expect(pretty.stdout).toContain("FAIL");
-    expect(pretty.stdout).toContain("hook never launched: spawn pyton3 ENOENT");
-    expect(pretty.stdout).toContain('command "pyton3"');
+    expect(pretty.stdout).toContain("hook never launched: spawn python33 ENOENT");
+    expect(pretty.stdout).toContain('command "python33"');
     expect(pretty.stdout).toMatch(/settings\.json:\d+\)/);
     // The launch message already names the hook and its location, so the
     // "decided by" suffix (only relevant for multi-hook cases anyway) never
@@ -383,7 +383,7 @@ describe("launch failures (issue #39)", () => {
       testDeps({ cwd: launchFailProjectDir, spawner: new RecordingSpawner() }),
     );
     expect(github.stdout).toMatch(/::error file=\.claude\/settings\.json,line=\d+/);
-    expect(github.stdout).toContain("hook never launched: spawn pyton3 ENOENT");
+    expect(github.stdout).toContain("hook never launched: spawn python33 ENOENT");
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -341,7 +341,10 @@ describe("Decision", () => {
             readonly kind: "error";
             readonly exitCode: number;
             readonly cause:
-              "nonzero-exit-without-json" | "invalid-json" | "schema-violation";
+              | "nonzero-exit-without-json"
+              | "invalid-json"
+              | "schema-violation"
+              | "launch-failed";
           }>();
           break;
         }
@@ -358,6 +361,7 @@ describe("Decision", () => {
     narrow({ kind: "allow", exitCode: 0 });
     narrow({ kind: "pass", exitCode: 1 });
     narrow({ kind: "error", exitCode: 127, cause: "nonzero-exit-without-json" });
+    narrow({ kind: "error", exitCode: -1, cause: "launch-failed" });
     narrow({
       kind: "unknown",
       reasons: [{ kind: "plugin-hooks-present", files: [] }],
@@ -392,12 +396,13 @@ describe("Decision", () => {
 });
 
 describe("ExecOutcome", () => {
-  it("requires exitCode, stdout, stderr, timedOut with no optional fields", () => {
+  it("requires exitCode, stdout, stderr, timedOut, launchError with no optional fields", () => {
     expectTypeOf<ExecOutcome>().toEqualTypeOf<{
       readonly exitCode: number;
       readonly stdout: string;
       readonly stderr: string;
       readonly timedOut: boolean;
+      readonly launchError: string | undefined;
     }>();
     expectTypeOf<Required<ExecOutcome>>().toEqualTypeOf<ExecOutcome>();
   });
@@ -405,10 +410,40 @@ describe("ExecOutcome", () => {
   it("rejects an outcome missing timedOut", () => {
     const rejected = (): void => {
       // @ts-expect-error every field is required, including timedOut
-      const outcome: ExecOutcome = { exitCode: 0, stdout: "", stderr: "" };
+      const outcome: ExecOutcome = {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        launchError: undefined,
+      };
       void outcome;
     };
     expect(rejected).toBeTypeOf("function");
+  });
+
+  it("rejects an outcome missing launchError, even though it may hold undefined", () => {
+    const rejected = (): void => {
+      // @ts-expect-error launchError is `string | undefined`, not optional — omitting the key is not the same as writing `undefined`
+      const outcome: ExecOutcome = {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+      };
+      void outcome;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("accepts launchError set explicitly to a string", () => {
+    const outcome: ExecOutcome = {
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      launchError: "spawn pyton3 ENOENT",
+    };
+    expectTypeOf(outcome.launchError).toEqualTypeOf<string | undefined>();
   });
 });
 
@@ -462,14 +497,40 @@ const hook: ResolvedHook = {
 };
 
 /** A complete `DecidingHook`, reused by the `CaseResult` cases below. */
-const decidingHook: DecidingHook = { hook, decision: { kind: "pass", exitCode: 0 } };
+const decidingHook: DecidingHook = {
+  hook,
+  decision: { kind: "pass", exitCode: 0 },
+  launchError: undefined,
+};
 
 describe("DecidingHook", () => {
-  it("carries the deciding hook and the Decision it produced", () => {
+  it("carries the deciding hook, the Decision it produced, and its own launchError", () => {
     expectTypeOf(decidingHook).toEqualTypeOf<{
       readonly hook: ResolvedHook;
       readonly decision: Decision;
+      readonly launchError: string | undefined;
     }>();
+  });
+
+  it("rejects a DecidingHook missing launchError", () => {
+    const rejected = (): void => {
+      // @ts-expect-error launchError is `string | undefined`, not optional
+      const missingLaunchError: DecidingHook = {
+        hook,
+        decision: { kind: "pass", exitCode: 0 },
+      };
+      void missingLaunchError;
+    };
+    expect(rejected).toBeTypeOf("function");
+  });
+
+  it("accepts launchError set to the OS-reported reason", () => {
+    const launchFailed: DecidingHook = {
+      hook,
+      decision: { kind: "error", exitCode: -1, cause: "launch-failed" },
+      launchError: "spawn pyton3 ENOENT",
+    };
+    expectTypeOf(launchFailed.launchError).toEqualTypeOf<string | undefined>();
   });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -441,7 +441,7 @@ describe("ExecOutcome", () => {
       stdout: "",
       stderr: "",
       timedOut: false,
-      launchError: "spawn pyton3 ENOENT",
+      launchError: "spawn python33 ENOENT",
     };
     expectTypeOf(outcome.launchError).toEqualTypeOf<string | undefined>();
   });
@@ -528,7 +528,7 @@ describe("DecidingHook", () => {
     const launchFailed: DecidingHook = {
       hook,
       decision: { kind: "error", exitCode: -1, cause: "launch-failed" },
-      launchError: "spawn pyton3 ENOENT",
+      launchError: "spawn python33 ENOENT",
     };
     expectTypeOf(launchFailed.launchError).toEqualTypeOf<string | undefined>();
   });


### PR DESCRIPTION
`NodeSpawner` mapped the child's `"error"` event — the command could not be launched at all — to `exitCode: -1` with the OS message appended to `stderr`, the same `-1` a signal kill and a timeout produce. `resolveDecision` found no `exitCodeEffects` row for `-1` and resolved it as `error / nonzero-exit-without-json` — exactly what a hook that ran and exited `9` gets. The user read "your hook errored" and debugged the hook's logic when the fault was a typo in `command` or a missing interpreter.

- `ExecOutcome` gains `launchError: string | undefined` — the OS-reported reason (`spawn pyton3 ENOENT`, `EACCES`) when the child's `"error"` event fired before a `close` with a real code, and `undefined` for every process that started. `NodeSpawner` stops appending that message to `stderr`; it has its own field now.
- `-1` stays a single sentinel, disambiguated by **documentation plus the other two fields** rather than by a fourth value. `ExecOutcome.exitCode`'s TSDoc states the three cases: killed by hookassert's timeout (`timedOut: true`), killed by a signal (`timedOut: false, launchError: undefined`), never started (`launchError` set).
- `Decision.error.cause` gains `"launch-failed"`. `resolveDecision` checks `outcome.launchError !== undefined` before the timeout check and before any `exitCodeEffects` lookup — the branch reads a field, no exit-code literal enters the resolver. It is a **case-level** error decision, not a run-level load error, so a fixture expecting `decision: error` for a deliberately broken hook passes.
- The message reaches the user through `decidedBy`: `DecidingHook` carries `launchError` beside `decision`, so a reporter prints it without holding the whole `ExecOutcome`.

Closes #39

Release impact: yes — MAJOR. `ExecOutcome` and `DecidingHook` each gain a **required** `launchError: string | undefined` field, and `Decision`'s `error` variant gains a `cause: "launch-failed"` member.

**Migration** (required by `release-impact` for a MAJOR change below `1.0.0`, which ships as a minor bump): a consumer that hand-constructs an `ExecOutcome` — a custom `Spawner`, a test stub — must add `launchError: undefined` for a process that started. A consumer that exhaustively `switch`es over `Decision`'s `error.cause` must add a `"launch-failed"` case. Nothing was removed or renamed.

## Scope boundary — what this PR deliberately does not do

`combineDecisions` ranks `deny` > `unknown` > `error`, and `DecidingHook` carries only the **winning** hook's `launchError`. So when one hook denies and another never launched, the launch failure is not surfaced — and because the OS message no longer lands in `stderr`, `expect.stderrContains` cannot see it either. That is a real narrowing versus `main` for that multi-hook shape.

Fixing it needs a report shape that carries *every* firing hook's launch error, which is its own public-surface change rather than something to fold in here. Filed as a follow-up (see the linked issue), alongside a related case where a launch-failure `FAIL` line replaces all of the other hooks' expectation diffs.

## Test plan

```
pnpm check:quick
pnpm check
```

Both green — 40 test files / 1690 tests; `pnpm check` adds build, `docs:build`, and `package:check`/`package:smoke`, required here because `src/types.ts` and a shipped schema changed. `pnpm test:coverage` also green (95.59% statements / 90.39% branches against a 90% floor).

New and updated coverage:

- `tests/executor.test.ts` — real-spawn exec-form ENOENT sets `launchError`; shell-form nonexistent script exits `127` with `launchError` left `undefined` (the shell launched fine, so this is *not* a launch failure).
- `tests/decision.test.ts` — `launchError` outranks both a documented block exit code and the timeout check.
- `tests/assert.test.ts` — `assertCase` propagates `execOutcome.launchError` into `decidedBy`.
- `tests/test-cmd.test.ts` — end-to-end `test` runs with a real nonexistent exec-form command, asserting the `pretty` message, the `github` annotation's `file:line`, and that a fixture expecting `decision: error` passes.
- `tests/reporters.test.ts` — a rendered launch-failure case validates against `schema/test-report.schema.json`.
- `tests/types.test.ts` — type-level assertions for the three changed public shapes.

## Review pass

`/code-review medium --fix` raised 5 findings; 2 were applied on this branch:

- The README overclaimed. `launch-failed` only arises for **exec-form** hooks (those declaring `args`); a shell-form hook always launches `/bin/sh` successfully, so a typo'd `command` there comes back as the shell's exit `127` — which this branch's own executor test asserts. The paragraph now says which form produces which, and which report surfaces the reason where.
- `decidedBySuffix` suppressed the `— decided by …` attribution whenever the deciding hook had a `launchError`, but it also renders `UNKNOWN` lines, and an `UNKNOWN` line never carries the launch-failure message (an event missing from the spec resolves to `unknown` *before* `launchError` is read). With more than one hook firing, that line lost its hook attribution and gained nothing. The suffix is now suppressed by an explicit `detailNamesHook` argument that only the `FAIL` branch passes.

The other 3 are the release-impact statement above and the two follow-up items in the scope-boundary section.

https://claude.ai/code/session_012my4Lq3svoxq6fF2FoyuXB
