### PR TITLE
test: make the grandchild-timeout test's margins contention-robust

### DIFF
--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -415,12 +415,16 @@ describe("timeout", () => {
     // The sleep duration itself doubles as a unique marker: pgrep -f can
     // then confirm afterward that no process still matches this exact
     // command line, i.e. the whole process group was actually killed rather
-    // than only the direct `sh` child.
-    const marker = (5 + Math.random()).toFixed(4);
+    // than only the direct `sh` child. It is deliberately far longer than
+    // hookTimeoutMs (below) needs any margin against, so the assertions
+    // below can both stay generous and still prove the promise settled from
+    // the timer path rather than from waiting on the grandchild's own exit.
+    const marker = (15 + Math.random() * 5).toFixed(4);
+    const hookTimeoutMs = 200;
     const hook = makeHook({
       command: `echo start; sleep ${marker}`,
       args: undefined,
-      timeoutMs: 200,
+      timeoutMs: hookTimeoutMs,
     });
     const deps = makeDeps({ spawner: new NodeSpawner() });
 
@@ -429,14 +433,33 @@ describe("timeout", () => {
     const elapsedMs = Date.now() - startedAt;
 
     expect(result?.outcome.timedOut).toBe(true);
-    // Comfortably under the 5+ second sleep, with headroom for process
-    // teardown; a spawner that only waits for "close" resolves near 5000ms.
-    expect(elapsedMs).toBeLessThan(2000);
+    // `NodeSpawner` settles from the timer callback itself (see its own
+    // remark), never by waiting for "close" — a spawner that regressed to
+    // waiting for the grandchild's own exit would take ~`marker` seconds
+    // instead of ~`hookTimeoutMs`. The bound below is not an unrelated
+    // hand-picked wall-clock figure: it is a generous multiple of the
+    // hook's own declared deadline, wide enough to absorb the scheduling
+    // delay a CPU-starved machine can add on top of process-spawn and
+    // timer-callback latency (this suite measured a single synchronous
+    // `pgrep` spawn taking over 1s, versus ~150ms idle, under deliberate
+    // three-way CPU contention — see issue #66), while staying far under
+    // the multi-second `marker` a "still waiting for close" regression
+    // would actually take.
+    expect(elapsedMs).toBeLessThan(hookTimeoutMs * 20);
 
-    // Give the OS a moment to finish reaping the killed processes before
-    // checking that none of them survived as an orphan.
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    const stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+    // Poll for the grandchild's actual disappearance instead of sleeping a
+    // fixed amount and checking once: under CPU contention, `pgrep` itself
+    // (a synchronous spawn) can take over a second just to run, which a
+    // fixed pre-sleep cannot budget for in advance. The outer bound is
+    // generous because this loop only ever runs for its full length on an
+    // actual orphan-process regression, never on ordinary scheduling
+    // jitter.
+    const pollDeadline = Date.now() + 10_000;
+    let stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+    while (stillRunning.status === 0 && Date.now() < pollDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+    }
     expect(stillRunning.status).not.toBe(0);
   });
 });

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -432,35 +432,56 @@ describe("timeout", () => {
     const [result] = await executeHooks(deps, makePlan([makeStep(hook)]));
     const elapsedMs = Date.now() - startedAt;
 
-    expect(result?.outcome.timedOut).toBe(true);
-    // `NodeSpawner` settles from the timer callback itself (see its own
-    // remark), never by waiting for "close" — a spawner that regressed to
-    // waiting for the grandchild's own exit would take ~`marker` seconds
-    // instead of ~`hookTimeoutMs`. The bound below is not an unrelated
-    // hand-picked wall-clock figure: it is a generous multiple of the
-    // hook's own declared deadline, wide enough to absorb the scheduling
-    // delay a CPU-starved machine can add on top of process-spawn and
-    // timer-callback latency (this suite measured a single synchronous
-    // `pgrep` spawn taking over 1s, versus ~150ms idle, under deliberate
-    // three-way CPU contention — see issue #66), while staying far under
-    // the multi-second `marker` a "still waiting for close" regression
-    // would actually take.
-    expect(elapsedMs).toBeLessThan(hookTimeoutMs * 20);
+    try {
+      expect(result?.outcome.timedOut).toBe(true);
+      // `NodeSpawner` settles from the timer callback itself (see its own
+      // remark), never by waiting for "close" — a spawner that regressed to
+      // waiting for the grandchild's own exit would take ~`marker` seconds
+      // (>= 15s) instead of ~`hookTimeoutMs`. The bound below is not an
+      // unrelated hand-picked wall-clock figure: it is a generous multiple
+      // of the hook's own declared deadline, wide enough to absorb the
+      // scheduling delay a CPU-starved machine can add on top of
+      // process-spawn and timer-callback latency (this suite measured a
+      // single synchronous `pgrep` spawn taking over 1s, versus ~150ms
+      // idle, under deliberate three-way CPU contention — see issue #66).
+      // 40x (8000ms) keeps that margin without costing any discriminating
+      // power: it is still far under the >= 15s a "still waiting for
+      // close" regression would actually take, so widening it only makes
+      // the test more tolerant of contention, never less able to catch the
+      // regression it guards against.
+      expect(elapsedMs).toBeLessThan(hookTimeoutMs * 40);
 
-    // Poll for the grandchild's actual disappearance instead of sleeping a
-    // fixed amount and checking once: under CPU contention, `pgrep` itself
-    // (a synchronous spawn) can take over a second just to run, which a
-    // fixed pre-sleep cannot budget for in advance. The outer bound is
-    // generous because this loop only ever runs for its full length on an
-    // actual orphan-process regression, never on ordinary scheduling
-    // jitter.
-    const pollDeadline = Date.now() + 10_000;
-    let stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
-    while (stillRunning.status === 0 && Date.now() < pollDeadline) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+      // Poll for the grandchild's actual disappearance instead of sleeping
+      // a fixed amount and checking once: under CPU contention, `pgrep`
+      // itself (a synchronous spawn) can take over a second just to run,
+      // which a fixed pre-sleep cannot budget for in advance. The outer
+      // bound is generous because this loop only ever runs for its full
+      // length on an actual orphan-process regression, never on ordinary
+      // scheduling jitter. A failed spawn (`error` set, `status: null` —
+      // EAGAIN/ENOMEM under fork pressure, or `pgrep` missing) breaks the
+      // loop immediately rather than being read as "no match", so it fails
+      // the assertions below instead of silently passing.
+      const pollDeadline = Date.now() + 10_000;
+      let stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+      while (
+        stillRunning.error === undefined &&
+        stillRunning.status === 0 &&
+        Date.now() < pollDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        stillRunning = spawnSync("pgrep", ["-f", `sleep ${marker}`]);
+      }
+      expect(stillRunning.error).toBeUndefined();
+      // pgrep's documented exit status for "no process matched" — anything
+      // else (a still-running match, or pgrep's own status 2/3 for a usage
+      // or fatal error) must fail this test rather than pass it.
+      expect(stillRunning.status).toBe(1);
+    } finally {
+      // Clean up the survivor on the failure path too: an actual kill
+      // regression must not leave a `sleep ${marker}` process outliving
+      // this test's own run just because an assertion above threw first.
+      spawnSync("pkill", ["-f", `sleep ${marker}`]);
     }
-    expect(stillRunning.status).not.toBe(0);
   });
 });
 


### PR DESCRIPTION
The timeout test for a surviving grandchild asserted a flat, hand-picked `elapsedMs < 2000` and reaped its orphan check with a fixed 300ms sleep followed by a single `pgrep` call — both patterns with little headroom under CPU contention, which is what made it fail once during three concurrent suite runs and pass on rerun.

Root cause is test calibration, not a race in `src/internal/exec/executor.ts`: under deliberate three-way contention a comparable synchronous `pgrep` spawn in the same test measured 1035–1473ms against ~150–200ms idle, a 7–10x latency multiplier that the old 2000ms bound (9x its own 200ms baseline) had no comfortable margin against. `elapsedMs` itself stayed at 202–215ms throughout, so the deadline was the fragile part, not the behaviour.

The bound is now derived from the hook's own declared `timeoutMs` (`hookTimeoutMs * 40`) instead of a bare literal, and the sleep marker is widened to 15–20s so the gap between "settled from the timer path" (~200ms) and "regressed to waiting for the grandchild's close" (>=15s) is far wider than before — the assertion discriminates more sharply than it did, not less. The orphan check polls for the grandchild's actual disappearance against a generous 10s outer bound instead of sleeping a fixed amount and asserting once, requires `pgrep` to have actually run (`error === undefined`, `status === 1`) so a failed fork under memory pressure cannot read as "no orphan", and cleans the survivor up in a `finally` so a genuine kill regression cannot leave a process outliving the test.

Release impact: no — test-only change; no `src/` behaviour and no published surface is touched.

Closes #66

## Test plan

- `pnpm exec vitest run tests/executor.test.ts` -> 34/34 passed.
- `pnpm check:quick` -> format, lint, typecheck and 1710/1710 tests pass.
- Idle margin: `elapsedMs` ~202-207ms against the new 8000ms bound.
- Under three concurrent `pnpm check:quick` / `pnpm test` loops (load average 10-15 on 8 cores): `elapsedMs` stayed 202-215ms, while a comparable synchronous `pgrep` spawn in the same test spiked to 1035-1473ms — the measurement the new bound is sized against.
- The fixed test re-run 10x under that same contention: all passed.

https://claude.ai/code/session_01KeAFVkV4zJ6LWNK6x6XL78
