### PR TITLE
fix: fail a case whose expect declares a field but no hook fired (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,13 @@ Each entry in `cases` may declare:
   against `hookSpecificOutput.additionalContext`; `updatedInput` compares the same way
   against `hookSpecificOutput.updatedInput`. Either is satisfied by any one firing
   hook's own value, and a mismatch (including no firing hook emitting the key at all)
-  fails. When _no_ hook fires at all, nothing is compared: the case passes unless it
-  declared `fires: true`, so pair a `context`/`updatedInput` expectation with
-  `fires: true` to keep a case that stopped firing from staying green.
+  fails. When _no_ hook fires at all: `fires: false` passes, since that is the explicit
+  "I expect nothing to fire"; a case that declares any other `expect` field — including
+  `fires: true` on its own — fails, with a `nonFiring` explanation naming why nothing
+  fired; a case with no `expect` fields at all still passes, since there was nothing to
+  compare. `fires: false` cannot be combined with any other `expect` field — loading a
+  fixture that does rejects it, since nothing observed a decision, exit code, stream,
+  context, or updated input if nothing fired.
 - `stub` — map an exact hook `command` string to a canned `{ exitCode }` instead of
   actually spawning it.
 - `dryRun: true` — skip execution for this one case, the same effect `--dry-run` has for

--- a/src/internal/assert/assertCase.ts
+++ b/src/internal/assert/assertCase.ts
@@ -96,8 +96,9 @@ export function isStubOnly(caseData: FixtureCase): boolean {
 }
 
 /**
- * Explain why `expect.fires: true` was not met, from what the matcher
- * engine already found for this case's event.
+ * Explain why no hook fired for a case that declared an expectation other
+ * than `fires: false`, from what the matcher engine already found for this
+ * case's event.
  *
  * @remarks
  * Checked in this order: a candidate hook the matcher rejected outranks a
@@ -257,9 +258,12 @@ function isNonEmptyFired(
  * Checked in this order:
  * 1. `caseData.dryRun: true` or a stub-only case with no declared
  *    expectation → `"skipped"`, nothing to compare.
- * 2. No hook fired at all: `expect.fires: true` → `"fail"` with
- *    {@link NonFiringExplanation}; otherwise → `"pass"`, since nothing else
- *    was declared to compare against a case that was not expected to fire.
+ * 2. No hook fired at all (issue #68): `expect.fires: false` → `"pass"`,
+ *    the explicit opt-out for "I expect nothing to fire". Any other
+ *    declared `expect` field (including `fires: true` on its own) →
+ *    `"fail"` with {@link NonFiringExplanation} — a declared expectation
+ *    that nothing fired could possibly satisfy. A wholly empty `expect` →
+ *    `"pass"`, since there was nothing declared to compare.
  * 3. One or more hooks fired: every firing hook's own `Decision` is folded
  *    into one combined verdict by `combineDecisions`
  *    (`deny` > `unknown` > `error` > `allow` > `pass` — any deny wins,
@@ -291,7 +295,20 @@ export function assertCase(
 
   const { fired } = observation;
   if (!isNonEmptyFired(fired)) {
-    if (caseData.expect.fires === true) {
+    // `fires: false` is the explicit opt-out — "I expect nothing to
+    // fire" — and passes on its own; `fixture/load.ts`'s
+    // FixtureFiresFalseConflictError already rejects pairing it with any
+    // other expect field at load time, so this branch never has to weigh
+    // the two against each other.
+    if (caseData.expect.fires === false) {
+      return { kind: "pass", origin, decidedBy: undefined };
+    }
+    // Any other declared expectation — decision, exitCode,
+    // stdoutContains, stderrContains, timedOut, context, updatedInput, or
+    // fires: true itself — cannot have been observed when nothing fired,
+    // so it fails rather than passing by default (issue #68). Only a
+    // wholly empty expectation still passes: there was nothing to compare.
+    if (!isEmptyExpectation(caseData.expect)) {
       return {
         kind: "fail",
         origin,

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -343,6 +343,54 @@ export class FixtureUnblockableDecisionError extends HookassertError {
 }
 
 /**
+ * Thrown when a fixture case pairs `expect.fires: false` with any other
+ * `expect` field.
+ *
+ * @remarks
+ * `expect.fires: false` already means "nothing fires, and that is the whole
+ * assertion" — `assertCase` (issue #68) treats that declaration as passing
+ * the moment no hook fires, before any other `expect` field is even
+ * consulted. Pairing it with `decision`, `exitCode`, `stdoutContains`,
+ * `stderrContains`, `context`, `updatedInput`, or `timedOut` is therefore
+ * unsatisfiable by construction: if nothing fires there is no decision, exit
+ * code, stream, context, or updated input to compare against those fields,
+ * and if something does fire, `fires: false` itself already fails the case.
+ * Rejecting the pair at load time — the same load-time-rejection shape
+ * {@link FixtureUnblockableDecisionError} uses — beats letting a fixture
+ * author discover the contradiction as a confusing runtime result.
+ */
+export class FixtureFiresFalseConflictError extends HookassertError {
+  /** Stable discriminator, unchanged across non-breaking releases. */
+  readonly code = "ERR_FIXTURE_FIRES_FALSE_CONFLICT" as const;
+
+  /** Fires-false-conflict failures always exit 5 (load error). */
+  readonly exitCode = 5;
+
+  /** Absolute path of the fixture file the offending case was declared in. */
+  readonly file: string;
+
+  /** Every other `expect` field the offending case declared alongside `fires: false`. */
+  readonly fields: readonly string[];
+
+  /**
+   * @param file - Absolute path of the fixture file the case was declared in.
+   * @param fields - Every other `expect` field declared alongside `fires: false`.
+   */
+  constructor(file: string, fields: readonly string[]) {
+    super(
+      `Fixture ${file} declares expect.fires: false together with ` +
+        `${fields.join(", ")}, but "fires: false" already means nothing fires ` +
+        `and the case passes on that alone — there is no decision, exit code, ` +
+        `stream, context, or updated input to compare the other field(s) ` +
+        `against. Drop "fires: false", or drop the other expect field(s).`,
+    );
+    this.name = "FixtureFiresFalseConflictError";
+    this.file = file;
+    this.fields = fields;
+  }
+}
+
+/**
  * Thrown when `record --stop` finds no active session to restore.
  *
  * @remarks

--- a/src/internal/fixture/load.ts
+++ b/src/internal/fixture/load.ts
@@ -9,14 +9,16 @@
  * it, but never spawns a process and never writes anything back, the same
  * convention `settings/load.ts` and `spec/load.ts` follow.
  *
- * The load-time rejection this issue exists for lives in
- * {@link toFixtureCase}: a case whose `expect.decision` is `"deny"` against
- * an event the spec documents no deny channel for — `decision/`'s
- * `canProduceDeny`, which reads both the exit-code and the JSON channel
- * rather than `blockable` alone — throws
- * {@link FixtureUnblockableDecisionError} while turning the raw case into a
- * typed `FixtureCase` — before `loadFixture` returns, so before any later
- * pipeline stage could spawn a process for it.
+ * Two load-time rejections live in {@link toFixtureCase}, both before
+ * `loadFixture` returns so before any later pipeline stage could spawn a
+ * process for the offending case: a case whose `expect.decision` is `"deny"`
+ * against an event the spec documents no deny channel for —
+ * `decision/`'s `canProduceDeny`, which reads both the exit-code and the
+ * JSON channel rather than `blockable` alone — throws
+ * {@link FixtureUnblockableDecisionError}; a case that pairs `expect.fires:
+ * false` with any other declared `expect` field — unsatisfiable by
+ * construction, since `assertCase` (issue #68) treats `fires: false` alone
+ * as the whole assertion — throws {@link FixtureFiresFalseConflictError}.
  */
 
 import { readFileSync } from "node:fs";
@@ -27,6 +29,7 @@ import { parse as parseYaml } from "yaml";
 import type { EventName, PayloadOrigin } from "../../types.js";
 import { canProduceDeny } from "../decision/index.js";
 import {
+  FixtureFiresFalseConflictError,
   FixtureNotFoundError,
   FixtureSchemaError,
   FixtureUnblockableDecisionError,
@@ -38,6 +41,7 @@ import type {
   FixtureFile,
   FixtureSet,
   RawFixtureCase,
+  RawFixtureExpectation,
   RawFixtureOrigin,
 } from "./types.js";
 
@@ -198,12 +202,51 @@ function resolveOrigin(
 }
 
 /**
+ * Every `RawFixtureExpectation` field other than `fires`, in the order a
+ * {@link FixtureFiresFalseConflictError} lists them.
+ */
+const OTHER_EXPECTATION_FIELDS = [
+  "decision",
+  "exitCode",
+  "stdoutContains",
+  "stderrContains",
+  "context",
+  "updatedInput",
+  "timedOut",
+] as const satisfies readonly (keyof Omit<RawFixtureExpectation, "fires">)[];
+
+/**
+ * Reject `expect.fires: false` paired with any other declared `expect`
+ * field, per {@link FixtureFiresFalseConflictError}'s rationale: that pair is
+ * unsatisfiable by construction.
+ *
+ * @throws {FixtureFiresFalseConflictError} `expect.fires === false` and at
+ * least one other `expect` field is also declared.
+ */
+function checkFiresFalseConflict(
+  expect: RawFixtureExpectation,
+  fixturePath: string,
+): void {
+  if (expect.fires !== false) {
+    return;
+  }
+  const declaredFields = OTHER_EXPECTATION_FIELDS.filter(
+    (field) => expect[field] !== undefined,
+  );
+  if (declaredFields.length > 0) {
+    throw new FixtureFiresFalseConflictError(fixturePath, declaredFields);
+  }
+}
+
+/**
  * Turn one already schema-valid raw case into a typed {@link FixtureCase}.
  *
  * @throws {FixtureSchemaError} `rawCase.event` is not a recognized event, or
  * its `origin.recorded` envelope cannot be resolved.
  * @throws {FixtureUnblockableDecisionError} `rawCase.expect.decision` is
  * `"deny"` against an event the loaded spec documents no deny channel for.
+ * @throws {FixtureFiresFalseConflictError} `rawCase.expect.fires` is `false`
+ * and at least one other `expect` field is also declared.
  */
 function toFixtureCase(
   rawCase: RawFixtureCase,
@@ -212,6 +255,7 @@ function toFixtureCase(
   spec: Spec,
 ): FixtureCase {
   const event = requireEventName(rawCase.event, index, fixturePath);
+  checkFiresFalseConflict(rawCase.expect, fixturePath);
 
   const decision = rawCase.expect.decision;
   const eventSpec = spec.events[event];
@@ -259,6 +303,8 @@ function toFixtureCase(
  * `origin.recorded` at an envelope file that cannot be resolved.
  * @throws {FixtureUnblockableDecisionError} a case expects `decision:
  * "deny"` from an event `spec` documents no deny channel for.
+ * @throws {FixtureFiresFalseConflictError} a case declares `expect.fires:
+ * false` alongside another `expect` field.
  */
 export function loadFixture(raw: unknown, filePath: string, spec: Spec): FixtureFile {
   if (!isValidRawFixtureFile(raw)) {
@@ -284,6 +330,8 @@ export function loadFixture(raw: unknown, filePath: string, spec: Spec): Fixture
  * does not satisfy `schema/fixture.schema.json` once parsed.
  * @throws {FixtureUnblockableDecisionError} a case expects `decision:
  * "deny"` from an event `spec` documents no deny channel for.
+ * @throws {FixtureFiresFalseConflictError} a case declares `expect.fires:
+ * false` alongside another `expect` field.
  */
 export function loadFixtureFile(filePath: string, spec: Spec): FixtureFile {
   let text: string;
@@ -315,6 +363,8 @@ export function loadFixtureFile(filePath: string, spec: Spec): FixtureFile {
  * YAML, or does not satisfy `schema/fixture.schema.json` once parsed.
  * @throws {FixtureUnblockableDecisionError} a case in one of `filePaths`
  * expects `decision: "deny"` from an event `spec` documents no deny channel for.
+ * @throws {FixtureFiresFalseConflictError} a case in one of `filePaths`
+ * declares `expect.fires: false` alongside another `expect` field.
  */
 export function loadFixtures(filePaths: readonly string[], spec: Spec): FixtureSet {
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -489,7 +489,8 @@ export interface RejectedMatch {
 }
 
 /**
- * Why a fixture case's `expect.fires: true` was not met.
+ * Why no hook fired for a fixture case that declared an `expect` field
+ * other than `fires: false` — which requires a hook to have fired.
  *
  * @remarks
  * `"matcher-did-not-match"` — at least one candidate hook was declared under
@@ -589,9 +590,11 @@ export type CaseResult =
        */
       readonly diffs: readonly ExpectationDiff[];
       /**
-       * Set when the failure is that `expect.fires: true` was declared but
-       * no hook fired; `undefined` when the failure is instead a `diffs`
-       * mismatch (on this same result) on a hook that did fire.
+       * Set when the failure is that a declared `expect` field (anything
+       * other than `fires: false`, which passes on its own) could not be
+       * met because no hook fired at all; `undefined` when the failure is
+       * instead a `diffs` mismatch (on this same result) on a hook that did
+       * fire.
        */
       readonly nonFiring: NonFiringExplanation | undefined;
       /** The hook whose `Decision` this case's verdict came from; `undefined` when no hook fired at all. */

--- a/tests/assert.test.ts
+++ b/tests/assert.test.ts
@@ -675,6 +675,51 @@ describe("assertCase: non-firing explanations", () => {
   });
 });
 
+describe("assertCase: no hook fired at all (issue #68)", () => {
+  it("expect.fires: false passes when nothing fires — the explicit opt-out", () => {
+    const caseData = makeCase({ expect: makeExpect({ fires: false }) });
+
+    const result = expectPass(assertCase(caseData, makeObservation()));
+
+    expect(result.decidedBy).toBeUndefined();
+  });
+
+  it("a wholly empty expect still passes when nothing fires — nothing was declared to compare", () => {
+    const caseData = makeCase();
+
+    const result = expectPass(assertCase(caseData, makeObservation()));
+
+    expect(result.decidedBy).toBeUndefined();
+  });
+
+  // Pinned per field, per issue #68's completion checklist: declaring any
+  // one of these on its own, with nothing firing, must fail rather than
+  // pass by default — the declared expectation could not possibly have
+  // been observed. `fires: false` is deliberately excluded from this list;
+  // it is the one field that passes on its own, covered above.
+  it.each([
+    ["fires", makeExpect({ fires: true })],
+    ["decision", makeExpect({ decision: "deny" })],
+    ["exitCode", makeExpect({ exitCode: 2 })],
+    ["stdoutContains", makeExpect({ stdoutContains: "blocked" })],
+    ["stderrContains", makeExpect({ stderrContains: "reason" })],
+    ["timedOut", makeExpect({ timedOut: true })],
+    ["context", makeExpect({ context: "extra context for the model" })],
+    ["updatedInput", makeExpect({ updatedInput: { command: "ls" } })],
+  ])(
+    "a case declaring only expect.%s fails with an empty diffs array and nonFiring set when nothing fires",
+    (_field, expectation) => {
+      const caseData = makeCase({ expect: expectation });
+
+      const result = expectFail(assertCase(caseData, makeObservation()));
+
+      expect(result.diffs).toEqual([]);
+      expect(result.nonFiring).toBeDefined();
+      expect(result.decidedBy).toBeUndefined();
+    },
+  );
+});
+
 describe("assertCase: unresolved decisions", () => {
   it("a case whose Decision could not be resolved produces an unknown CaseResult carrying at least one UnknownReason", () => {
     const caseData = makeCase({ expect: makeExpect({ fires: true }) });

--- a/tests/fixture.test.ts
+++ b/tests/fixture.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
 
 import {
+  FixtureFiresFalseConflictError,
   FixtureNotFoundError,
   FixtureSchemaError,
   FixtureUnblockableDecisionError,
@@ -255,6 +256,78 @@ describe("loadFixtureFile: ERR_FIXTURE_UNBLOCKABLE_DECISION (exit 5)", () => {
       ).not.toThrow();
     },
   );
+});
+
+describe("loadFixtureFile: ERR_FIXTURE_FIRES_FALSE_CONFLICT (exit 5)", () => {
+  it("throws ERR_FIXTURE_FIRES_FALSE_CONFLICT (exit 5) when fires: false is paired with another expect field", () => {
+    const error = caught(() =>
+      loadFixture(
+        {
+          cases: [
+            {
+              event: "PreToolUse",
+              expect: { fires: false, decision: "deny" },
+            },
+          ],
+        },
+        fixturePath("synthetic.yaml"),
+        spec,
+      ),
+    );
+
+    expect(error).toBeInstanceOf(FixtureFiresFalseConflictError);
+    const conflictError = error as FixtureFiresFalseConflictError;
+    expect(conflictError.code).toBe("ERR_FIXTURE_FIRES_FALSE_CONFLICT");
+    expect(conflictError.exitCode).toBe(5);
+    expect(conflictError.fields).toEqual(["decision"]);
+    expect(conflictError.message).toContain("fires: false");
+  });
+
+  it("names every other declared expect field, not only the first", () => {
+    const error = caught(() =>
+      loadFixture(
+        {
+          cases: [
+            {
+              event: "PreToolUse",
+              expect: {
+                fires: false,
+                exitCode: 0,
+                stdoutContains: "ok",
+                timedOut: false,
+              },
+            },
+          ],
+        },
+        fixturePath("synthetic.yaml"),
+        spec,
+      ),
+    ) as FixtureFiresFalseConflictError;
+
+    expect(error.fields).toEqual(["exitCode", "stdoutContains", "timedOut"]);
+  });
+
+  it("does not throw for fires: false declared alone", () => {
+    expect(() =>
+      loadFixture(
+        { cases: [{ event: "PreToolUse", expect: { fires: false } }] },
+        fixturePath("synthetic.yaml"),
+        spec,
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not throw for fires: true paired with another expect field", () => {
+    expect(() =>
+      loadFixture(
+        {
+          cases: [{ event: "PreToolUse", expect: { fires: true, decision: "deny" } }],
+        },
+        fixturePath("synthetic.yaml"),
+        spec,
+      ),
+    ).not.toThrow();
+  });
 });
 
 describe("loadFixtureFile: filesystem edge cases", () => {


### PR DESCRIPTION
`assertCase` reported `pass` whenever no hook fired for a case, unless the case declared `fires: true` — discarding every other declared `expect` field (`decision`, `exitCode`, `stdoutContains`, `stderrContains`, `timedOut`, `context`, `updatedInput`). A case whose matcher was re-cased or whose hook was deleted went silently green instead of catching the regression it exists for.

Now `fires: false` is the explicit "nothing should fire" opt-out and passes; any other declared `expect` field — including `fires: true` alone — fails with the existing `nonFiring` explanation; a wholly empty `expect` still passes. Pairing `fires: false` with any other `expect` field is rejected at load time (`FixtureFiresFalseConflictError`, `ERR_FIXTURE_FIRES_FALSE_CONFLICT`), since that combination can never be satisfied. No `CaseResult` or schema shape change: this reuses the existing fail + `nonFiring` + empty-diffs shape the `fires: true` branch already produced.

Closes #68

## Answer to the issue's question 5

Yes — this blocks #20. It is a breaking change to fixture semantics, and it lands before the `0.1.0` release so that no published version ever carries the old silent-pass behavior. #20 (release readiness) is sequenced after it.

## Release impact

Release impact: no — the package is unreleased at `0.0.0`; #20 carries the first published version, and this change lands before it.

## Test plan

- `pnpm check:quick` in a clean worktree of this branch → pass (format, lint, typecheck, full vitest run).
- `tests/assert.test.ts`: one case per `expect` field pinning that a declared field with no firing hook now reports `FAIL` with a `nonFiring` explanation, plus `fires: false` passing and an empty `expect` passing.
- `tests/fixture.test.ts`: `fires: false` paired with each other `expect` field is rejected at load with `ERR_FIXTURE_FIRES_FALSE_CONFLICT`.
- This repository's own fixtures and the conformance harness pass unchanged.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
