### PR TITLE
fix: give the out-of-range version-notation finding its own wording (#48)

### DIFF
--- a/src/internal/lint/rules/versionNotationRule.ts
+++ b/src/internal/lint/rules/versionNotationRule.ts
@@ -24,7 +24,10 @@
  * *anything* about the spec it is checked against, not only the notation
  * rules this module gates, so this mirrors that rather than trusting
  * `meetsSinceVersion` on a version the loaded spec was never declared to
- * describe.
+ * describe. Its own message names the declared range instead of reusing the
+ * undetermined wording, since the version here *was* determined — only
+ * `spec.claudeCodeRange` fails to cover it — and saying otherwise would
+ * contradict the `--claude-version` the caller just passed.
  */
 
 import { isInDeclaredRange, meetsSinceVersion } from "../../spec/index.js";
@@ -110,14 +113,25 @@ export function createVersionNotationRule(
           continue;
         }
 
-        const message =
-          ctx.versionContext.kind === "undetermined" || isOutOfRange
-            ? `Matcher "${matcher}" uses ${notationLabel}, supported since Claude ` +
-              `Code ${rule.sinceVersion}, but the running Claude Code version could ` +
-              "not be determined — this notation might not be supported."
-            : `Matcher "${matcher}" uses ${notationLabel}, which requires Claude ` +
-              `Code >= ${rule.sinceVersion}, but the detected version is ` +
-              `${formatKnownVersion(ctx.versionContext)}.`;
+        let message: string;
+        if (ctx.versionContext.kind === "known" && isOutOfRange) {
+          message =
+            `Matcher "${matcher}" uses ${notationLabel}, supported since Claude ` +
+            `Code ${rule.sinceVersion}, but the detected Claude Code version ` +
+            `${formatKnownVersion(ctx.versionContext)} is outside the range this spec ` +
+            `describes (\`${ctx.spec.claudeCodeRange}\`), so support for this notation ` +
+            "cannot be confirmed.";
+        } else if (ctx.versionContext.kind === "undetermined") {
+          message =
+            `Matcher "${matcher}" uses ${notationLabel}, supported since Claude ` +
+            `Code ${rule.sinceVersion}, but the running Claude Code version could ` +
+            "not be determined — this notation might not be supported.";
+        } else {
+          message =
+            `Matcher "${matcher}" uses ${notationLabel}, which requires Claude ` +
+            `Code >= ${rule.sinceVersion}, but the detected version is ` +
+            `${formatKnownVersion(ctx.versionContext)}.`;
+        }
 
         findings.push({
           file: group.file,

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -627,11 +627,17 @@ describe.each([
     expect(undeterminedFinding?.message).not.toBe(oldVersionFinding?.message);
   });
 
-  it("degrades to the same unknown-confidence finding — rather than silently passing — when the known version is outside spec.claudeCodeRange", () => {
+  it("degrades to an unknown-confidence finding — rather than silently passing — when the known version is outside spec.claudeCodeRange, with wording distinct from the undetermined case", () => {
     const [finding] = rule.run(contextFor(source, OUT_OF_RANGE_VERSION));
 
     expect(finding).toBeDefined();
-    expect(finding?.message).toContain("could not be determined");
+    expect(finding?.message).not.toContain("could not be determined");
+    expect(finding?.message).toContain("3.0.0");
+    expect(finding?.message).toContain("outside the range this spec describes");
+    expect(finding?.message).toContain(REAL_SPEC.claudeCodeRange);
+
+    const [undeterminedFinding] = rule.run(contextFor(source, UNDETERMINED));
+    expect(undeterminedFinding?.message).not.toBe(finding?.message);
   });
 });
 


### PR DESCRIPTION
`matcher-comma-version` and `matcher-hyphen-version` told users the Claude Code version "could not be determined" even when a known version (via `--claude-version`) was simply outside `spec.claudeCodeRange` — contradicting the flag the user had just passed.

This splits that case into its own message naming the declared range, keeping it distinguishable from both the "truly undetermined" finding and the "definitely below `sinceVersion`" one. The degrade-to-unknown-confidence behavior itself is unchanged: an out-of-range version still yields a finding rather than silence.

Closes #48

## Release impact

Release impact: no — user-facing lint message text only; no change to `src/index.ts`'s exported surface.

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 1719 tests).
- `pnpm exec vitest run tests/lint.test.ts` → pass (115 tests).
- New test in `tests/lint.test.ts` pins the out-of-range wording separately from the undetermined wording: it asserts the message contains the detected version and the declared `claudeCodeRange`, does not contain "could not be determined", and differs from the undetermined-case message for the same fixture.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
