### PR TITLE
fix: compare expect.context and expect.updatedInput against firing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ Each entry in `cases` may declare:
   against `hookSpecificOutput.additionalContext`; `updatedInput` compares the same way
   against `hookSpecificOutput.updatedInput`. Either is satisfied by any one firing
   hook's own value, and a mismatch (including no firing hook emitting the key at all)
-  fails.
+  fails. When _no_ hook fires at all, nothing is compared: the case passes unless it
+  declared `fires: true`, so pair a `context`/`updatedInput` expectation with
+  `fires: true` to keep a case that stopped firing from staying green.
 - `stub` — map an exact hook `command` string to a canned `{ exitCode }` instead of
   actually spawning it.
 - `dryRun: true` — skip execution for this one case, the same effect `--dry-run` has for

--- a/README.md
+++ b/README.md
@@ -201,8 +201,12 @@ Each entry in `cases` may declare:
   writing `input` by hand. A case with a recorded origin counts toward `test`'s own
   `(N from recorded)` summary count.
 - `expect` — any of `fires`, `decision` (`deny`/`allow`/`pass`/`error`/`unknown`),
-  `exitCode`, `stdoutContains`, `stderrContains`, `timedOut`. Only the fields you set
-  are asserted.
+  `exitCode`, `stdoutContains`, `stderrContains`, `context`, `updatedInput`, `timedOut`.
+  Only the fields you set are asserted. `context` compares by exact deep equality
+  against `hookSpecificOutput.additionalContext`; `updatedInput` compares the same way
+  against `hookSpecificOutput.updatedInput`. Either is satisfied by any one firing
+  hook's own value, and a mismatch (including no firing hook emitting the key at all)
+  fails.
 - `stub` — map an exact hook `command` string to a canned `{ exitCode }` instead of
   actually spawning it.
 - `dryRun: true` — skip execution for this one case, the same effect `--dry-run` has for

--- a/schema/test-report.schema.json
+++ b/schema/test-report.schema.json
@@ -293,6 +293,24 @@
             "expectedTimedOut": { "type": "boolean" },
             "actualTimedOut": { "type": "boolean" }
           }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedContext", "actualContext"],
+          "properties": {
+            "field": { "const": "context" },
+            "expectedContext": {},
+            "actualContext": {}
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["field", "expectedUpdatedInput", "actualUpdatedInput"],
+          "properties": {
+            "field": { "const": "updatedInput" },
+            "expectedUpdatedInput": {},
+            "actualUpdatedInput": {}
+          }
         }
       ]
     },

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -272,9 +272,9 @@ function isNonEmptyFired(
  * 5. The combined `Decision` resolved with confidence → every declared
  *    `expect` field is compared against what was observed (`decision`/
  *    `exitCode` against the combined verdict, `stdoutContains`/
- *    `stderrContains`/`timedOut` against every firing hook's own stream);
- *    any mismatch produces `"fail"` with a non-empty `diffs`, otherwise
- *    `"pass"`.
+ *    `stderrContains`/`timedOut`/`context`/`updatedInput` against every
+ *    firing hook's own stream); any mismatch produces `"fail"` with a
+ *    non-empty `diffs`, otherwise `"pass"`.
  */
 export function assertCase(
   caseData: FixtureCase,

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -21,9 +21,47 @@ import type {
   NonFiringExplanation,
   RejectedMatch,
 } from "../../types.js";
-import { combineDecisions } from "../decision/index.js";
+import { combineDecisions, readHookOutput } from "../decision/index.js";
+import type { HookOutput } from "../decision/index.js";
 import type { FixtureCase, FixtureExpectation } from "../fixture/index.js";
 import type { CaseObservation, FiredHook } from "./types.js";
+
+/**
+ * Exact structural equality over JSON-shaped values: same type, same keys
+ * (order-independent), same array length, recursive. No dependency — this is
+ * `expect.context`/`expect.updatedInput`'s comparison rule
+ * (`computeFiredDiffs` below), and a partial/subset match was deliberately
+ * rejected for it: `context` is a string in practice, where "subset" has no
+ * meaning, and a subset rule for `updatedInput` would make
+ * `expect.updatedInput: {}` pass against anything.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (typeof a === "object" && a !== null && typeof b === "object" && b !== null) {
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+    const aKeys = Object.keys(aRecord);
+    const bKeys = Object.keys(bRecord);
+    if (aKeys.length !== bKeys.length) {
+      return false;
+    }
+    return aKeys.every(
+      (key) => Object.hasOwn(bRecord, key) && deepEqual(aRecord[key], bRecord[key]),
+    );
+  }
+
+  return false;
+}
 
 /** Whether `expect` declares no assertion at all — every field is `undefined`. */
 function isEmptyExpectation(expect: FixtureExpectation): boolean {
@@ -94,9 +132,13 @@ function deriveNonFiring(
  * "unknown"` rather than a `diffs` mismatch. `decision`/`exitCode` are
  * compared against the combined verdict (`exitCode` is the deciding hook's
  * own, since that is whose `Decision` won the fold); `stdoutContains`,
- * `stderrContains`, and `timedOut` are checked against *every* firing hook
- * — a real Claude Code session shows every hook's output, not only the one
- * that decided — so any one of them satisfying the expectation is enough.
+ * `stderrContains`, `timedOut`, `context`, and `updatedInput` are checked
+ * against *every* firing hook — a real Claude Code session shows every
+ * hook's output, not only the one that decided — so any one of them
+ * satisfying the expectation is enough. `context`/`updatedInput` compare
+ * `hookSpecificOutput.additionalContext`/`hookSpecificOutput.updatedInput`
+ * (read by `decision/`'s `readHookOutput`) by exact `deepEqual`, never a
+ * partial match.
  */
 function computeFiredDiffs(
   expect: FixtureExpectation,
@@ -160,7 +202,44 @@ function computeFiredDiffs(
     }
   }
 
+  if (expect.context !== undefined || expect.updatedInput !== undefined) {
+    const outputs = fired.map((f) => readHookOutput(f.execOutcome));
+
+    if (expect.context !== undefined) {
+      const expectedContext = expect.context;
+      if (!outputs.some((o) => deepEqual(o.additionalContext, expectedContext))) {
+        diffs.push({
+          field: "context",
+          expectedContext,
+          actualContext: firstEmitted(outputs, "additionalContext"),
+        });
+      }
+    }
+
+    if (expect.updatedInput !== undefined) {
+      const expectedUpdatedInput = expect.updatedInput;
+      if (!outputs.some((o) => deepEqual(o.updatedInput, expectedUpdatedInput))) {
+        diffs.push({
+          field: "updatedInput",
+          expectedUpdatedInput,
+          actualUpdatedInput: firstEmitted(outputs, "updatedInput"),
+        });
+      }
+    }
+  }
+
   return diffs;
+}
+
+/**
+ * `outputs[*][key]` from the first `HookOutput` that emitted it, or
+ * `undefined` when none did — the `actualContext`/`actualUpdatedInput` a
+ * `"context"`/`"updatedInput"` {@link ExpectationDiff} reports, independent
+ * of which firing hook (if any) is what {@link computeFiredDiffs} actually
+ * compared `expect.context`/`expect.updatedInput` against.
+ */
+function firstEmitted(outputs: readonly HookOutput[], key: keyof HookOutput): unknown {
+  return outputs.find((o) => o[key] !== undefined)?.[key];
 }
 
 /** Type guard narrowing `fired` to a non-empty tuple once its length has been checked. */

--- a/src/internal/decision/index.ts
+++ b/src/internal/decision/index.ts
@@ -15,3 +15,5 @@ export { allowed, denied, errored, passed, unknownDecision } from "./factory.js"
 export { canProduceDeny, exit2OverridesAllowJson, resolveDecision } from "./resolve.js";
 export { combineDecisions } from "./combine.js";
 export type { CombinedDecision } from "./combine.js";
+export { readHookOutput } from "./read-output.js";
+export type { HookOutput } from "./read-output.js";

--- a/src/internal/decision/read-output.ts
+++ b/src/internal/decision/read-output.ts
@@ -1,0 +1,62 @@
+/**
+ * Reads the two `hookSpecificOutput` fields a fixture's `expect.context` and
+ * `expect.updatedInput` compare against.
+ *
+ * @remarks
+ * Static layer: pure function, no I/O — `readHookOutput` only ever reads the
+ * `ExecOutcome` it is given.
+ *
+ * Claude Code's hook JSON output carries both values nested under
+ * `hookSpecificOutput`: `additionalContext` (a string the model sees) and
+ * `updatedInput` (an object replacing the tool's input). That nested
+ * location is the only one Claude Code documents — a top-level
+ * `additionalContext`/`updatedInput` key is not read.
+ */
+
+import type { ExecOutcome } from "../../types.js";
+import { isPlainRecord, parseJsonStdout } from "./resolve.js";
+
+/**
+ * The two `hookSpecificOutput` fields a fixture case's `expect.context` and
+ * `expect.updatedInput` compare against.
+ *
+ * @remarks
+ * Each field is `undefined` when `outcome.stdout` is not JSON, is not a
+ * plain object, or its `hookSpecificOutput` (itself not a plain object, or
+ * absent) does not carry that key — `readHookOutput` never throws over a
+ * hook's stdout, however malformed.
+ */
+export interface HookOutput {
+  /** `hookSpecificOutput.additionalContext`, or `undefined` when absent. */
+  readonly additionalContext: unknown;
+  /** `hookSpecificOutput.updatedInput`, or `undefined` when absent. */
+  readonly updatedInput: unknown;
+}
+
+const EMPTY_OUTPUT: HookOutput = {
+  additionalContext: undefined,
+  updatedInput: undefined,
+};
+
+/**
+ * Read `outcome.stdout`'s `hookSpecificOutput.additionalContext` and
+ * `hookSpecificOutput.updatedInput`, sharing `resolve.ts`'s
+ * `parseJsonStdout` — the same "is this even JSON" rule `classifyJsonDecision`
+ * uses for `permissionDecision`.
+ */
+export function readHookOutput(outcome: ExecOutcome): HookOutput {
+  const parsed = parseJsonStdout(outcome.stdout);
+  if (parsed.kind !== "record") {
+    return EMPTY_OUTPUT;
+  }
+
+  const hookSpecificOutput = parsed.value["hookSpecificOutput"];
+  if (!isPlainRecord(hookSpecificOutput)) {
+    return EMPTY_OUTPUT;
+  }
+
+  return {
+    additionalContext: hookSpecificOutput["additionalContext"],
+    updatedInput: hookSpecificOutput["updatedInput"],
+  };
+}

--- a/src/internal/decision/resolve.ts
+++ b/src/internal/decision/resolve.ts
@@ -87,8 +87,51 @@ function looksLikeJson(text: string): boolean {
   return text.startsWith("{") || text.startsWith("[");
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
+/** Whether `value` is a plain JSON object, as opposed to an array, `null`, or a scalar. */
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** What {@link parseJsonStdout} found in a hook's stdout. */
+type StdoutJsonResult =
+  | { readonly kind: "none" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "record"; readonly value: Record<string, unknown> };
+
+/**
+ * Parse a hook's stdout as JSON, sharing the one rule every stdout-JSON
+ * reader in this package uses for "is this even worth trying": only text
+ * that looks like JSON (`{`/`[`-prefixed after trimming) is attempted at
+ * all — most hooks print plain text and exit, and that is not an error,
+ * since Claude Code itself only tries to parse stdout as JSON when it looks
+ * like one. A value that parses but is not a plain object (an array, a JSON
+ * scalar) reads the same as "no JSON here" (`kind: "none"`), never as a
+ * decision or a hook output.
+ *
+ * @remarks
+ * `classifyJsonDecision` below and `readHookOutput` (`read-output.ts`) both
+ * call this rather than each parsing stdout their own way — the two readers
+ * differ only in what they look for inside the parsed record once they have
+ * one.
+ */
+export function parseJsonStdout(stdout: string): StdoutJsonResult {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0 || !looksLikeJson(trimmed)) {
+    return { kind: "none" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return { kind: "malformed" };
+  }
+
+  if (!isPlainRecord(parsed)) {
+    return { kind: "none" };
+  }
+
+  return { kind: "record", value: parsed };
 }
 
 /**
@@ -136,23 +179,12 @@ type JsonDecision =
  * looks like one.
  */
 function classifyJsonDecision(eventSpec: EventSpec, stdout: string): JsonDecision {
-  const trimmed = stdout.trim();
-  if (trimmed.length === 0 || !looksLikeJson(trimmed)) {
-    return { kind: "none" };
+  const parsedStdout = parseJsonStdout(stdout);
+  if (parsedStdout.kind === "none" || parsedStdout.kind === "malformed") {
+    return parsedStdout;
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed) as unknown;
-  } catch {
-    return { kind: "malformed" };
-  }
-
-  if (!isPlainRecord(parsed)) {
-    return { kind: "none" };
-  }
-
-  const raw = readDecisionValue(parsed);
+  const raw = readDecisionValue(parsedStdout.value);
   if (raw === undefined) {
     return { kind: "none" };
   }

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -127,7 +127,16 @@ function describeDiff(diff: ExpectationDiff): string {
       return `stderrContains: expected stderr to contain ${JSON.stringify(diff.expectedSubstring)}, got ${JSON.stringify(diff.actualStderr)}`;
     case "timedOut":
       return `timedOut: expected ${String(diff.expectedTimedOut)}, got ${String(diff.actualTimedOut)}`;
+    case "context":
+      return `context: expected ${jsonOrAbsent(diff.expectedContext)}, got ${jsonOrAbsent(diff.actualContext)}`;
+    case "updatedInput":
+      return `updatedInput: expected ${jsonOrAbsent(diff.expectedUpdatedInput)}, got ${jsonOrAbsent(diff.actualUpdatedInput)}`;
   }
+}
+
+/** `JSON.stringify(value)`, or the literal `"absent"` for `undefined` — `JSON.stringify(undefined)` itself returns `undefined`, not a string. */
+function jsonOrAbsent(value: unknown): string {
+  return value === undefined ? "absent" : JSON.stringify(value);
 }
 
 /** `<command> (<file>:<line>)` for the hook a multi-hook case's verdict came from. */
@@ -340,6 +349,38 @@ function toJsonNonFiringExplanation(
 }
 
 /**
+ * `ExpectationDiff`, with a `"context"`/`"updatedInput"` diff's
+ * `actualContext`/`actualUpdatedInput` normalized to `null` when no firing
+ * hook emitted the key.
+ *
+ * @remarks
+ * `JSON.stringify` drops an object property whose value is `undefined`
+ * outright, rather than emitting `null` for it — the same gap
+ * {@link toJsonPayloadOrigin} exists to close for a `"recorded"` origin's
+ * `claudeVersion` — which `schema/test-report.schema.json`'s
+ * `additionalProperties: false` plus full `required` list would then reject
+ * as a missing key. `??` rather than `||`: a hook that legitimately emitted
+ * `additionalContext: false` or `""` must stay that value, not become
+ * `null`. The other six variants never carry `undefined`, so they pass
+ * through unchanged.
+ */
+function toJsonExpectationDiff(diff: ExpectationDiff): ExpectationDiff {
+  switch (diff.field) {
+    case "fires":
+    case "decision":
+    case "exitCode":
+    case "stdoutContains":
+    case "stderrContains":
+    case "timedOut":
+      return diff;
+    case "context":
+      return { ...diff, actualContext: diff.actualContext ?? null };
+    case "updatedInput":
+      return { ...diff, actualUpdatedInput: diff.actualUpdatedInput ?? null };
+  }
+}
+
+/**
  * `CaseResult`, mapped field by field to the shape
  * `schema/test-report.schema.json` describes: every value `CaseResult` may
  * leave absent (`decidedBy`, a `"fail"` result's `nonFiring`, a `"recorded"`
@@ -390,7 +431,7 @@ function toJsonCaseResult(result: CaseResult): JsonCaseResult {
       return {
         kind: "fail",
         origin,
-        diffs: result.diffs,
+        diffs: result.diffs.map(toJsonExpectationDiff),
         nonFiring:
           result.nonFiring === undefined
             ? null

--- a/src/types.ts
+++ b/src/types.ts
@@ -445,6 +445,34 @@ export type ExpectationDiff =
       readonly expectedTimedOut: boolean;
       /** Whether the hook actually timed out. */
       readonly actualTimedOut: boolean;
+    }
+  | {
+      /**
+       * No firing hook's `hookSpecificOutput.additionalContext` deep-equaled
+       * `expect.context`.
+       */
+      readonly field: "context";
+      /** The fixture's declared `expect.context`. */
+      readonly expectedContext: unknown;
+      /**
+       * `hookSpecificOutput.additionalContext` from the first firing hook
+       * that emitted it, or `undefined` when no firing hook did.
+       */
+      readonly actualContext: unknown;
+    }
+  | {
+      /**
+       * No firing hook's `hookSpecificOutput.updatedInput` deep-equaled
+       * `expect.updatedInput`.
+       */
+      readonly field: "updatedInput";
+      /** The fixture's declared `expect.updatedInput`. */
+      readonly expectedUpdatedInput: unknown;
+      /**
+       * `hookSpecificOutput.updatedInput` from the first firing hook that
+       * emitted it, or `undefined` when no firing hook did.
+       */
+      readonly actualUpdatedInput: unknown;
     };
 
 /**

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -80,6 +80,14 @@ function makeExecOutcome(overrides: Partial<ExecOutcome> = {}): ExecOutcome {
   };
 }
 
+/** `stdout` JSON carrying `hookSpecificOutput.additionalContext`/`.updatedInput`, `readHookOutput`'s documented location. */
+function hookOutputStdout(output: {
+  readonly additionalContext?: unknown;
+  readonly updatedInput?: unknown;
+}): string {
+  return JSON.stringify({ hookSpecificOutput: output });
+}
+
 function makeFired(overrides: Partial<FiredHook> = {}): FiredHook {
   return {
     hook: makeHook(),
@@ -219,6 +227,196 @@ describe("assertCase: expectation diffing", () => {
   it("a case with no expectations at all, whose hook did not fire, produces a pass CaseResult", () => {
     const caseData = makeCase();
     const result = assertCase(caseData, makeObservation());
+
+    expect(result.kind).toBe("pass");
+  });
+});
+
+describe("assertCase: expect.context and expect.updatedInput (issue #34)", () => {
+  it("expect.context passes on an exact match against hookSpecificOutput.additionalContext", () => {
+    const caseData = makeCase({
+      expect: makeExpect({ context: "extra context for the model" }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({
+              additionalContext: "extra context for the model",
+            }),
+          }),
+        }),
+      ],
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("expect.context fails on a mismatch, with the diff carrying both sides", () => {
+    const caseData = makeCase({ expect: makeExpect({ context: "expected" }) });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ additionalContext: "actual" }),
+          }),
+        }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "context",
+      expectedContext: "expected",
+      actualContext: "actual",
+    });
+  });
+
+  it("expect.context fails with actualContext: undefined when no firing hook emitted it", () => {
+    const caseData = makeCase({ expect: makeExpect({ context: "expected" }) });
+    const observation = makeObservation({
+      fired: [makeFired({ execOutcome: makeExecOutcome({ stdout: "not json" }) })],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "context",
+      expectedContext: "expected",
+      actualContext: undefined,
+    });
+  });
+
+  it("expect.updatedInput passes on an exact deep-equal match against hookSpecificOutput.updatedInput", () => {
+    const caseData = makeCase({
+      expect: makeExpect({
+        updatedInput: { command: "git push", flags: ["--dry-run"] },
+      }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({
+              updatedInput: { command: "git push", flags: ["--dry-run"] },
+            }),
+          }),
+        }),
+      ],
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("expect.updatedInput fails on a partial (subset) match — exact equality only", () => {
+    const caseData = makeCase({ expect: makeExpect({ updatedInput: {} }) });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ updatedInput: { command: "git push" } }),
+          }),
+        }),
+      ],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "updatedInput",
+      expectedUpdatedInput: {},
+      actualUpdatedInput: { command: "git push" },
+    });
+  });
+
+  it("expect.updatedInput fails with actualUpdatedInput: undefined when no firing hook emitted it", () => {
+    const caseData = makeCase({ expect: makeExpect({ updatedInput: { a: 1 } }) });
+    const observation = makeObservation({
+      fired: [makeFired({ execOutcome: makeExecOutcome({ stdout: "" }) })],
+    });
+
+    const result = expectFail(assertCase(caseData, observation));
+
+    expect(result.diffs).toContainEqual({
+      field: "updatedInput",
+      expectedUpdatedInput: { a: 1 },
+      actualUpdatedInput: undefined,
+    });
+  });
+
+  it("a case declaring only expect.context is not skipped", () => {
+    const caseData = makeCase({ expect: makeExpect({ context: "anything" }) });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ additionalContext: "anything" }),
+          }),
+        }),
+      ],
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).not.toBe("skipped");
+  });
+
+  it("a case declaring only expect.updatedInput is not skipped", () => {
+    const caseData = makeCase({ expect: makeExpect({ updatedInput: { a: 1 } }) });
+    const result = assertCase(caseData, makeObservation());
+
+    expect(result.kind).not.toBe("skipped");
+  });
+
+  it("expect.context is satisfied when only the second of two firing hooks emitted a matching value", () => {
+    const caseData = makeCase({
+      expect: makeExpect({ context: "only in the second hook" }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ additionalContext: "first hook's own context" }),
+          }),
+        }),
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ additionalContext: "only in the second hook" }),
+          }),
+        }),
+      ],
+    });
+
+    const result = assertCase(caseData, observation);
+
+    expect(result.kind).toBe("pass");
+  });
+
+  it("expect.updatedInput is satisfied when only the second of two firing hooks emitted a matching value", () => {
+    const caseData = makeCase({
+      expect: makeExpect({ updatedInput: { command: "only-in-second" } }),
+    });
+    const observation = makeObservation({
+      fired: [
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ updatedInput: { command: "first-hook" } }),
+          }),
+        }),
+        makeFired({
+          execOutcome: makeExecOutcome({
+            stdout: hookOutputStdout({ updatedInput: { command: "only-in-second" } }),
+          }),
+        }),
+      ],
+    });
+
+    const result = assertCase(caseData, observation);
 
     expect(result.kind).toBe("pass");
   });

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -10,6 +10,7 @@ import {
   errored,
   exit2OverridesAllowJson,
   passed,
+  readHookOutput,
   resolveDecision,
   unknownDecision,
 } from "../src/internal/decision/index.js";
@@ -698,5 +699,84 @@ describe("combineDecisions", () => {
     ];
 
     expect(combineDecisions(decisions).index).toBe(0);
+  });
+});
+
+describe("readHookOutput", () => {
+  it("reads hookSpecificOutput.additionalContext and .updatedInput from JSON stdout", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          additionalContext: "extra context for the model",
+          updatedInput: { command: "git push" },
+        },
+      }),
+    });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: "extra context for the model",
+      updatedInput: { command: "git push" },
+    });
+  });
+
+  it.each([
+    ["empty stdout", ""],
+    ["plain-text stdout that does not look like JSON", "hook finished successfully"],
+    ["stdout that looks like JSON but fails to parse", "{not valid json"],
+    ["JSON that parses to an array rather than a plain object", "[1, 2, 3]"],
+  ])("both fields are undefined for %s", (_label, stdout) => {
+    const outcome = makeOutcome({ stdout });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: undefined,
+      updatedInput: undefined,
+    });
+  });
+
+  it("both fields are undefined for well-formed JSON with no hookSpecificOutput at all", () => {
+    const outcome = makeOutcome({ stdout: JSON.stringify({ decision: "allow" }) });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: undefined,
+      updatedInput: undefined,
+    });
+  });
+
+  it("both fields are undefined when hookSpecificOutput itself is not a plain object", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({ hookSpecificOutput: "not-an-object" }),
+    });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: undefined,
+      updatedInput: undefined,
+    });
+  });
+
+  it("only reads the nested hookSpecificOutput location — top-level additionalContext/updatedInput keys are ignored", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({
+        additionalContext: "top-level, not Claude Code's documented location",
+        updatedInput: { command: "top-level too" },
+      }),
+    });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: undefined,
+      updatedInput: undefined,
+    });
+  });
+
+  it("reads whichever of the two keys hookSpecificOutput carries, leaving the other undefined", () => {
+    const outcome = makeOutcome({
+      stdout: JSON.stringify({
+        hookSpecificOutput: { additionalContext: "context only" },
+      }),
+    });
+
+    expect(readHookOutput(outcome)).toEqual({
+      additionalContext: "context only",
+      updatedInput: undefined,
+    });
   });
 });

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -709,6 +709,8 @@ class ScriptedSpawner implements Spawner {
 /** The loosely typed shape this suite reads back out of `renderTestJson`'s output. */
 interface JsonExpectationDiffShape {
   readonly field: string;
+  readonly actualContext?: unknown;
+  readonly actualUpdatedInput?: unknown;
 }
 interface JsonNonFiringExplanationShape {
   readonly kind: string;
@@ -756,6 +758,8 @@ describe("renderTestJson: schema validation against a real rendering", () => {
   const CMD_NOTIFICATION_NOOP = "cmd-notification-noop";
   const CMD_STOP_LOCAL_ONLY = "cmd-stop-local-only";
   const CMD_LAUNCH_FAIL = "cmd-launch-fail";
+  const CMD_CONTEXT_MISMATCH = "cmd-context-mismatch";
+  const CMD_UPDATED_INPUT_ABSENT = "cmd-updated-input-absent";
 
   beforeAll(() => {
     projectDir = mkdtempSync(path.join(tmpdir(), "hookassert-reporters-test-schema-"));
@@ -778,6 +782,9 @@ describe("renderTestJson: schema validation against a real rendering", () => {
             matcher: "LaunchFail",
             hooks: [{ type: "command", command: CMD_LAUNCH_FAIL, args: [] }],
           },
+          // Issue #34: expect.context / expect.updatedInput diffs.
+          commandGroup("Agent", CMD_CONTEXT_MISMATCH),
+          commandGroup("AskUserQuestion", CMD_UPDATED_INPUT_ABSENT),
         ],
         Notification: [commandGroup(undefined, CMD_NOTIFICATION_NOOP)],
       },
@@ -840,8 +847,22 @@ describe("renderTestJson: schema validation against a real rendering", () => {
           tool: "WebFetch",
           expect: { timedOut: false },
         },
-        // "fail" via NonFiringExplanation.kind: "matcher-did-not-match" — six
-        // candidates are declared under PreToolUse, none matches "Read".
+        // "fail" via field: "context" (issue #34) — hookSpecificOutput.additionalContext
+        // disagrees with expect.context.
+        {
+          event: "PreToolUse",
+          tool: "Agent",
+          expect: { context: "expected-context" },
+        },
+        // "fail" via field: "updatedInput" (issue #34), actualUpdatedInput
+        // undefined — the hook's stdout is not JSON, so nothing was emitted.
+        {
+          event: "PreToolUse",
+          tool: "AskUserQuestion",
+          expect: { updatedInput: { command: "git push" } },
+        },
+        // "fail" via NonFiringExplanation.kind: "matcher-did-not-match" —
+        // several candidates are declared under PreToolUse, none matches "Read".
         { event: "PreToolUse", tool: "Read", expect: { fires: true } },
         // "fail" via NonFiringExplanation.kind: "no-hook-configured" —
         // nothing is declared under SessionStart anywhere.
@@ -888,6 +909,16 @@ describe("renderTestJson: schema validation against a real rendering", () => {
           CMD_LAUNCH_FAIL,
           { exitCode: -1, launchError: "spawn cmd-launch-fail ENOENT" },
         ],
+        [
+          CMD_CONTEXT_MISMATCH,
+          {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              hookSpecificOutput: { additionalContext: "actual-context" },
+            }),
+          },
+        ],
+        [CMD_UPDATED_INPUT_ABSENT, { exitCode: 0, stdout: "not json" }],
       ]),
     );
 
@@ -903,7 +934,7 @@ describe("renderTestJson: schema validation against a real rendering", () => {
       },
     );
 
-    // 9 of the 14 cases fail — `resolveTestExitCode` returns 1 whenever
+    // 11 of the 16 cases fail — `resolveTestExitCode` returns 1 whenever
     // `summary.failed > 0`, regardless of `--ci`.
     expect(result.exitCode).toBe(1);
     const parsed: unknown = JSON.parse(result.stdout);
@@ -926,6 +957,8 @@ describe("renderTestJson: schema validation against a real rendering", () => {
         "stdoutContains",
         "stderrContains",
         "timedOut",
+        "context",
+        "updatedInput",
       ]),
     );
 
@@ -956,6 +989,25 @@ describe("renderTestJson: schema validation against a real rendering", () => {
     );
     expect(decisionDiffCase?.result.nonFiring).toBeNull();
 
+    // Issue #34: expect.context compares against hookSpecificOutput.additionalContext.
+    const contextDiffCase = report.cases.find(
+      (c) => c.event === "PreToolUse" && c.tool === "Agent",
+    );
+    expect(contextDiffCase?.result.diffs).toContainEqual(
+      expect.objectContaining({ field: "context", actualContext: "actual-context" }),
+    );
+
+    // Issue #34: expect.updatedInput compares against hookSpecificOutput.updatedInput —
+    // no hook emitted it here (non-JSON stdout), so actualUpdatedInput is the
+    // explicit JSON `null` schema/test-report.schema.json requires, never an
+    // absent key.
+    const updatedInputDiffCase = report.cases.find(
+      (c) => c.event === "PreToolUse" && c.tool === "AskUserQuestion",
+    );
+    expect(updatedInputDiffCase?.result.diffs).toContainEqual(
+      expect.objectContaining({ field: "updatedInput", actualUpdatedInput: null }),
+    );
+
     // Issue #39: a launch failure resolves to a "pass" CaseResult when the
     // fixture expects decision: "error", and decidedBy.launchError carries
     // the OS-reported reason through to the JSON report.
@@ -965,6 +1017,85 @@ describe("renderTestJson: schema validation against a real rendering", () => {
     expect(launchFailedCase?.result.kind).toBe("pass");
     expect(launchFailedCase?.result.decidedBy?.launchError).toBe(
       "spawn cmd-launch-fail ENOENT",
+    );
+  });
+
+  it("pretty and github both render the context and updatedInput diffs (issue #34)", async () => {
+    const fixture = {
+      settings: [".claude/settings.json"],
+      cases: [
+        { event: "PreToolUse", tool: "Agent", expect: { context: "expected-context" } },
+        {
+          event: "PreToolUse",
+          tool: "AskUserQuestion",
+          expect: { updatedInput: { command: "git push" } },
+        },
+      ],
+    };
+    const fixturePath = path.join(projectDir, "context-diff.yaml");
+    writeFileSync(fixturePath, JSON.stringify(fixture, null, 2));
+
+    const spawner = new ScriptedSpawner(
+      new Map<string, ScriptedOutcome>([
+        [
+          CMD_CONTEXT_MISMATCH,
+          {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              hookSpecificOutput: { additionalContext: "actual-context" },
+            }),
+          },
+        ],
+        [CMD_UPDATED_INPUT_ABSENT, { exitCode: 0, stdout: "not json" }],
+      ]),
+    );
+
+    const deps = {
+      cwd: projectDir,
+      home: path.join(FIXTURES_DIR, "no-such-directory"),
+      env: {},
+      specPath: MINIMAL_SPEC_PATH,
+      spawner,
+    };
+
+    const prettyResult = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "pretty",
+      ],
+      "hookassert",
+      deps,
+    );
+    expect(prettyResult.stdout).toContain(
+      'context: expected "expected-context", got "actual-context"',
+    );
+    expect(prettyResult.stdout).toContain(
+      'updatedInput: expected {"command":"git push"}, got absent',
+    );
+
+    const githubResult = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--format",
+        "github",
+      ],
+      "hookassert",
+      deps,
+    );
+    expect(githubResult.stdout).toContain(
+      'context: expected "expected-context", got "actual-context"',
+    );
+    expect(githubResult.stdout).toContain(
+      'updatedInput: expected {"command":"git push"}, got absent',
     );
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -717,6 +717,22 @@ describe("ExpectationDiff", () => {
           }>();
           break;
         }
+        case "context": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "context";
+            readonly expectedContext: unknown;
+            readonly actualContext: unknown;
+          }>();
+          break;
+        }
+        case "updatedInput": {
+          expectTypeOf(diff).toEqualTypeOf<{
+            readonly field: "updatedInput";
+            readonly expectedUpdatedInput: unknown;
+            readonly actualUpdatedInput: unknown;
+          }>();
+          break;
+        }
       }
     };
     narrow({ field: "fires", expectedFires: true, actualFires: false });
@@ -733,6 +749,16 @@ describe("ExpectationDiff", () => {
       actualStderr: "",
     });
     narrow({ field: "timedOut", expectedTimedOut: true, actualTimedOut: false });
+    narrow({
+      field: "context",
+      expectedContext: "expected",
+      actualContext: "actual",
+    });
+    narrow({
+      field: "updatedInput",
+      expectedUpdatedInput: { command: "git push" },
+      actualUpdatedInput: undefined,
+    });
   });
 });
 


### PR DESCRIPTION
`computeFiredDiffs` never compared `expect.context` or `expect.updatedInput`, although `isEmptyExpectation` counts both as real expectations (so a case declaring only one of them is not skipped) and both are live, schema-validated `FixtureExpectation` fields. A fixture declaring only `expect: { updatedInput: {...} }` therefore always passed once a hook fired — a silent, permanent false pass, live since #11 shipped the executor.

- `src/internal/decision/read-output.ts` adds `readHookOutput(outcome): HookOutput`, returning `{ additionalContext, updatedInput }` read from `hookSpecificOutput` — the nested location Claude Code documents; top-level keys are ignored. Each is `undefined` when stdout is not JSON, is not an object, or lacks the key.
- It shares `classifyJsonDecision`'s parse literally rather than by duplication: the stdout-JSON rule is extracted into an exported `parseJsonStdout` in `resolve.ts`, and both readers call it. They differ only in what they look for inside the parsed record.
- `assertCase.ts` adds a dependency-free `deepEqual` and compares both fields by **exact structural equality**. A partial/subset match was rejected: `context` is a string in practice, where "subset" has no meaning, and a subset rule for `updatedInput` would make `expect.updatedInput: {}` pass against anything.
- **Any firing hook satisfies it**, consistent with #42's rule for `stdoutContains` — Claude Code appends every hook's `additionalContext`, and a fixture asserting a value was produced should not depend on which hook produced it. With one firing hook this reduces to plain equality.
- An expectation declared when **no** firing hook emitted the key is a mismatch with `actual: undefined`, never a pass.
- Two new whole-value `ExpectationDiff` variants carry the diff; all three reporters render both sides with `JSON.stringify` (`absent` for `undefined`), and `schema/test-report.schema.json` describes them. A structured per-key diff was rejected — two JSON dumps are enough for a hook author, and a key-path diff format is its own contract to maintain.

Closes #34

Release impact: yes — MINOR. Adds two `ExpectationDiff` variants (`field: "context"` / `"updatedInput"`) to the published discriminated union, following this repository's own precedent for the same shape of change (#42 / #54, which added `DecidingHook`/`decidedBy` and called it MINOR — additive for anything that only *reads* a `CaseResult`, the only way an `ExpectationDiff` is obtained). Worth a reviewer's eye: an exhaustive `switch` over `ExpectationDiff["field"]` in consumer code gains two arms, the same way #39's `cause` addition did — that one was called MAJOR. The difference relied on here is that `ExpectationDiff` is only ever read out of a `CaseResult`, never constructed by a consumer.

## Test plan

```
pnpm check:quick
pnpm check
```

Both green — 1710 tests; `pnpm check` adds build, `docs:build`, and `package:check`/`package:smoke`, required because `src/types.ts` and a shipped schema changed. `typos` run over the changed files: no findings.

- `tests/decision.test.ts` — `readHookOutput` against JSON with both keys, one key, no `hookSpecificOutput`; empty, non-JSON, malformed, and array stdout; top-level (non-nested) keys ignored.
- `tests/assert.test.ts` — pass on exact match; fail with both sides on mismatch; fail with `actual*: undefined` when no hook emitted the key; satisfied by the *second* of two firing hooks; a subset/partial match rejected; a case declaring only one of the two fields is not `"skipped"`.
- `tests/reporters.test.ts` — both new diffs validate against `schema/test-report.schema.json` (including `actual*: null` normalization, never a dropped key) and render in `pretty` and `github`.
- `tests/types.test.ts` — `ExpectationDiff` narrows on the two new `field` values.

## Review pass

`/code-review medium --fix` raised 2 findings, both documentation drift, both applied here:

- The README said a mismatch "including no firing hook emitting the key at all" fails. That holds once *any* hook fires, but `assertCase` returns `"pass"` before `computeFiredDiffs` runs when **nothing** fires and `fires: true` was not declared. The paragraph now says so and tells the reader to pair the expectation with `fires: true`.
- `assertCase`'s step-5 TSDoc still listed only `stdoutContains`/`stderrContains`/`timedOut` as compared against every firing hook; `computeFiredDiffs`' own doc was updated but the entry point's was not.

The review also noted the underlying behavior — a case with declared expectations passes when **no** hook fires — as a latent false pass. It is pre-existing and applies to every `expect` field, not just the two added here, so changing it is well outside this diff. Filed separately (see the linked issue).

https://claude.ai/code/session_012my4Lq3svoxq6fF2FoyuXB
