### PR TITLE
fix: honor spec.matcherSyntax.caseSensitive in matcher and lint comparisons

### DIFF
--- a/schema/spec.schema.json
+++ b/schema/spec.schema.json
@@ -68,7 +68,10 @@
         "rules"
       ],
       "properties": {
-        "caseSensitive": { "type": "boolean" },
+        "caseSensitive": {
+          "type": "boolean",
+          "description": "Whether the exact-list and regex comparisons are case-sensitive. Does not affect exactListPattern."
+        },
         "exactListPattern": {
           "type": "string",
           "minLength": 1,

--- a/src/internal/lint/rules/matcherCase.ts
+++ b/src/internal/lint/rules/matcherCase.ts
@@ -3,10 +3,13 @@
  * tool's own case.
  *
  * @remarks
- * `spec.matcherSyntax.caseSensitive` is `true`, and `matcher/match.ts`
- * compares an exact-list item against `req.target` with plain `===` — so
- * `"bash"` when the tool is `"Bash"` is a real, silent non-match, not a
- * style nit: the hook this matcher is attached to will never fire.
+ * Conditional on `spec.matcherSyntax.caseSensitive`. When it is `true`,
+ * `matcher/match.ts` compares an exact-list item against `req.target` with
+ * plain `===` — so `"bash"` when the tool is `"Bash"` is a real, silent
+ * non-match, not a style nit: the hook this matcher is attached to will
+ * never fire. When it is `false`, `match.ts` lowercases both sides before
+ * comparing, so a wrong-case matcher matches anyway and this rule reports
+ * nothing.
  */
 
 import type { Finding, LintContext, LintRule } from "../types.js";
@@ -59,6 +62,9 @@ export const matcherCaseRule: LintRule = {
   id: "matcher-case",
 
   run(ctx: LintContext): readonly Finding[] {
+    if (!ctx.spec.matcherSyntax.caseSensitive) {
+      return [];
+    }
     const findings: Finding[] = [];
     for (const group of ctx.groups) {
       if (group.matcher.kind !== "string") {

--- a/src/internal/lint/rules/matcherUnanchored.ts
+++ b/src/internal/lint/rules/matcherUnanchored.ts
@@ -131,16 +131,34 @@ function alternationBranches(matcher: string): readonly string[] | undefined {
   return branches;
 }
 
-/** `new RegExp(matcher).test(tool)`, with `matcher/match.ts`'s own tolerance for `"*"` and an uncompilable pattern. */
-function testRegexSafe(matcher: string, tool: string): boolean {
+/**
+ * `new RegExp(matcher, caseSensitive ? undefined : "i").test(tool)`, mirroring
+ * `matcher/match.ts`'s own `testUnanchoredRegex` — including its tolerance
+ * for `"*"` and an uncompilable pattern, and its `"i"` flag when
+ * `spec.matcherSyntax.caseSensitive` is `false`.
+ */
+function testRegexSafe(matcher: string, tool: string, caseSensitive: boolean): boolean {
   if (matcher === "*") {
     return true;
   }
   try {
-    return new RegExp(matcher).test(tool);
+    return new RegExp(matcher, caseSensitive ? undefined : "i").test(tool);
   } catch {
     return false;
   }
+}
+
+/** Whether `items` contains `tool`, honoring `spec.matcherSyntax.caseSensitive` the same way `matcher/match.ts`'s `exactListIncludes` does. */
+function includesTool(
+  items: readonly string[],
+  tool: string,
+  caseSensitive: boolean,
+): boolean {
+  if (caseSensitive) {
+    return items.includes(tool);
+  }
+  const lowerTool = tool.toLowerCase();
+  return items.some((item) => item.toLowerCase() === lowerTool);
 }
 
 export const matcherUnanchoredRule: LintRule = {
@@ -164,15 +182,18 @@ export const matcherUnanchoredRule: LintRule = {
         continue;
       }
 
+      const caseSensitive = ctx.spec.matcherSyntax.caseSensitive;
       const matched = ctx.spec.knownTools.filter((tool) =>
-        testRegexSafe(matcher, tool),
+        testRegexSafe(matcher, tool, caseSensitive),
       );
       if (matched.length <= 1) {
         continue;
       }
       const branches = alternationBranches(matcher);
       const intended = branches ?? [literalPrefix(matcher)];
-      const unintended = matched.filter((tool) => !intended.includes(tool));
+      const unintended = matched.filter(
+        (tool) => !includesTool(intended, tool, caseSensitive),
+      );
       if (unintended.length === 0) {
         continue;
       }

--- a/src/internal/matcher/match.ts
+++ b/src/internal/matcher/match.ts
@@ -28,7 +28,25 @@ function exactListItems(matcher: string): readonly string[] {
 }
 
 /**
- * Test `matcher` as an unanchored regular expression against `target`.
+ * Whether `matcher`'s exact-match list contains `target`, honoring
+ * `spec.matcherSyntax.caseSensitive`.
+ */
+function exactListIncludes(
+  matcher: string,
+  target: string,
+  caseSensitive: boolean,
+): boolean {
+  const items = exactListItems(matcher);
+  if (caseSensitive) {
+    return items.includes(target);
+  }
+  const lowerTarget = target.toLowerCase();
+  return items.some((item) => item.toLowerCase() === lowerTarget);
+}
+
+/**
+ * Test `matcher` as an unanchored regular expression against `target`,
+ * honoring `spec.matcherSyntax.caseSensitive`.
  *
  * @remarks
  * `"*"` is Claude Code's documented "match everything" wildcard and is
@@ -45,12 +63,16 @@ function exactListItems(matcher: string): readonly string[] {
  * aborting every other hook's evaluation; `lint-matcher`'s later issue is
  * where that gets surfaced as a finding instead of swallowed here.
  */
-function testUnanchoredRegex(matcher: string, target: string): boolean {
+function testUnanchoredRegex(
+  matcher: string,
+  target: string,
+  caseSensitive: boolean,
+): boolean {
   if (matcher === "*") {
     return true;
   }
   try {
-    return new RegExp(matcher).test(target);
+    return new RegExp(matcher, caseSensitive ? undefined : "i").test(target);
   } catch {
     return false;
   }
@@ -130,7 +152,10 @@ export function matchHooks(
         break;
       }
       case "exact-list": {
-        if (req.target !== undefined && exactListItems(matcher).includes(req.target)) {
+        if (
+          req.target !== undefined &&
+          exactListIncludes(matcher, req.target, spec.matcherSyntax.caseSensitive)
+        ) {
           firing.push(hook);
         } else {
           rejected.push(exactListOutcome(hook, req.target));
@@ -138,7 +163,10 @@ export function matchHooks(
         break;
       }
       case "unanchored-regex": {
-        if (req.target !== undefined && testUnanchoredRegex(matcher, req.target)) {
+        if (
+          req.target !== undefined &&
+          testUnanchoredRegex(matcher, req.target, spec.matcherSyntax.caseSensitive)
+        ) {
           firing.push(hook);
         } else {
           rejected.push(unanchoredRegexOutcome(hook));

--- a/src/internal/matcher/types.ts
+++ b/src/internal/matcher/types.ts
@@ -36,9 +36,11 @@ export type VersionContext =
  * with confidence.
  *
  * @remarks
- * - `"exact-list"` — the matcher is a comma/pipe-delimited list of exact,
- *   case-sensitive values.
+ * - `"exact-list"` — the matcher is a comma/pipe-delimited list of exact
+ *   values, compared case-sensitively or not per
+ *   `spec.matcherSyntax.caseSensitive`.
  * - `"unanchored-regex"` — the matcher is tested as `new RegExp(matcher)`
+ *   (with an `"i"` flag when `spec.matcherSyntax.caseSensitive` is `false`)
  *   with no implicit `^`/`$` added, so it can match a substring of a longer
  *   name (`"Edit.*"` matching `"NotebookEdit"` is the documented, real
  *   Claude Code behavior this reproduces, not a bug).

--- a/src/internal/spec/types.ts
+++ b/src/internal/spec/types.ts
@@ -82,6 +82,10 @@ export interface MatcherRule {
 
 /** The matcher notation Claude Code accepts, and since which version. */
 export interface MatcherSyntax {
+  /**
+   * Whether the exact-list and regex comparisons are case-sensitive. Does
+   * not affect `exactListPattern`.
+   */
   readonly caseSensitive: boolean;
   readonly exactListPattern: string;
   readonly narrowExactMatchEvents: readonly string[];

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,12 +24,37 @@ import {
   type LintReport,
 } from "../src/internal/report/index.js";
 import type { SettingsSource } from "../src/internal/settings/index.js";
-import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
+import {
+  loadSpec,
+  loadSpecFile,
+  parseClaudeVersion,
+} from "../src/internal/spec/index.js";
 import type { Spec } from "../src/internal/spec/index.js";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
 const REAL_SPEC: Spec = loadSpecFile(REAL_SPEC_PATH);
+const SPEC_FIXTURES_DIR = fileURLToPath(new URL("./fixtures/spec/", import.meta.url));
+
+function readJson(file: string): unknown {
+  return JSON.parse(readFileSync(file, "utf8")) as unknown;
+}
+
+/**
+ * `valid-minimal.json` mutated to `caseSensitive: false` — mirrors
+ * `tests/matcher.test.ts`'s own `specWithCaseSensitive`. Its `knownTools`
+ * (`Bash`, `Edit`, `Write`, `NotebookEdit`, …) and its `PreToolUse` event
+ * (`matcherTargets.kind: "tool-name"`) are exactly what `matcher-case` and
+ * `matcher-unanchored` need.
+ */
+const CASE_INSENSITIVE_SPEC: Spec = (() => {
+  const raw = readJson(path.join(SPEC_FIXTURES_DIR, "valid-minimal.json")) as Record<
+    string,
+    unknown
+  >;
+  (raw["matcherSyntax"] as Record<string, unknown>)["caseSensitive"] = false;
+  return loadSpec(raw, "synthetic-lint-caseSensitive-false");
+})();
 
 /**
  * The real spec's own `claudeCodeRange` (`">=2.1.251 <2.2.0"`) starts past
@@ -447,6 +473,59 @@ describe("matcher-unanchored", () => {
     const [finding] = rule.run(unanchoredCtx("Edit|Write.*"));
 
     expect(finding?.suggestion).toContain('"^(?:Edit|Write.*)$"');
+  });
+});
+
+describe("spec.matcherSyntax.caseSensitive: honored by matcher-case and matcher-unanchored", () => {
+  function caseCtx(spec: Spec, matcher: string): LintContext {
+    return {
+      spec,
+      versionContext: UNDETERMINED,
+      groups: [
+        {
+          file: "/fake/settings.json",
+          layer: "project",
+          event: "PreToolUse",
+          line: 1,
+          matcher: { kind: "string", value: matcher },
+        },
+      ],
+      commands: [],
+      projectRoot: REPO_ROOT,
+      pathEnv: undefined,
+      homeDir: undefined,
+    };
+  }
+
+  it('matcher-case: reports nothing for "bash" vs Bash under a caseSensitive: false spec', () => {
+    const findings = ruleById("matcher-case").run(
+      caseCtx(CASE_INSENSITIVE_SPEC, "bash"),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('matcher-case: still reports the mismatch for "bash" vs Bash under the shipped (case-sensitive) spec', () => {
+    const findings = ruleById("matcher-case").run(caseCtx(REAL_SPEC, "bash"));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.ruleId).toBe("matcher-case");
+  });
+
+  it('matcher-unanchored: "edit.*" still reports the genuine NotebookEdit over-match under a caseSensitive: false spec', () => {
+    const [finding] = ruleById("matcher-unanchored").run(
+      caseCtx(CASE_INSENSITIVE_SPEC, "edit.*"),
+    );
+
+    expect(finding?.message).toContain("NotebookEdit");
+  });
+
+  it('matcher-unanchored: "(edit|write)" does not misreport its own branches as unintended under a caseSensitive: false spec', () => {
+    const [finding] = ruleById("matcher-unanchored").run(
+      caseCtx(CASE_INSENSITIVE_SPEC, "(edit|write)"),
+    );
+
+    expect(finding?.message).toContain("NotebookEdit");
+    expect(finding?.message).not.toContain('"Edit"');
+    expect(finding?.message).not.toContain('"Write"');
   });
 });
 

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,12 +10,25 @@ import {
   matchHooks,
 } from "../src/internal/matcher/index.js";
 import type { MatchRequest, VersionContext } from "../src/internal/matcher/index.js";
-import { loadSpecFile, parseClaudeVersion } from "../src/internal/spec/index.js";
+import {
+  loadSpec,
+  loadSpecFile,
+  parseClaudeVersion,
+} from "../src/internal/spec/index.js";
 import type { Spec } from "../src/internal/spec/index.js";
 import type { EventName, Provenance, ResolvedHook } from "../src/types.js";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const REAL_SPEC_PATH = path.join(REPO_ROOT, "spec", "claude-code-2.1.251-2.2.0.json");
+const FIXTURES_DIR = fileURLToPath(new URL("./fixtures/spec/", import.meta.url));
+
+function fixturePath(file: string): string {
+  return path.join(FIXTURES_DIR, file);
+}
+
+function readJson(file: string): unknown {
+  return JSON.parse(readFileSync(file, "utf8")) as unknown;
+}
 
 const REAL_SPEC: Spec = loadSpecFile(REAL_SPEC_PATH);
 
@@ -312,6 +326,77 @@ describe("MatcherOutcome: why a hook did not fire", () => {
       requestFor("PreToolUse", hook, "Bash"),
     );
     expect(result.firing).toEqual([]);
+    expect(result.rejected).toEqual([]);
+  });
+});
+
+describe("spec.matcherSyntax.caseSensitive: honored on both matching paths", () => {
+  /**
+   * `valid-minimal.json` mutated to `caseSensitive: false` — `classify.ts`'s
+   * character-class checks are unaffected by the flag, only the comparison
+   * `match.ts` performs once a matcher is classified.
+   */
+  function specWithCaseSensitive(caseSensitive: boolean): Spec {
+    const raw = readJson(fixturePath("valid-minimal.json")) as Record<string, unknown>;
+    (raw["matcherSyntax"] as Record<string, unknown>)["caseSensitive"] = caseSensitive;
+    return loadSpec(raw, `synthetic-caseSensitive-${String(caseSensitive)}`);
+  }
+
+  const CASE_SENSITIVE_SPEC = specWithCaseSensitive(true);
+  const CASE_INSENSITIVE_SPEC = specWithCaseSensitive(false);
+
+  it("exact-list path: bash fires for Bash when caseSensitive is false", () => {
+    const hook = makeHook("PreToolUse", "bash");
+    const result = matchHooks(
+      CASE_INSENSITIVE_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, "Bash"),
+    );
+    expect(result.firing).toEqual([hook]);
+    expect(result.rejected).toEqual([]);
+  });
+
+  it("exact-list path: bash does not fire for Bash under the shipped (case-sensitive) spec", () => {
+    const hook = makeHook("PreToolUse", "bash");
+    const result = matchHooks(
+      CASE_SENSITIVE_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, "Bash"),
+    );
+    expect(result.firing).toEqual([]);
+    expect(result.rejected).toHaveLength(1);
+  });
+
+  it("regex path: edit.* fires for NotebookEdit when caseSensitive is false", () => {
+    const hook = makeHook("PreToolUse", "edit.*");
+    const result = matchHooks(
+      CASE_INSENSITIVE_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, "NotebookEdit"),
+    );
+    expect(result.firing).toEqual([hook]);
+    expect(result.rejected).toEqual([]);
+  });
+
+  it("regex path: edit.* does not fire for NotebookEdit under the shipped (case-sensitive) spec", () => {
+    const hook = makeHook("PreToolUse", "edit.*");
+    const result = matchHooks(
+      CASE_SENSITIVE_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, "NotebookEdit"),
+    );
+    expect(result.firing).toEqual([]);
+    expect(result.rejected).toHaveLength(1);
+  });
+
+  it("the * wildcard still matches everything regardless of caseSensitive", () => {
+    const hook = makeHook("PreToolUse", "*");
+    const result = matchHooks(
+      CASE_INSENSITIVE_SPEC,
+      IN_RANGE_VERSION,
+      requestFor("PreToolUse", hook, "Bash"),
+    );
+    expect(result.firing).toEqual([hook]);
     expect(result.rejected).toEqual([]);
   });
 });


### PR DESCRIPTION
`spec.matcherSyntax.caseSensitive` was transcribed in the shipped spec, declared in `schema/spec.schema.json`, typed in `src/internal/spec/types.ts` and validated in `guards.ts` — and read by nothing. `matcher/match.ts` compared the exact-list path with `Array.prototype.includes` and the regex path with `new RegExp(matcher)`, both case-sensitive regardless of the flag. Behavior was right today only because the shipped spec says `true`: a consumer authoring a spec against the published schema could set `false`, validate, and silently get case-sensitive matching.

The field is now honored rather than removed — the spec is a transcription of observed Claude Code behavior, and "matchers are case-sensitive" is a fact worth recording where a future version could change it. When `caseSensitive` is `false`, the exact-list path compares both sides lowercased and the regex path compiles with the `"i"` flag; the `"*"` wildcard short-circuit is unaffected, and `classify.ts`'s `exactListPattern` / `narrowExactListPattern` character-class checks are deliberately untouched — the flag governs comparison, not classification. That distinction is now stated in the field's TSDoc and in the schema `description`.

Review caught that `matcher/` was not the only place reading the field wrong, and the two `lint` rules are the same defect rather than a separate one: `matcher-case` would have kept reporting "matcher `bash` uses the wrong case for `Bash`, so this never matches" under a spec where it now does match, and `matcher-unanchored`'s `testRegexSafe` compiled without the flag — silently suppressing a genuine over-match finding for `edit.*`, and reporting `Edit`/`Write` as unintended for `(edit|write)`. Both now follow the spec flag, so `lint` cannot contradict `explain`/`test` on the same spec.

Release impact: no — `specPath` is `overrides.specPath ?? SPEC_PATH` (`src/cli.ts:301`) and `overrides` is the `CliDeps` test seam: there is no CLI flag or environment variable to supply a different spec, and the only shipped spec sets `caseSensitive: true`. No consumer-observable behavior changes, and `src/index.ts`'s exported surface is untouched; the schema gains a `description` only.

Closes #29

## Test plan

- `pnpm check` -> pass (format, lint, typecheck, coverage tests, build, docs:build, package:verify).
- `tests/matcher.test.ts` gains a block building a synthetic spec (the `valid-minimal.json` fixture mutated to `caseSensitive: false`, loaded through `loadSpec`): exact-list `bash` fires for `Bash` and regex `edit.*` fires for `NotebookEdit` under it, neither fires under the shipped spec, and `*` still matches regardless of the flag.
- `tests/lint.test.ts` gains the same synthetic spec: `matcher-case` reports nothing for `bash` vs `Bash` under it while still reporting under the shipped spec, and `matcher-unanchored` still reports the genuine `NotebookEdit` over-match for `edit.*` while no longer misreporting `Edit`/`Write` as unintended for `(edit|write)`.
- Every existing matcher, lint and spec test passes unchanged under the shipped spec — that is the invariant this change is measured against.

https://claude.ai/code/session_01KeAFVkV4zJ6LWNK6x6XL78
