### PR TITLE
refactor: extract the shared JSONC settings reader out of lint and load (#49)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,6 +75,7 @@ import {
   discoverSources,
   hooksForEvent,
   loadSettings,
+  type SettingsSource,
 } from "./internal/settings/index.js";
 import { loadSpecFile, parseClaudeVersion, type Spec } from "./internal/spec/index.js";
 import type { CaseResult, EventName, ExecOutcome, ResolvedHook } from "./types.js";
@@ -432,6 +433,38 @@ function parseArgsForExplain(args: readonly string[]) {
 }
 
 /**
+ * `explain`, `lint`, and `test`'s shared settings-discovery prologue: assert
+ * every caller-named `--settings <file>` exists, then discover the three
+ * well-known layers alongside it.
+ *
+ * @remarks
+ * A missing *discovered* layer (`user`/`project`/`local`) is not an error —
+ * most projects declare only one or two of the three, and `loadSourceHooks`
+ * treats a missing file as contributing zero hooks. A file the caller named
+ * explicitly is an assertion it exists: without this check, a typo would
+ * print "no hooks fire" at exit 0 from the command whose whole job is
+ * saying which hooks fire, instead of failing loudly.
+ *
+ * @throws {SettingsNotFoundError} a named `--settings` file does not exist.
+ */
+function resolveSettingsSources(
+  explicitSettings: readonly string[] | undefined,
+  deps: CliDeps,
+): readonly SettingsSource[] {
+  for (const file of explicitSettings ?? []) {
+    const resolved = path.resolve(deps.cwd, file);
+    if (!existsSync(resolved)) {
+      throw new SettingsNotFoundError(resolved);
+    }
+  }
+  return discoverSources({
+    cwd: deps.cwd,
+    home: deps.home,
+    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
+  });
+}
+
+/**
  * `parseArgs({ strict: true })` throws on an unknown option, a missing
  * required value, or a value of the wrong type. Translated here into a
  * `UsageError` rather than letting the raw exception escape `runCli`.
@@ -490,21 +523,7 @@ function runExplain(args: readonly string[], deps: CliDeps): CliResult {
   const spec = loadSpecFile(deps.specPath);
 
   const explicitSettings = parsed.values.settings;
-  // The loader maps a missing settings file to zero hooks, which is right for
-  // the three discovered layers and wrong for one the caller named: a typo
-  // would otherwise print "Firing hooks: none" at exit 0. This is the only
-  // layer that can tell the two apart.
-  for (const file of explicitSettings ?? []) {
-    const resolved = path.resolve(deps.cwd, file);
-    if (!existsSync(resolved)) {
-      throw new SettingsNotFoundError(resolved);
-    }
-  }
-  const sources = discoverSources({
-    cwd: deps.cwd,
-    home: deps.home,
-    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
-  });
+  const sources = resolveSettingsSources(explicitSettings, deps);
   const settings = loadSettings(sources);
   const hooks = hooksForEvent(settings, event);
   const match = matchHooks(spec, versionContext, { event, hooks, target: tool });
@@ -597,19 +616,7 @@ function runLint(args: readonly string[], deps: CliDeps): CliResult {
   const spec = loadSpecFile(deps.specPath);
 
   const explicitSettings = parsed.values.settings;
-  // Same rationale as runExplain: a settings file the caller named
-  // explicitly is an assertion it exists, unlike a discovered layer.
-  for (const file of explicitSettings ?? []) {
-    const resolved = path.resolve(deps.cwd, file);
-    if (!existsSync(resolved)) {
-      throw new SettingsNotFoundError(resolved);
-    }
-  }
-  const sources = discoverSources({
-    cwd: deps.cwd,
-    home: deps.home,
-    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
-  });
+  const sources = resolveSettingsSources(explicitSettings, deps);
 
   const ctx = buildLintContext(sources, spec, versionContext, deps.cwd, deps.env);
   const findings = LINT_RULES.flatMap((rule) => rule.run(ctx));
@@ -1154,12 +1161,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
   const timeoutOverrideMs = parseTimeoutOption(parsed.values.timeout);
 
   const explicitSettings = parsed.values.settings;
-  for (const file of explicitSettings ?? []) {
-    const resolved = path.resolve(deps.cwd, file);
-    if (!existsSync(resolved)) {
-      throw new SettingsNotFoundError(resolved);
-    }
-  }
+  const sources = resolveSettingsSources(explicitSettings, deps);
 
   const dryRunFlag = parsed.values["dry-run"] === true;
 
@@ -1190,12 +1192,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     probe,
   );
 
-  const discoveredSources = discoverSources({
-    cwd: deps.cwd,
-    home: deps.home,
-    ...(explicitSettings === undefined ? {} : { explicit: explicitSettings }),
-  });
-  const discoveredSettings = loadSettings(discoveredSources);
+  const discoveredSettings = loadSettings(sources);
   const cliEnvNames = parsed.values.env ?? [];
 
   const prepared: PreparedCase[] = [];

--- a/src/internal/lint/parse.ts
+++ b/src/internal/lint/parse.ts
@@ -6,7 +6,8 @@
  * @remarks
  * Static layer: reads a file's text and parses it, but never spawns a
  * process and never writes anything back — the same guarantee
- * `settings/load.ts` makes.
+ * `settings/load.ts` makes. This is not a second reader: it is a second
+ * *walk* over the same shared parse `settings/jsonc.ts` owns.
  *
  * `settings/load.ts`'s own `loadSourceHooks` cannot be reused here: it calls
  * `requireString` on every declared `matcher`, which throws
@@ -23,22 +24,25 @@
  * rejected exactly as `settings/load.ts` would reject it — this module is
  * not a general-purpose lenient settings reader, only the one exception
  * `matcher-is-array` needs. Every command entry (`hooks.<event>[].hooks[]`)
- * is read with the same strictness `settings/load.ts`'s own
- * `readCommandHooks` applies — no exception carved out there.
+ * is read with the same strictness `settings/jsonc.ts`'s `readCommandEntry`
+ * applies — no exception carved out there.
  */
 
-import { readFileSync } from "node:fs";
-
-import {
-  type Node,
-  type ParseError,
-  parseTree,
-  printParseErrorCode,
-} from "jsonc-parser";
+import type { Node } from "jsonc-parser";
 
 import type { EventName } from "../../types.js";
-import { SettingsParseError } from "../errors.js";
-import type { SettingsSource } from "../settings/index.js";
+import {
+  fail,
+  getProperty,
+  isEventName,
+  positionAt,
+  readCommandEntry,
+  readSettingsTree,
+  requireArray,
+  requireObject,
+  requireString,
+  type SettingsSource,
+} from "../settings/index.js";
 import type {
   LintContext,
   LintHookCommand,
@@ -47,151 +51,9 @@ import type {
 } from "./types.js";
 
 /**
- * The event names this reader recognizes — the same set
- * `settings/load.ts`'s own `KNOWN_EVENT_NAMES` mirrors from `EventName`.
- *
- * @remarks
- * Typed as `Record<EventName, true>` rather than an array so widening
- * `EventName` without extending this map is a type error here, instead of a
- * reader that quietly drops every group declared under the new event. A
- * `hooks` key outside this set is not an error — see `KNOWN_EVENT_NAMES`'s
- * own doc comment in `settings/load.ts` for why.
- */
-const KNOWN_EVENT_NAMES: Readonly<Record<EventName, true>> = {
-  SessionStart: true,
-  Setup: true,
-  InstructionsLoaded: true,
-  UserPromptSubmit: true,
-  UserPromptExpansion: true,
-  MessageDisplay: true,
-  PreToolUse: true,
-  PermissionRequest: true,
-  PostToolUse: true,
-  PostToolUseFailure: true,
-  PostToolBatch: true,
-  PermissionDenied: true,
-  Notification: true,
-  SubagentStart: true,
-  SubagentStop: true,
-  TaskCreated: true,
-  TaskCompleted: true,
-  Stop: true,
-  StopFailure: true,
-  TeammateIdle: true,
-  ConfigChange: true,
-  CwdChanged: true,
-  DirectoryAdded: true,
-  FileChanged: true,
-  WorktreeCreate: true,
-  WorktreeRemove: true,
-  PreCompact: true,
-  PostCompact: true,
-  PreModelSwitch: true,
-  PostModelSwitch: true,
-  SessionEnd: true,
-  Elicitation: true,
-  ElicitationResult: true,
-};
-
-function isEventName(value: string): value is EventName {
-  return Object.hasOwn(KNOWN_EVENT_NAMES, value);
-}
-
-/** Find a property node's *value* node inside an object node, by key. */
-function getProperty(objectNode: Node, key: string): Node | undefined {
-  for (const property of objectNode.children ?? []) {
-    const [keyNode, valueNode] = property.children ?? [];
-    if (keyNode?.type === "string" && keyNode.value === key) {
-      return valueNode;
-    }
-  }
-  return undefined;
-}
-
-/** 1-based line of a UTF-16 code-unit offset into `text`. */
-function lineAt(text: string, offset: number): number {
-  let line = 1;
-  for (let i = 0; i < offset; i++) {
-    if (text[i] === "\n") {
-      line++;
-    }
-  }
-  return line;
-}
-
-function describeParseErrors(errors: readonly ParseError[]): string {
-  return errors
-    .map(
-      (error) =>
-        `${printParseErrorCode(error.error)} at offset ${String(error.offset)}`,
-    )
-    .join(", ");
-}
-
-function fail(source: SettingsSource, reason: string): never {
-  throw new SettingsParseError(source.path, source.layer, reason);
-}
-
-function requireObject(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): Node {
-  if (node?.type !== "object") {
-    fail(source, `${description} must be an object`);
-  }
-  return node;
-}
-
-function requireArray(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): readonly Node[] {
-  if (node?.type !== "array") {
-    fail(source, `${description} must be an array`);
-  }
-  return node.children ?? [];
-}
-
-function requireString(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): string {
-  if (node?.type !== "string" || typeof node.value !== "string") {
-    fail(source, `${description} must be a string`);
-  }
-  return node.value;
-}
-
-function requireNonEmptyString(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): string {
-  const value = requireString(node, source, description);
-  if (value.length === 0) {
-    fail(source, `${description} must be a non-empty string`);
-  }
-  return value;
-}
-
-function readStringArray(
-  node: Node,
-  source: SettingsSource,
-  description: string,
-): readonly string[] {
-  const elements = requireArray(node, source, description);
-  return elements.map((element) =>
-    requireString(element, source, `every element of ${description}`),
-  );
-}
-
-/**
  * Read one group's `matcher` property tolerantly: `absent`, `string`, or
  * `array` never throw — anything else is still a structural error, exactly
- * as `settings/load.ts`'s `requireString` would reject it.
+ * as `settings/jsonc.ts`'s `requireString` would reject it.
  */
 function readMatcherValue(
   node: Node | undefined,
@@ -215,7 +77,7 @@ function readMatcherValue(
 
 /**
  * Read one group's own `hooks: [...]` command entries — the same shape
- * `settings/load.ts`'s `readCommandHooks` reads, minus the `timeoutMs`
+ * `settings/jsonc.ts`'s `readCommandEntry` reads, minus the `timeoutMs`
  * conversion and `dedupeKey` fields the command rules never need.
  */
 function readGroupCommands(
@@ -228,26 +90,13 @@ function readGroupCommands(
   const commandNodes = requireArray(commandsNode, source, `"hooks.${event}[].hooks"`);
 
   return commandNodes.map((hookNode) => {
-    requireObject(hookNode, source, `an entry of "hooks.${event}[].hooks"`);
-
-    const commandNode = getProperty(hookNode, "command");
-    const command = requireNonEmptyString(
-      commandNode,
-      source,
-      `"hooks.${event}[].hooks[].command"`,
-    );
-
-    const argsNode = getProperty(hookNode, "args");
-    const args =
-      argsNode === undefined
-        ? undefined
-        : readStringArray(argsNode, source, `"hooks.${event}[].hooks[].args"`);
+    const { command, args } = readCommandEntry(hookNode, event, source);
 
     return {
       file: source.path,
       layer: source.layer,
       event,
-      line: lineAt(text, hookNode.offset),
+      line: positionAt(text, hookNode.offset).line,
       command,
       args,
     } satisfies LintHookCommand;
@@ -259,33 +108,14 @@ function readGroupsAndCommands(source: SettingsSource): {
   readonly groups: readonly LintMatcherGroup[];
   readonly commands: readonly LintHookCommand[];
 } {
-  let text: string;
-  try {
-    text = readFileSync(source.path, "utf8");
-  } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return { groups: [], commands: [] };
-    }
-    throw error;
+  const settingsTree = readSettingsTree(source);
+  if (settingsTree === undefined) {
+    return { groups: [], commands: [] };
   }
-
-  const errors: ParseError[] = [];
-  const root = parseTree(text, errors, { allowTrailingComma: true });
-  if (errors.length > 0) {
-    fail(source, describeParseErrors(errors));
-  }
-  const rootNode = requireObject(root, source, "the settings file");
-
-  const hooksNode = getProperty(rootNode, "hooks");
+  const { text, hooksNode } = settingsTree;
   if (hooksNode === undefined) {
     return { groups: [], commands: [] };
   }
-  requireObject(hooksNode, source, '"hooks"');
 
   const groups: LintMatcherGroup[] = [];
   const commands: LintHookCommand[] = [];
@@ -294,7 +124,8 @@ function readGroupsAndCommands(source: SettingsSource): {
     const eventKey = requireString(keyNode, source, 'every key of "hooks"');
     if (!isEventName(eventKey)) {
       // Forward-compatible: an event this reader does not yet know about is
-      // skipped rather than rejected. See KNOWN_EVENT_NAMES's doc comment.
+      // skipped rather than rejected. See `settings/jsonc.ts`'s
+      // `isEventName` doc comment.
       continue;
     }
 
@@ -303,7 +134,7 @@ function readGroupsAndCommands(source: SettingsSource): {
       requireObject(groupNode, source, `an entry of "hooks.${eventKey}"`);
       const matcherNode = getProperty(groupNode, "matcher");
       const matcher = readMatcherValue(matcherNode, source, eventKey);
-      const line = lineAt(text, matcherNode?.offset ?? groupNode.offset);
+      const line = positionAt(text, matcherNode?.offset ?? groupNode.offset).line;
       groups.push({
         file: source.path,
         layer: source.layer,

--- a/src/internal/settings/edit.ts
+++ b/src/internal/settings/edit.ts
@@ -26,7 +26,6 @@ import {
   findNodeAtLocation,
   modify,
   parseTree,
-  printParseErrorCode,
   type ModificationOptions,
   type Node,
   type ParseError,
@@ -34,6 +33,7 @@ import {
 
 import { SettingsParseError } from "../errors.js";
 import type { EventName } from "../../types.js";
+import { describeParseErrors } from "./jsonc.js";
 
 /** One event `record` inserts a capture-hook matcher group for. */
 export interface CaptureHookEntry {
@@ -146,15 +146,6 @@ function groupValue(command: string, matcher: string | undefined): unknown {
   return matcher === undefined
     ? { hooks: [{ command: quotedCommand }] }
     : { matcher, hooks: [{ command: quotedCommand }] };
-}
-
-function describeParseErrors(errors: readonly ParseError[]): string {
-  return errors
-    .map(
-      (error) =>
-        `${printParseErrorCode(error.error)} at offset ${String(error.offset)}`,
-    )
-    .join(", ");
 }
 
 /**

--- a/src/internal/settings/index.ts
+++ b/src/internal/settings/index.ts
@@ -21,6 +21,17 @@ export type {
   CaptureHookEntry,
   CapturePlan,
 } from "./edit.js";
+export {
+  fail,
+  getProperty,
+  isEventName,
+  positionAt,
+  readCommandEntry,
+  readSettingsTree,
+  requireArray,
+  requireObject,
+  requireString,
+} from "./jsonc.js";
 export { loadSourceHooks } from "./load.js";
 export { hooksForEvent, mergeSources } from "./merge.js";
 export type {

--- a/src/internal/settings/jsonc.ts
+++ b/src/internal/settings/jsonc.ts
@@ -1,0 +1,266 @@
+/**
+ * The shared JSONC reading primitives `settings/load.ts`'s strict loader and
+ * `lint/parse.ts`'s tolerant walk both build on.
+ *
+ * @remarks
+ * Static layer: reads a file's text and parses it, but never spawns a
+ * process and never writes anything back — the same guarantee every module
+ * under `src/internal/settings/` and `src/internal/lint/` makes. Uses
+ * `jsonc-parser`'s `parseTree` rather than `JSON.parse` so a hook's
+ * declaration keeps its offset into the source text — the same convention
+ * `record`'s later write-back path depends on. Neither `load.ts` nor
+ * `parse.ts` may drift from what counts as a well-formed settings file
+ * without also drifting from this module — that is the point of pulling it
+ * out from under both.
+ */
+
+import { readFileSync } from "node:fs";
+
+import {
+  type Node,
+  type ParseError,
+  parseTree,
+  printParseErrorCode,
+} from "jsonc-parser";
+
+import type { EventName } from "../../types.js";
+import { SettingsParseError } from "../errors.js";
+import type { SettingsSource } from "./types.js";
+
+/**
+ * The event names hookassert recognizes today.
+ *
+ * @remarks
+ * Typed as `Record<EventName, true>` rather than an array so the mirror
+ * cannot silently drift: widening `src/types.ts`'s `EventName` without
+ * extending this map is a type error here, instead of a reader that quietly
+ * drops every hook declared under the new event. A `hooks` key outside this
+ * set is still not an error — it is treated as an event Claude Code added
+ * after this map was last extended, and silently carries no hooks forward,
+ * exactly as it would if the spec module does not yet classify it either. The
+ * `matcher` issue is what wires the strict loader to `src/internal/spec/`
+ * instead of this hand-kept mirror.
+ */
+const KNOWN_EVENT_NAMES: Readonly<Record<EventName, true>> = {
+  SessionStart: true,
+  Setup: true,
+  InstructionsLoaded: true,
+  UserPromptSubmit: true,
+  UserPromptExpansion: true,
+  MessageDisplay: true,
+  PreToolUse: true,
+  PermissionRequest: true,
+  PostToolUse: true,
+  PostToolUseFailure: true,
+  PostToolBatch: true,
+  PermissionDenied: true,
+  Notification: true,
+  SubagentStart: true,
+  SubagentStop: true,
+  TaskCreated: true,
+  TaskCompleted: true,
+  Stop: true,
+  StopFailure: true,
+  TeammateIdle: true,
+  ConfigChange: true,
+  CwdChanged: true,
+  DirectoryAdded: true,
+  FileChanged: true,
+  WorktreeCreate: true,
+  WorktreeRemove: true,
+  PreCompact: true,
+  PostCompact: true,
+  PreModelSwitch: true,
+  PostModelSwitch: true,
+  SessionEnd: true,
+  Elicitation: true,
+  ElicitationResult: true,
+};
+
+/** Whether `value` is one of the events {@link KNOWN_EVENT_NAMES} mirrors from `EventName`. */
+export function isEventName(value: string): value is EventName {
+  return Object.hasOwn(KNOWN_EVENT_NAMES, value);
+}
+
+/** Find a property node's *value* node inside an object node, by key. */
+export function getProperty(objectNode: Node, key: string): Node | undefined {
+  for (const property of objectNode.children ?? []) {
+    const [keyNode, valueNode] = property.children ?? [];
+    if (keyNode?.type === "string" && keyNode.value === key) {
+      return valueNode;
+    }
+  }
+  return undefined;
+}
+
+/** 1-based line and column of a UTF-16 code-unit offset into `text`. */
+export function positionAt(
+  text: string,
+  offset: number,
+): { line: number; col: number } {
+  let line = 1;
+  let lastNewline = -1;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: offset - lastNewline };
+}
+
+export function describeParseErrors(errors: readonly ParseError[]): string {
+  return errors
+    .map(
+      (error) =>
+        `${printParseErrorCode(error.error)} at offset ${String(error.offset)}`,
+    )
+    .join(", ");
+}
+
+export function fail(source: SettingsSource, reason: string): never {
+  throw new SettingsParseError(source.path, source.layer, reason);
+}
+
+export function requireObject(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): Node {
+  if (node?.type !== "object") {
+    fail(source, `${description} must be an object`);
+  }
+  return node;
+}
+
+export function requireArray(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): readonly Node[] {
+  if (node?.type !== "array") {
+    fail(source, `${description} must be an array`);
+  }
+  return node.children ?? [];
+}
+
+export function requireString(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): string {
+  if (node?.type !== "string" || typeof node.value !== "string") {
+    fail(source, `${description} must be a string`);
+  }
+  return node.value;
+}
+
+export function requireNonEmptyString(
+  node: Node | undefined,
+  source: SettingsSource,
+  description: string,
+): string {
+  const value = requireString(node, source, description);
+  if (value.length === 0) {
+    fail(source, `${description} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function requireNumber(
+  node: Node,
+  source: SettingsSource,
+  description: string,
+): number {
+  if (node.type !== "number" || typeof node.value !== "number") {
+    fail(source, `${description} must be a number`);
+  }
+  return node.value;
+}
+
+export function readStringArray(
+  node: Node,
+  source: SettingsSource,
+  description: string,
+): readonly string[] {
+  const elements = requireArray(node, source, description);
+  return elements.map((element) =>
+    requireString(element, source, `every element of ${description}`),
+  );
+}
+
+/**
+ * Read `source`'s file text and its `hooks` object node.
+ *
+ * @remarks
+ * Returns `undefined` when the file does not exist — most projects declare
+ * only one or two of the three well-known layers, and that is not an error.
+ * A file that exists but cannot be parsed as JSONC, or whose top level or
+ * `hooks` value is not an object, throws {@link SettingsParseError}.
+ * `hooksNode` is `undefined` when the file parses but declares no `hooks`
+ * key at all — distinct from the file not existing, which this function
+ * signals by returning `undefined` itself rather than an object whose
+ * `hooksNode` is `undefined`.
+ */
+export function readSettingsTree(
+  source: SettingsSource,
+): { readonly text: string; readonly hooksNode: Node | undefined } | undefined {
+  let text: string;
+  try {
+    text = readFileSync(source.path, "utf8");
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+
+  const errors: ParseError[] = [];
+  const root = parseTree(text, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    fail(source, describeParseErrors(errors));
+  }
+  const rootNode = requireObject(root, source, "the settings file");
+
+  const hooksNode = getProperty(rootNode, "hooks");
+  if (hooksNode === undefined) {
+    return { text, hooksNode: undefined };
+  }
+  requireObject(hooksNode, source, '"hooks"');
+
+  return { text, hooksNode };
+}
+
+/**
+ * Read one `hooks.<event>[].hooks[]` entry's `command` and `args` — the part
+ * `settings/load.ts`'s strict `readCommandHooks` and `lint/parse.ts`'s
+ * tolerant `readGroupCommands` both read identically. `load.ts` adds
+ * `timeout` and `provenance` on top; `parse.ts` adds `line`.
+ */
+export function readCommandEntry(
+  hookNode: Node,
+  event: EventName,
+  source: SettingsSource,
+): { readonly command: string; readonly args: readonly string[] | undefined } {
+  requireObject(hookNode, source, `an entry of "hooks.${event}[].hooks"`);
+
+  const commandNode = getProperty(hookNode, "command");
+  const command = requireNonEmptyString(
+    commandNode,
+    source,
+    `"hooks.${event}[].hooks[].command"`,
+  );
+
+  const argsNode = getProperty(hookNode, "args");
+  const args =
+    argsNode === undefined
+      ? undefined
+      : readStringArray(argsNode, source, `"hooks.${event}[].hooks[].args"`);
+
+  return { command, args };
+}

--- a/src/internal/settings/load.ts
+++ b/src/internal/settings/load.ts
@@ -12,8 +12,8 @@
 import type { Node } from "jsonc-parser";
 
 import type { EventName, Provenance } from "../../types.js";
-import { SettingsParseError } from "../errors.js";
 import {
+  fail,
   getProperty,
   isEventName,
   positionAt,
@@ -46,9 +46,8 @@ function requirePositiveNumber(
   const value = requireNumber(node, source, description);
   if (!Number.isFinite(value) || value <= 0) {
     const { line } = positionAt(text, node.offset);
-    throw new SettingsParseError(
-      source.path,
-      source.layer,
+    fail(
+      source,
       `${description} at line ${String(line)} must be a positive number of seconds, got ${String(value)}`,
     );
   }

--- a/src/internal/settings/load.ts
+++ b/src/internal/settings/load.ts
@@ -3,103 +3,28 @@
  *
  * @remarks
  * Static layer: reads a file's text and parses it, but never spawns a
- * process and never writes anything back. Uses `jsonc-parser`'s `parseTree`
- * rather than `JSON.parse` so a hook's declaration keeps its offset into the
- * source text — the same convention `record`'s later write-back path depends
- * on. `merge.ts` is what turns several files' worth of these into one
- * ordered, deduped `ResolvedSettings`.
+ * process and never writes anything back — see `jsonc.ts`'s own remark for
+ * the shared reading primitives this module builds on. `merge.ts` is what
+ * turns several files' worth of these into one ordered, deduped
+ * `ResolvedSettings`.
  */
 
-import { readFileSync } from "node:fs";
-
-import {
-  type Node,
-  type ParseError,
-  parseTree,
-  printParseErrorCode,
-} from "jsonc-parser";
+import type { Node } from "jsonc-parser";
 
 import type { EventName, Provenance } from "../../types.js";
 import { SettingsParseError } from "../errors.js";
+import {
+  getProperty,
+  isEventName,
+  positionAt,
+  readCommandEntry,
+  readSettingsTree,
+  requireArray,
+  requireNumber,
+  requireObject,
+  requireString,
+} from "./jsonc.js";
 import type { RawHook, SettingsSource } from "./types.js";
-
-/**
- * The event names this loader recognizes today.
- *
- * @remarks
- * Typed as `Record<EventName, true>` rather than an array so the mirror
- * cannot silently drift: widening `src/types.ts`'s `EventName` without
- * extending this map is a type error here, instead of a loader that quietly
- * drops every hook declared under the new event. A `hooks` key outside this
- * set is still not an error — it is treated as an event Claude Code added
- * after this map was last extended, and silently carries no hooks forward,
- * exactly as it would if the spec module does not yet classify it either. The
- * `matcher` issue is what wires this loader to `src/internal/spec/` instead
- * of this hand-kept mirror.
- */
-const KNOWN_EVENT_NAMES: Readonly<Record<EventName, true>> = {
-  SessionStart: true,
-  Setup: true,
-  InstructionsLoaded: true,
-  UserPromptSubmit: true,
-  UserPromptExpansion: true,
-  MessageDisplay: true,
-  PreToolUse: true,
-  PermissionRequest: true,
-  PostToolUse: true,
-  PostToolUseFailure: true,
-  PostToolBatch: true,
-  PermissionDenied: true,
-  Notification: true,
-  SubagentStart: true,
-  SubagentStop: true,
-  TaskCreated: true,
-  TaskCompleted: true,
-  Stop: true,
-  StopFailure: true,
-  TeammateIdle: true,
-  ConfigChange: true,
-  CwdChanged: true,
-  DirectoryAdded: true,
-  FileChanged: true,
-  WorktreeCreate: true,
-  WorktreeRemove: true,
-  PreCompact: true,
-  PostCompact: true,
-  PreModelSwitch: true,
-  PostModelSwitch: true,
-  SessionEnd: true,
-  Elicitation: true,
-  ElicitationResult: true,
-};
-
-function isEventName(value: string): value is EventName {
-  return Object.hasOwn(KNOWN_EVENT_NAMES, value);
-}
-
-/** Find a property node's *value* node inside an object node, by key. */
-function getProperty(objectNode: Node, key: string): Node | undefined {
-  for (const property of objectNode.children ?? []) {
-    const [keyNode, valueNode] = property.children ?? [];
-    if (keyNode?.type === "string" && keyNode.value === key) {
-      return valueNode;
-    }
-  }
-  return undefined;
-}
-
-/** 1-based line and column of a UTF-16 code-unit offset into `text`. */
-function positionAt(text: string, offset: number): { line: number; col: number } {
-  let line = 1;
-  let lastNewline = -1;
-  for (let i = 0; i < offset; i++) {
-    if (text[i] === "\n") {
-      line++;
-      lastNewline = i;
-    }
-  }
-  return { line, col: offset - lastNewline };
-}
 
 function provenanceAt(
   file: string,
@@ -109,75 +34,6 @@ function provenanceAt(
 ): Provenance {
   const { line, col } = positionAt(text, offset);
   return { file, layer, line, col, offset };
-}
-
-function describeParseErrors(errors: readonly ParseError[]): string {
-  return errors
-    .map(
-      (error) =>
-        `${printParseErrorCode(error.error)} at offset ${String(error.offset)}`,
-    )
-    .join(", ");
-}
-
-function fail(source: SettingsSource, reason: string): never {
-  throw new SettingsParseError(source.path, source.layer, reason);
-}
-
-function requireObject(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): Node {
-  if (node?.type !== "object") {
-    fail(source, `${description} must be an object`);
-  }
-  return node;
-}
-
-function requireArray(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): readonly Node[] {
-  if (node?.type !== "array") {
-    fail(source, `${description} must be an array`);
-  }
-  return node.children ?? [];
-}
-
-function requireString(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): string {
-  if (node?.type !== "string" || typeof node.value !== "string") {
-    fail(source, `${description} must be a string`);
-  }
-  return node.value;
-}
-
-function requireNonEmptyString(
-  node: Node | undefined,
-  source: SettingsSource,
-  description: string,
-): string {
-  const value = requireString(node, source, description);
-  if (value.length === 0) {
-    fail(source, `${description} must be a non-empty string`);
-  }
-  return value;
-}
-
-function requireNumber(
-  node: Node,
-  source: SettingsSource,
-  description: string,
-): number {
-  if (node.type !== "number" || typeof node.value !== "number") {
-    fail(source, `${description} must be a number`);
-  }
-  return node.value;
 }
 
 /** A {@link requireNumber} that also rejects zero, negative, and non-finite values. */
@@ -190,23 +46,13 @@ function requirePositiveNumber(
   const value = requireNumber(node, source, description);
   if (!Number.isFinite(value) || value <= 0) {
     const { line } = positionAt(text, node.offset);
-    fail(
-      source,
+    throw new SettingsParseError(
+      source.path,
+      source.layer,
       `${description} at line ${String(line)} must be a positive number of seconds, got ${String(value)}`,
     );
   }
   return value;
-}
-
-function readStringArray(
-  node: Node,
-  source: SettingsSource,
-  description: string,
-): readonly string[] {
-  const elements = requireArray(node, source, description);
-  return elements.map((element) =>
-    requireString(element, source, `every element of ${description}`),
-  );
 }
 
 /** One `hooks.<event>[]` matcher group's own `hooks: [...]` entries. */
@@ -226,20 +72,7 @@ function readCommandHooks(
   const commandNodes = requireArray(commandsNode, source, `"hooks.${event}[].hooks"`);
 
   return commandNodes.map((hookNode) => {
-    requireObject(hookNode, source, `an entry of "hooks.${event}[].hooks"`);
-
-    const commandNode = getProperty(hookNode, "command");
-    const command = requireNonEmptyString(
-      commandNode,
-      source,
-      `"hooks.${event}[].hooks[].command"`,
-    );
-
-    const argsNode = getProperty(hookNode, "args");
-    const args =
-      argsNode === undefined
-        ? undefined
-        : readStringArray(argsNode, source, `"hooks.${event}[].hooks[].args"`);
+    const { command, args } = readCommandEntry(hookNode, event, source);
 
     const timeoutNode = getProperty(hookNode, "timeout");
     // Claude Code's own settings schema writes `timeout` in seconds;
@@ -281,33 +114,14 @@ function readCommandHooks(
  * {@link SettingsParseError}.
  */
 export function loadSourceHooks(source: SettingsSource): readonly RawHook[] {
-  let text: string;
-  try {
-    text = readFileSync(source.path, "utf8");
-  } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      return [];
-    }
-    throw error;
+  const settingsTree = readSettingsTree(source);
+  if (settingsTree === undefined) {
+    return [];
   }
-
-  const errors: ParseError[] = [];
-  const root = parseTree(text, errors, { allowTrailingComma: true });
-  if (errors.length > 0) {
-    fail(source, describeParseErrors(errors));
-  }
-  const rootNode = requireObject(root, source, "the settings file");
-
-  const hooksNode = getProperty(rootNode, "hooks");
+  const { text, hooksNode } = settingsTree;
   if (hooksNode === undefined) {
     return [];
   }
-  requireObject(hooksNode, source, '"hooks"');
 
   const hooks: RawHook[] = [];
   for (const property of hooksNode.children ?? []) {
@@ -315,7 +129,8 @@ export function loadSourceHooks(source: SettingsSource): readonly RawHook[] {
     const eventKey = requireString(keyNode, source, 'every key of "hooks"');
     if (!isEventName(eventKey)) {
       // Forward-compatible: an event this loader does not yet know about is
-      // skipped rather than rejected. See KNOWN_EVENT_NAMES's doc comment.
+      // skipped rather than rejected. See `jsonc.ts`'s `isEventName` doc
+      // comment.
       continue;
     }
 

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ import { SettingsParseError } from "../src/internal/errors.js";
 import {
   buildLintContext,
   LINT_RULES,
+  readHookCommands,
   readMatcherGroups,
 } from "../src/internal/lint/index.js";
 import type {
@@ -23,6 +24,7 @@ import {
   toJsonLintReport,
   type LintReport,
 } from "../src/internal/report/index.js";
+import { loadSourceHooks } from "../src/internal/settings/index.js";
 import type { SettingsSource } from "../src/internal/settings/index.js";
 import {
   loadSpec,
@@ -921,6 +923,60 @@ describe("readMatcherGroups: the tolerant reader's own structural strictness", (
       layer: "project",
     };
     expect(readMatcherGroups(source)).toEqual([]);
+  });
+});
+
+describe("readHookCommands: agreement with the strict loader", () => {
+  it("yields the same (event, command, args, line) tuples as loadSourceHooks, for every settings fixture the strict loader accepts", () => {
+    // Both readers walk the same shared parse (`settings/jsonc.ts`) and are
+    // meant to read every command entry identically — the only place they
+    // may differ is how a `matcher` itself is read, which this comparison
+    // never looks at. A fixture the strict loader rejects (malformed JSONC,
+    // an array-valued matcher, any other structural error) is skipped here:
+    // it is exactly the case the two readers are allowed to disagree about,
+    // and `tests/settings.test.ts` and the "structural strictness" describe
+    // block above already cover it.
+    const fixtureFiles = readdirSync(SETTINGS_FIXTURES_DIR, {
+      recursive: true,
+      encoding: "utf8",
+    })
+      .filter((entry) => entry.endsWith(".json"))
+      .map((relative) => path.join(SETTINGS_FIXTURES_DIR, relative));
+
+    expect(fixtureFiles.length).toBeGreaterThan(0);
+
+    let comparedAtLeastOne = false;
+    for (const file of fixtureFiles) {
+      const source: SettingsSource = { path: file, layer: "project" };
+
+      let strictHooks: ReturnType<typeof loadSourceHooks>;
+      try {
+        strictHooks = loadSourceHooks(source);
+      } catch (error) {
+        expect(error).toBeInstanceOf(SettingsParseError);
+        continue;
+      }
+
+      comparedAtLeastOne = true;
+      const tolerantCommands = readHookCommands(source);
+      expect(
+        tolerantCommands.map((command) => [
+          command.event,
+          command.command,
+          command.args,
+          command.line,
+        ]),
+      ).toEqual(
+        strictHooks.map((hook) => [
+          hook.event,
+          hook.command,
+          hook.args,
+          hook.provenance.line,
+        ]),
+      );
+    }
+
+    expect(comparedAtLeastOne).toBe(true);
   });
 });
 

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -951,7 +951,7 @@ describe("readHookCommands: agreement with the strict loader", () => {
 
     expect(fixtureFiles.length).toBeGreaterThan(0);
 
-    let comparedAtLeastOne = false;
+    let hookTuplesCompared = 0;
     for (const file of fixtureFiles) {
       const source: SettingsSource = { path: file, layer: "project" };
 
@@ -963,7 +963,7 @@ describe("readHookCommands: agreement with the strict loader", () => {
         continue;
       }
 
-      comparedAtLeastOne = true;
+      hookTuplesCompared += strictHooks.length;
       const tolerantCommands = readHookCommands(source);
       expect(
         tolerantCommands.map((command) => [
@@ -982,7 +982,14 @@ describe("readHookCommands: agreement with the strict loader", () => {
       );
     }
 
-    expect(comparedAtLeastOne).toBe(true);
+    // A fixture set that yields zero hooks on both sides (every accepted
+    // fixture happens to declare no `hooks` key) would satisfy a
+    // files-were-compared guard while never exercising the tuple comparison
+    // above. Require at least one actual (event, command, args, line) tuple
+    // to have been compared, so a strict loader that started rejecting every
+    // hook-bearing fixture would fail this assertion instead of passing
+    // vacuously.
+    expect(hookTuplesCompared).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
`src/internal/lint/parse.ts` re-declared the whole of `src/internal/settings/load.ts`'s JSONC-reading layer — the known-event-name mirror, the node accessor and `require*` helpers, and the read-file / ENOENT / `parseTree` / root-object / `hooks`-object prologue — with only the `matcher` read actually differing in strictness. `src/cli.ts` carried three copies of the settings-discovery prologue.

This pulls the shared parts into a new `src/internal/settings/jsonc.ts` so the two readers cannot silently drift apart, and collapses the CLI's three discovery prologues into one `resolveSettingsSources` helper used by `runExplain`, `runLint`, and `runTest`. The strict/tolerant split is preserved exactly and is now the only difference between the two readers: `lint` still reads `matcher` tolerantly (absent, string, or array) where the strict loader throws.

Follow-on cleanups from review, in the same spirit: `settings/edit.ts`'s third byte-identical copy of `describeParseErrors` is gone, and `load.ts`'s one remaining inline `SettingsParseError` throw now goes through the shared `fail()` like its neighbours.

Closes #49

## Release impact

Release impact: no — pure internal refactor; nothing exported from `src/index.ts` changes, and there is no observable behavior change.

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 40 test files / 1734 tests).
- `pnpm exec vitest run tests/settings.test.ts tests/lint.test.ts tests/cli.test.ts` → pass (236 tests, unchanged — the existing tests are the contract for a refactor).
- New drift test in `tests/lint.test.ts` walks every fixture under `tests/fixtures/settings/` and pins `readHookCommands` and `loadSourceHooks` to agreement wherever the strict loader accepts the fixture. Its guard counts actual `(event, command, args, line)` hook tuples compared, so it cannot go green on a sample that contains no hooks.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
