### PR TITLE
fix: surface every firing hook's launch failure in test's report (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,20 @@ hookassert --help
   names the hook that decided. A hook whose process never starts at all — an exec-form
   hook (one declaring `args`) naming a command that does not exist, a missing
   interpreter — resolves to `decision: error` (`cause: launch-failed`) rather than being
-  mistaken for a hook that ran and exited non-zero. A failing case's `pretty` and
-  `github` output then shows the OS-reported reason (`spawn python33 ENOENT`, say)
-  alongside the hook's own declaration, and the JSON report carries it as
-  `decidedBy.launchError`. A shell-form hook (no `args`, the shape Claude Code's own
-  docs show) always launches `/bin/sh` successfully, so a typo'd `command` there is
-  reported by the shell itself — usually exit `127` — not as `launch-failed`. Exits `0`
-  when every case passes (and, with `--ci`, none is `unknown` either), `1` when at least
-  one fails, and `3` when there are no failures but `--ci` was given and at least one
-  case is `unknown`.
+  mistaken for a hook that ran and exited non-zero. Every hook that fired for a case and
+  never launched is surfaced, not only the one whose decision decided the case's
+  verdict: `pretty` and `github` show the OS-reported reason (`spawn python33 ENOENT`,
+  say) alongside the hook's own declaration on the case's own PASS/UNKNOWN/FAIL line,
+  whichever that case's verdict turned out to be — `github` emits an error annotation
+  for a failing case and a warning annotation for a passing or unknown one, since
+  neither of those verdicts is itself a failure. The JSON report carries every launch
+  failure for the case as `launchFailures[]`, including the deciding hook's own, which
+  duplicates what `decidedBy.launchError` already reports. A shell-form hook (no `args`,
+  the shape Claude Code's own docs show) always launches `/bin/sh` successfully, so a
+  typo'd `command` there is reported by the shell itself — usually exit `127` — not as
+  `launch-failed`. Exits `0` when every case passes (and, with `--ci`, none is `unknown`
+  either), `1` when at least one fails, and `3` when there are no failures but `--ci`
+  was given and at least one case is `unknown`.
 
   ```console
   $ hookassert test fixtures/force-push.fixture.yaml --ci

--- a/schema/test-report.schema.json
+++ b/schema/test-report.schema.json
@@ -430,16 +430,29 @@
         }
       ]
     },
+    "launchFailure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hook", "launchError"],
+      "properties": {
+        "hook": { "$ref": "#/$defs/hook" },
+        "launchError": { "type": "string" }
+      }
+    },
     "testCaseReport": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["file", "index", "event", "tool", "result"],
+      "required": ["file", "index", "event", "tool", "result", "launchFailures"],
       "properties": {
         "file": { "type": "string", "minLength": 1 },
         "index": { "type": "integer", "minimum": 0 },
         "event": { "type": "string", "minLength": 1 },
         "tool": { "type": ["string", "null"] },
-        "result": { "$ref": "#/$defs/caseResult" }
+        "result": { "$ref": "#/$defs/caseResult" },
+        "launchFailures": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/launchFailure" }
+        }
       }
     },
     "summary": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ import {
   renderTestJson,
   renderTestPretty,
   type ExplainReport,
+  type LaunchFailure,
   type LintReport,
   type TestCaseReport,
   type TestReport,
@@ -1325,6 +1326,16 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     };
     const result = assertCase(p.caseData, observation);
     caseResults.push(result);
+    // Every firing hook whose process never started at all, in firing
+    // order — including the deciding hook when it is one of them. `assertCase`
+    // already folds every firing hook's `Decision` into the one verdict
+    // above; this is a separate, reporter-only projection so a launch
+    // failure that loses that fold is still surfaced (#65).
+    const launchFailures = fired.flatMap<LaunchFailure>((f) =>
+      f.execOutcome.launchError === undefined
+        ? []
+        : [{ hook: f.hook, launchError: f.execOutcome.launchError }],
+    );
     caseReports.push({
       file: p.fixturePath,
       index: p.index,
@@ -1332,6 +1343,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
       tool: p.caseData.tool,
       result,
       firedCount: fired.length,
+      launchFailures,
     });
   }
 

--- a/src/internal/report/github.ts
+++ b/src/internal/report/github.ts
@@ -33,6 +33,12 @@ export interface ReportFinding {
   readonly title: string;
   /** Human-readable explanation, shown as the annotation body. */
   readonly message: string;
+  /**
+   * The workflow-command level this finding renders as. Omit to take the
+   * default, `"error"` — every finding before `test` gained something to
+   * annotate that is not itself a failed verdict.
+   */
+  readonly level?: "error" | "warning";
 }
 
 /**
@@ -84,17 +90,19 @@ function escapeData(value: string): string {
 }
 
 /**
- * Render one {@link ReportFinding} as a single GitHub Actions `::error`
- * workflow command, in the form
- * `::error file=<settings file>,line=<line>,title=<rule or case>::<message>`.
+ * Render one {@link ReportFinding} as a single GitHub Actions workflow
+ * command, in the form
+ * `::<level> file=<settings file>,line=<line>,title=<rule or case>::<message>`
+ * — `<level>` is {@link ReportFinding.level}, defaulting to `"error"`.
  */
 export function renderGithubFinding(
   finding: ReportFinding,
   workspaceRoot: string,
 ): string {
+  const level = finding.level ?? "error";
   const file = escapeProperty(relativizeForGithub(finding.file, workspaceRoot));
   const title = escapeProperty(finding.title);
-  return `::error file=${file},line=${String(finding.line)},title=${title}::${escapeData(finding.message)}`;
+  return `::${level} file=${file},line=${String(finding.line)},title=${title}::${escapeData(finding.message)}`;
 }
 
 /**

--- a/src/internal/report/index.ts
+++ b/src/internal/report/index.ts
@@ -27,7 +27,12 @@ export {
   renderTestPretty,
   toJsonTestReport,
 } from "./testReport.js";
-export type { JsonTestReport, TestCaseReport, TestReport } from "./testReport.js";
+export type {
+  JsonTestReport,
+  LaunchFailure,
+  TestCaseReport,
+  TestReport,
+} from "./testReport.js";
 export {
   renderLintGithub,
   renderLintJson,

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -587,14 +587,35 @@ interface CaseAnnotation {
 }
 
 /**
+ * The `{ file, line }` a launch-failure-driven annotation points at: the
+ * failing hook's own `Provenance` when it resolves inside the workspace,
+ * otherwise line 1 of the fixture file — the same fallback the `"fail"`
+ * branch below uses, for the reason given in this function's own remarks.
+ */
+function launchFailureLocation(
+  failure: LaunchFailure,
+  caseReport: TestCaseReport,
+  workspaceRoot: string,
+): { readonly file: string; readonly line: number } {
+  const attachable = attachesInWorkspace(failure.hook.provenance.file, workspaceRoot);
+  return attachable
+    ? { file: failure.hook.provenance.file, line: failure.hook.provenance.line }
+    : { file: caseReport.file, line: 1 };
+}
+
+/**
  * Decide the `github` annotation for one {@link TestCaseReport}, or
  * `undefined` for a case that gets no annotation at all: an `::error` for a
- * `"fail"` verdict, an `::warning` for a non-`"fail"` case that still carries
- * a launch failure (some other firing hook's own `Decision` outranked the
- * launch-failed one, so `assertCase`'s fold never saw it), otherwise none.
- * `::error` is deliberately never used for a passing case: the run's exit
- * code is `0` there, and a red annotation on a green run would report a
- * failure the verdict did not reach.
+ * `"fail"` verdict; an `::warning` for an `"unknown"` verdict that carries a
+ * launch failure, stating both why the case is `"unknown"` and which hook
+ * never launched (an `"unknown"` case without a launch failure gets none,
+ * matching how `"unknown"` was reported before this function existed);
+ * an `::warning` for a `"pass"` case that still carries a launch failure
+ * (some other firing hook's own `Decision` outranked the launch-failed one,
+ * so `assertCase`'s fold never saw it); otherwise none. `::error` is
+ * deliberately never used for a `"pass"`/`"unknown"` case: neither verdict is
+ * itself a failed assertion, and a red annotation would report a failure the
+ * verdict did not reach.
  *
  * @remarks
  * A fixture case carries no line number of its own the way a `ResolvedHook`
@@ -602,13 +623,14 @@ interface CaseAnnotation {
  * annotation points at line 1 of its fixture file, identified instead by the
  * case's own 0-based index and event/target in the annotation's title,
  * *unless* the annotation names a hook — the `"fail"` branch's `decidedBy`,
- * or the `"warning"` branch's first {@link TestCaseReport.launchFailures}
- * entry — in which case the annotation points at that hook's own
- * `Provenance` instead, the more actionable location. A hook declared
- * outside the workspace (the user layer's `~/.claude/settings.json`, or the
- * enterprise layer's) is the exception: an annotation whose `file=` is not
- * inside `GITHUB_WORKSPACE` silently attaches to nothing, so the annotation
- * stays on the fixture — which is inside the checkout.
+ * or the `"unknown"`/`"pass"` branches' first
+ * {@link TestCaseReport.launchFailures} entry — in which case the annotation
+ * points at that hook's own `Provenance` instead, the more actionable
+ * location. A hook declared outside the workspace (the user layer's
+ * `~/.claude/settings.json`, or the enterprise layer's) is the exception: an
+ * annotation whose `file=` is not inside `GITHUB_WORKSPACE` silently attaches
+ * to nothing, so the annotation stays on the fixture — which is inside the
+ * checkout.
  */
 function caseAnnotation(
   caseReport: TestCaseReport,
@@ -635,23 +657,32 @@ function caseAnnotation(
     return { level: "error", location, message };
   }
 
+  if (result.kind === "unknown") {
+    const [firstLaunchFailure] = caseReport.launchFailures;
+    if (firstLaunchFailure === undefined) {
+      return undefined;
+    }
+    const message = [
+      ...describeLaunchFailures(caseReport),
+      ...result.reasons.map(describeUnknownReason),
+    ].join("; ");
+    return {
+      level: "warning",
+      location: launchFailureLocation(firstLaunchFailure, caseReport, workspaceRoot),
+      message,
+    };
+  }
+
+  if (result.kind !== "pass") {
+    return undefined;
+  }
   const [firstLaunchFailure] = caseReport.launchFailures;
   if (firstLaunchFailure === undefined) {
     return undefined;
   }
-  const attachable = attachesInWorkspace(
-    firstLaunchFailure.hook.provenance.file,
-    workspaceRoot,
-  );
-  const location = attachable
-    ? {
-        file: firstLaunchFailure.hook.provenance.file,
-        line: firstLaunchFailure.hook.provenance.line,
-      }
-    : { file: caseReport.file, line: 1 };
   return {
     level: "warning",
-    location,
+    location: launchFailureLocation(firstLaunchFailure, caseReport, workspaceRoot),
     message: describeLaunchFailures(caseReport).join("; "),
   };
 }
@@ -659,9 +690,8 @@ function caseAnnotation(
 /**
  * Render a {@link TestReport} as GitHub Actions workflow commands: the
  * leading header line, then one annotation per case {@link caseAnnotation}
- * decides needs one — an `::error` for every `"fail"` case, an `::warning`
- * for a non-`"fail"` case with a launch failure `assertCase`'s fold did not
- * pick.
+ * decides needs one — see that function for which verdicts get one and at
+ * what level.
  */
 export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
   const lines: string[] = [renderGithubHeader(report.header)];

--- a/src/internal/report/testReport.ts
+++ b/src/internal/report/testReport.ts
@@ -20,6 +20,7 @@ import type {
   ExpectationDiff,
   NonFiringExplanation,
   PayloadOrigin,
+  ResolvedHook,
   Summary,
   UnknownReason,
 } from "../../types.js";
@@ -30,6 +31,18 @@ import {
 } from "./github.js";
 import { toJsonHook, type JsonHook } from "./json.js";
 import type { ReportHeader } from "./summary.js";
+
+/**
+ * One hook that fired for a case and whose process never started at all,
+ * carried to the reporters so a launch failure is visible even on a hook the
+ * verdict's fold did not pick.
+ */
+export interface LaunchFailure {
+  /** The hook that never launched. */
+  readonly hook: ResolvedHook;
+  /** That hook's own `ExecOutcome.launchError` — the OS-reported reason. */
+  readonly launchError: string;
+}
 
 /** One fixture case's result, identified by which file and position it came from. */
 export interface TestCaseReport {
@@ -58,6 +71,24 @@ export interface TestCaseReport {
    * else needs.
    */
   readonly firedCount: number;
+
+  /**
+   * Every hook that fired for this case whose process never started, in
+   * firing order — including the deciding hook when its own process is one
+   * of them. Empty for a case where nothing fired, and for every stubbed
+   * step (`stub` bypasses the spawner, so it can never produce a
+   * `launchError`).
+   *
+   * @remarks
+   * Not part of `CaseResult`, for the reason `firedCount` above is not: it
+   * takes no part in the verdict — `assertCase` folds every firing hook's
+   * `Decision` into one verdict (#42) and a launch failure that loses that
+   * fold changes nothing about it — and only a reporter reads it. #39 gave
+   * the *deciding* hook's launch error its own home on `DecidingHook`; this
+   * is the same fact for every other firing hook, which the report was
+   * otherwise dropping entirely (#65).
+   */
+  readonly launchFailures: readonly LaunchFailure[];
 }
 
 /** The full result `test <fixture>...` renders. */
@@ -147,34 +178,38 @@ function describeDecidedBy(decidedBy: DecidingHook): string {
 
 /**
  * `hook never launched: <OS message> (command "<command>", <file>:<line>)` —
- * the message every reporter shows for a case whose deciding hook's process
- * never started at all (`DecidingHook.launchError` set). Already names the
- * hook and its declaration site, so callers never also append
- * {@link decidedBySuffix}'s "— decided by …" for the same `DecidingHook`.
+ * the message every reporter shows for one hook that fired for a case but
+ * whose process never started at all. Already names the hook and its
+ * declaration site, so callers never also append {@link decidedBySuffix}'s
+ * "— decided by …" for the same hook.
  */
-function describeLaunchFailure(
-  decidedBy: DecidingHook & { launchError: string },
-): string {
-  const { hook, launchError } = decidedBy;
+function describeLaunchFailure(failure: LaunchFailure): string {
+  const { hook, launchError } = failure;
   return `hook never launched: ${launchError} (command "${hook.command}", ${hook.provenance.file}:${String(hook.provenance.line)})`;
+}
+
+/** Every {@link TestCaseReport.launchFailures} entry, rendered in firing order. */
+function describeLaunchFailures(report: TestCaseReport): string[] {
+  return report.launchFailures.map(describeLaunchFailure);
 }
 
 /**
  * ` — decided by …` suffix for a `FAIL`/`UNKNOWN` line, shown only when more
  * than one hook fired for the case — naming the hook for a single-hook case
- * would just repeat what the line already says. `detailNamesHook` suppresses
- * it for the one line whose detail has already named the hook itself, a
- * `FAIL` rendered by {@link describeLaunchFailure}; an `UNKNOWN` line never
- * carries that message — a launch failure whose event is missing from the
- * spec resolves to `unknown` before `launchError` is ever read — so it keeps
- * the suffix regardless of the deciding hook's `launchError`.
+ * would just repeat what the line already says — and suppressed when the
+ * deciding hook's own process never started: that hook's launch-failure
+ * segment (from {@link describeLaunchFailures}) already names it and its
+ * declaration site, so the suffix would only repeat it.
  */
 function decidedBySuffix(
   report: TestCaseReport,
   decidedBy: DecidingHook | undefined,
-  detailNamesHook: boolean,
 ): string {
-  if (decidedBy === undefined || report.firedCount <= 1 || detailNamesHook) {
+  if (
+    decidedBy === undefined ||
+    report.firedCount <= 1 ||
+    decidedBy.launchError !== undefined
+  ) {
     return "";
   }
   return ` — decided by ${describeDecidedBy(decidedBy)}`;
@@ -182,38 +217,43 @@ function decidedBySuffix(
 
 /**
  * The detail text after a `FAIL` line's label, for a case whose combined
- * verdict is a `"fail"`: the launch-failure message when the deciding hook
- * never launched, otherwise the ordinary diff/non-firing explanation.
+ * verdict is a `"fail"`: every fired hook's launch-failure message first
+ * (root cause before consequence), then the ordinary diff/non-firing
+ * explanation — never one replacing the other.
  */
-function describeFailDetail(result: Extract<CaseResult, { kind: "fail" }>): string {
-  const { decidedBy } = result;
-  if (decidedBy?.launchError !== undefined) {
-    return describeLaunchFailure({ ...decidedBy, launchError: decidedBy.launchError });
-  }
-  return result.nonFiring === undefined
-    ? result.diffs.map(describeDiff).join("; ")
-    : describeNonFiring(result.nonFiring);
+function describeFailDetail(
+  report: TestCaseReport & { readonly result: Extract<CaseResult, { kind: "fail" }> },
+): string {
+  const { result } = report;
+  const detailSegments =
+    result.nonFiring === undefined
+      ? result.diffs.map(describeDiff)
+      : [describeNonFiring(result.nonFiring)];
+  return [...describeLaunchFailures(report), ...detailSegments].join("; ");
 }
 
 /** One human-readable line per {@link TestCaseReport}, for `renderTestPretty`. */
 function renderCaseLine(report: TestCaseReport): string {
   const label = caseLabel(report);
   const { result } = report;
+  const launchSegments = describeLaunchFailures(report);
   switch (result.kind) {
     case "pass":
-      return `PASS  ${label}`;
+      return launchSegments.length === 0
+        ? `PASS  ${label}`
+        : `PASS  ${label} — ${launchSegments.join("; ")}`;
     case "skipped":
       return `SKIP  ${label} (${result.reason})`;
     case "unknown": {
-      const reasons = result.reasons.map(describeUnknownReason).join("; ");
-      return `UNKNOWN ${label} — ${reasons}${decidedBySuffix(report, result.decidedBy, false)}`;
+      const detail = [
+        ...launchSegments,
+        ...result.reasons.map(describeUnknownReason),
+      ].join("; ");
+      return `UNKNOWN ${label} — ${detail}${decidedBySuffix(report, result.decidedBy)}`;
     }
     case "fail": {
-      const detail = describeFailDetail(result);
-      // The launch-failure detail already names the hook and its declaration
-      // site, so the suffix would only repeat it.
-      const detailNamesHook = result.decidedBy?.launchError !== undefined;
-      return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy, detailNamesHook)}`;
+      const detail = describeFailDetail({ ...report, result });
+      return `FAIL  ${label} — ${detail}${decidedBySuffix(report, result.decidedBy)}`;
     }
   }
 }
@@ -450,6 +490,22 @@ function toJsonCaseResult(result: CaseResult): JsonCaseResult {
   }
 }
 
+/**
+ * JSON shape of a {@link LaunchFailure}, with its own `hook` converted
+ * through `json.ts`'s {@link toJsonHook} for the same reason
+ * {@link JsonDecidingHook} is: a raw `ResolvedHook`'s `matcher`/`args`/
+ * `timeoutMs` are `T | undefined`, which `JSON.stringify` would drop.
+ */
+interface JsonLaunchFailure {
+  readonly hook: JsonHook;
+  readonly launchError: string;
+}
+
+/** Build the {@link JsonLaunchFailure} for one {@link LaunchFailure}. */
+function toJsonLaunchFailure(failure: LaunchFailure): JsonLaunchFailure {
+  return { hook: toJsonHook(failure.hook), launchError: failure.launchError };
+}
+
 /** JSON-serializable shape one {@link TestCaseReport} renders to. */
 interface JsonTestCaseReport {
   readonly file: string;
@@ -457,6 +513,7 @@ interface JsonTestCaseReport {
   readonly event: EventName;
   readonly tool: string | null;
   readonly result: JsonCaseResult;
+  readonly launchFailures: readonly JsonLaunchFailure[];
 }
 
 /**
@@ -500,6 +557,7 @@ export function toJsonTestReport(report: TestReport): JsonTestReport {
       event: caseReport.event,
       tool: caseReport.tool ?? null,
       result: toJsonCaseResult(caseReport.result),
+      launchFailures: caseReport.launchFailures.map(toJsonLaunchFailure),
     })),
     summary: report.summary,
   };
@@ -521,58 +579,106 @@ function attachesInWorkspace(file: string, workspaceRoot: string): boolean {
   return !relative.startsWith("/") && !/^[A-Za-z]:\//.test(relative);
 }
 
+/** What {@link caseAnnotation} decided about one case's `github` annotation. */
+interface CaseAnnotation {
+  readonly level: "error" | "warning";
+  readonly location: { readonly file: string; readonly line: number };
+  readonly message: string;
+}
+
 /**
- * Render a {@link TestReport} as GitHub Actions workflow commands: the
- * leading header line, then one `::error` per `"fail"` case.
+ * Decide the `github` annotation for one {@link TestCaseReport}, or
+ * `undefined` for a case that gets no annotation at all: an `::error` for a
+ * `"fail"` verdict, an `::warning` for a non-`"fail"` case that still carries
+ * a launch failure (some other firing hook's own `Decision` outranked the
+ * launch-failed one, so `assertCase`'s fold never saw it), otherwise none.
+ * `::error` is deliberately never used for a passing case: the run's exit
+ * code is `0` there, and a red annotation on a green run would report a
+ * failure the verdict did not reach.
  *
  * @remarks
  * A fixture case carries no line number of its own the way a `ResolvedHook`
  * does through `Provenance` — `fixture/load.ts` never records one — so every
  * annotation points at line 1 of its fixture file, identified instead by the
  * case's own 0-based index and event/target in the annotation's title,
- * *unless* the failure names a `decidedBy` hook — a hook fired and its own
- * `Decision` decided the case's verdict — in which case the annotation
- * points at that hook's own `Provenance` instead, the more actionable
- * location. A deciding hook declared outside the workspace (the user layer's
- * `~/.claude/settings.json`, or the enterprise layer's) is the exception: an
- * annotation whose `file=` is not inside `GITHUB_WORKSPACE` silently attaches
- * to nothing, so the annotation stays on the fixture — which is inside the
- * checkout — and names the deciding hook in its message instead.
+ * *unless* the annotation names a hook — the `"fail"` branch's `decidedBy`,
+ * or the `"warning"` branch's first {@link TestCaseReport.launchFailures}
+ * entry — in which case the annotation points at that hook's own
+ * `Provenance` instead, the more actionable location. A hook declared
+ * outside the workspace (the user layer's `~/.claude/settings.json`, or the
+ * enterprise layer's) is the exception: an annotation whose `file=` is not
+ * inside `GITHUB_WORKSPACE` silently attaches to nothing, so the annotation
+ * stays on the fixture — which is inside the checkout.
  */
-export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
-  const lines: string[] = [renderGithubHeader(report.header)];
-
-  for (const caseReport of report.cases) {
-    if (caseReport.result.kind !== "fail") {
-      continue;
-    }
-    const { result } = caseReport;
-    const detail = describeFailDetail(result);
+function caseAnnotation(
+  caseReport: TestCaseReport,
+  workspaceRoot: string,
+): CaseAnnotation | undefined {
+  const { result } = caseReport;
+  if (result.kind === "fail") {
+    const detail = describeFailDetail({ ...caseReport, result });
     const { decidedBy } = result;
     const attachable =
       decidedBy !== undefined &&
       attachesInWorkspace(decidedBy.hook.provenance.file, workspaceRoot);
     const location = attachable
-      ? {
-          file: decidedBy.hook.provenance.file,
-          line: decidedBy.hook.provenance.line,
-        }
+      ? { file: decidedBy.hook.provenance.file, line: decidedBy.hook.provenance.line }
       : { file: caseReport.file, line: 1 };
-    // Never appends "— decided by …" when the hook never launched: `detail`
-    // already names the hook and its declaration site (see
+    // Never appends "— decided by …" when the deciding hook never launched:
+    // `detail` already names it and its declaration site (see
     // `describeLaunchFailure`), so the annotation would otherwise repeat
     // itself.
     const message =
       decidedBy === undefined || attachable || decidedBy.launchError !== undefined
         ? detail
         : `${detail} — decided by ${describeDecidedBy(decidedBy)}`;
+    return { level: "error", location, message };
+  }
+
+  const [firstLaunchFailure] = caseReport.launchFailures;
+  if (firstLaunchFailure === undefined) {
+    return undefined;
+  }
+  const attachable = attachesInWorkspace(
+    firstLaunchFailure.hook.provenance.file,
+    workspaceRoot,
+  );
+  const location = attachable
+    ? {
+        file: firstLaunchFailure.hook.provenance.file,
+        line: firstLaunchFailure.hook.provenance.line,
+      }
+    : { file: caseReport.file, line: 1 };
+  return {
+    level: "warning",
+    location,
+    message: describeLaunchFailures(caseReport).join("; "),
+  };
+}
+
+/**
+ * Render a {@link TestReport} as GitHub Actions workflow commands: the
+ * leading header line, then one annotation per case {@link caseAnnotation}
+ * decides needs one — an `::error` for every `"fail"` case, an `::warning`
+ * for a non-`"fail"` case with a launch failure `assertCase`'s fold did not
+ * pick.
+ */
+export function renderTestGithub(report: TestReport, workspaceRoot: string): string {
+  const lines: string[] = [renderGithubHeader(report.header)];
+
+  for (const caseReport of report.cases) {
+    const annotation = caseAnnotation(caseReport, workspaceRoot);
+    if (annotation === undefined) {
+      continue;
+    }
     lines.push(
       renderGithubFinding(
         {
-          file: location.file,
-          line: location.line,
+          file: annotation.location.file,
+          line: annotation.location.line,
           title: `test case #${String(caseReport.index)}: ${caseLabel(caseReport)}`,
-          message,
+          message: annotation.message,
+          level: annotation.level,
         },
         workspaceRoot,
       ),

--- a/tests/reporters.test.ts
+++ b/tests/reporters.test.ts
@@ -728,10 +728,15 @@ interface JsonCaseResultShape {
   readonly reasons?: readonly JsonUnknownReasonShape[];
   readonly decidedBy?: JsonDecidingHookShape | null;
 }
+interface JsonLaunchFailureShape {
+  readonly hook: { readonly command: string };
+  readonly launchError: string;
+}
 interface JsonTestCaseShape {
   readonly event: string;
   readonly tool: string | null;
   readonly result: JsonCaseResultShape;
+  readonly launchFailures: readonly JsonLaunchFailureShape[];
 }
 interface JsonTestReportForAssertions {
   readonly reportVersion: string;
@@ -760,6 +765,8 @@ describe("renderTestJson: schema validation against a real rendering", () => {
   const CMD_LAUNCH_FAIL = "cmd-launch-fail";
   const CMD_CONTEXT_MISMATCH = "cmd-context-mismatch";
   const CMD_UPDATED_INPUT_ABSENT = "cmd-updated-input-absent";
+  const CMD_MULTI_LAUNCH_FAIL = "cmd-multi-launch-fail";
+  const CMD_MULTI_DENY = "cmd-multi-deny";
 
   beforeAll(() => {
     projectDir = mkdtempSync(path.join(tmpdir(), "hookassert-reporters-test-schema-"));
@@ -785,6 +792,16 @@ describe("renderTestJson: schema validation against a real rendering", () => {
           // Issue #34: expect.context / expect.updatedInput diffs.
           commandGroup("Agent", CMD_CONTEXT_MISMATCH),
           commandGroup("AskUserQuestion", CMD_UPDATED_INPUT_ABSENT),
+          // Issue #65: two hooks under one matcher, one of which never
+          // launches — proves `launchFailures` is carried for a hook the
+          // verdict's fold did not pick.
+          {
+            matcher: "MultiHook",
+            hooks: [
+              { type: "command", command: CMD_MULTI_LAUNCH_FAIL, args: [] },
+              { type: "command", command: CMD_MULTI_DENY },
+            ],
+          },
         ],
         Notification: [commandGroup(undefined, CMD_NOTIFICATION_NOOP)],
       },
@@ -877,6 +894,10 @@ describe("renderTestJson: schema validation against a real rendering", () => {
         // fixture that expects the launch failure exactly still passes, and
         // decidedBy.launchError carries the OS-reported reason.
         { event: "PreToolUse", tool: "LaunchFail", expect: { decision: "error" } },
+        // "pass" — the deny (`CMD_MULTI_DENY`) wins the fold over its
+        // launch-failed sibling (issue #65): `launchFailures` carries the
+        // loser even though `decidedBy` never names it.
+        { event: "PreToolUse", tool: "MultiHook", expect: { decision: "deny" } },
         // "skipped", reason "dry-run".
         {
           event: "PreToolUse",
@@ -919,6 +940,11 @@ describe("renderTestJson: schema validation against a real rendering", () => {
           },
         ],
         [CMD_UPDATED_INPUT_ABSENT, { exitCode: 0, stdout: "not json" }],
+        [
+          CMD_MULTI_LAUNCH_FAIL,
+          { exitCode: -1, launchError: "spawn cmd-multi-launch-fail ENOENT" },
+        ],
+        [CMD_MULTI_DENY, { exitCode: 2 }],
       ]),
     );
 
@@ -934,7 +960,7 @@ describe("renderTestJson: schema validation against a real rendering", () => {
       },
     );
 
-    // 11 of the 16 cases fail — `resolveTestExitCode` returns 1 whenever
+    // 11 of the 17 cases fail — `resolveTestExitCode` returns 1 whenever
     // `summary.failed > 0`, regardless of `--ci`.
     expect(result.exitCode).toBe(1);
     const parsed: unknown = JSON.parse(result.stdout);
@@ -1018,6 +1044,37 @@ describe("renderTestJson: schema validation against a real rendering", () => {
     expect(launchFailedCase?.result.decidedBy?.launchError).toBe(
       "spawn cmd-launch-fail ENOENT",
     );
+    // Issue #65: the deciding hook's own launch failure is also carried on
+    // `launchFailures`, not only on `decidedBy`.
+    expect(launchFailedCase?.launchFailures).toHaveLength(1);
+    expect(launchFailedCase?.launchFailures[0]?.hook.command).toBe(CMD_LAUNCH_FAIL);
+    expect(launchFailedCase?.launchFailures[0]?.launchError).toBe(
+      "spawn cmd-launch-fail ENOENT",
+    );
+
+    // Issue #65: a launch failure on a hook the fold did not pick is still
+    // carried on `launchFailures`, even though `decidedBy` never names it.
+    const multiHookCase = report.cases.find(
+      (c) => c.event === "PreToolUse" && c.tool === "MultiHook",
+    );
+    expect(multiHookCase?.result.kind).toBe("pass");
+    expect(multiHookCase?.result.decidedBy?.launchError).toBeNull();
+    expect(multiHookCase?.launchFailures).toHaveLength(1);
+    expect(multiHookCase?.launchFailures[0]?.hook.command).toBe(CMD_MULTI_LAUNCH_FAIL);
+    expect(multiHookCase?.launchFailures[0]?.launchError).toBe(
+      "spawn cmd-multi-launch-fail ENOENT",
+    );
+
+    // Every case with no launch failure of its own carries an explicit
+    // empty array, never an absent key — `additionalProperties: false` plus
+    // a full `required` list on `testCaseReport` demands it. `LaunchFail`
+    // and `MultiHook` are the two cases that spawn a launch-failing hook.
+    const otherCases = report.cases.filter(
+      (c) => c.tool !== "MultiHook" && c.tool !== "LaunchFail",
+    );
+    for (const c of otherCases) {
+      expect(c.launchFailures).toEqual([]);
+    }
   });
 
   it("pretty and github both render the context and updatedInput diffs (issue #34)", async () => {

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -672,6 +672,140 @@ describe("a non-deciding hook's launch failure (issue #65)", () => {
   });
 });
 
+describe("an unknown case that also carries a launch failure", () => {
+  // `Notification` has no entry in `MINIMAL_SPEC_PATH`'s spec, so every hook
+  // that fires for it resolves to an "unknown" Decision (event-not-in-spec)
+  // regardless of whether its process ever launched — the scenario
+  // `caseAnnotation`'s launch-failure warning branch dropped every
+  // `UnknownReason` for by treating an "unknown" result like a "pass".
+  let unknownProjectDir: string;
+  let unknownHomeDir: string;
+
+  afterEach(() => {
+    rmSync(unknownProjectDir, { recursive: true, force: true });
+    rmSync(unknownHomeDir, { recursive: true, force: true });
+  });
+
+  function notificationSettings(script: string): unknown {
+    return {
+      hooks: {
+        Notification: [
+          { hooks: [{ type: "command", command: process.execPath, args: [script] }] },
+        ],
+      },
+    };
+  }
+
+  function setUpOneLayer(script: string): void {
+    unknownProjectDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-unknown-launch-project-"),
+    );
+    unknownHomeDir = path.join(unknownProjectDir, "no-such-home");
+    mkdirSync(path.join(unknownProjectDir, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(unknownProjectDir, ".claude", "settings.json"),
+      JSON.stringify(notificationSettings(script), null, 2),
+    );
+  }
+
+  function setUpTwoLayers(userScript: string, projectScript: string): void {
+    unknownProjectDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-unknown-launch-project-"),
+    );
+    unknownHomeDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-unknown-launch-home-"),
+    );
+    mkdirSync(path.join(unknownProjectDir, ".claude"), { recursive: true });
+    mkdirSync(path.join(unknownHomeDir, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(unknownHomeDir, ".claude", "settings.json"),
+      JSON.stringify(notificationSettings(userScript), null, 2),
+    );
+    writeFileSync(
+      path.join(unknownProjectDir, ".claude", "settings.json"),
+      JSON.stringify(notificationSettings(projectScript), null, 2),
+    );
+  }
+
+  function fixturePath(): string {
+    const filePath = path.join(unknownProjectDir, "fixture.yaml");
+    writeFileSync(
+      filePath,
+      JSON.stringify({ cases: [{ event: "Notification", expect: {} }] }, null, 2),
+    );
+    return filePath;
+  }
+
+  const LAUNCH_ERROR = "spawn notify-hook ENOENT";
+
+  it("pretty states both the launch failure and the unknown reason on the UNKNOWN line", async () => {
+    setUpOneLayer(EXIT0_SILENT);
+    const spawner = new FakeSpawner(
+      new Map([[EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }]]),
+    );
+    const fp = fixturePath();
+
+    const pretty = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ cwd: unknownProjectDir, home: unknownHomeDir, spawner }),
+    );
+
+    const line = pretty.stdout.split("\n").find((l) => l.startsWith("UNKNOWN"));
+    expect(line).toBeDefined();
+    expect(line).toContain(`hook never launched: ${LAUNCH_ERROR}`);
+    expect(line).toContain("has no entry in the loaded spec");
+  });
+
+  it("github states both the launch failure and the unknown reason in one ::warning, never ::error", async () => {
+    setUpOneLayer(EXIT0_SILENT);
+    const spawner = new FakeSpawner(
+      new Map([[EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }]]),
+    );
+    const fp = fixturePath();
+
+    const github = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--format", "github"],
+      "hookassert",
+      testDeps({ cwd: unknownProjectDir, home: unknownHomeDir, spawner }),
+    );
+
+    expect(github.stdout).toMatch(/::warning file=.*,line=\d+,title=test case #0/);
+    expect(github.stdout).toContain(LAUNCH_ERROR);
+    expect(github.stdout).toContain("has no entry in the loaded spec");
+    expect(github.stdout).not.toContain("::error");
+  });
+
+  it("a multi-hook UNKNOWN case whose deciding hook never launched still attributes the hook exactly once (issue #64 regression)", async () => {
+    // The user-layer hook fires first and never launches; the project-layer
+    // hook fires second and runs normally. Both resolve "unknown"
+    // (event-not-in-spec), so the tie is broken by firing order
+    // (`combineDecisions`) and the launch-failed user-layer hook becomes
+    // `decidedBy` — the same hook `describeLaunchFailures` already names, so
+    // `decidedBySuffix` must not also append "— decided by …" for it.
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([[EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }]]),
+      { exitCode: 0 },
+    );
+    const fp = fixturePath();
+
+    const pretty = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ cwd: unknownProjectDir, home: unknownHomeDir, spawner }),
+    );
+
+    const line = pretty.stdout.split("\n").find((l) => l.startsWith("UNKNOWN"));
+    expect(line).toBeDefined();
+    expect(line).toContain(`hook never launched: ${LAUNCH_ERROR}`);
+    expect(line).toContain(`command "${process.execPath}"`);
+    expect(line).not.toContain("decided by");
+    const attributions = line?.match(/settings\.json:\d+/g) ?? [];
+    expect(attributions).toHaveLength(1);
+  });
+});
+
 describe("combining more than one firing hook (issue #42)", () => {
   // A dedicated project/home pair per test, isolated from the shared
   // projectDir's own settings.json: two hooks (one per settings layer) fire

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -173,6 +173,10 @@ interface JsonTestCase {
     readonly reason?: string;
     readonly decidedBy?: JsonDecidedBy | null;
   };
+  readonly launchFailures: readonly {
+    readonly hook: { readonly command: string };
+    readonly launchError: string;
+  }[];
 }
 
 interface JsonTestReportShape {
@@ -349,8 +353,8 @@ describe("launch failures (issue #39)", () => {
   it("pretty prints the launch-failure message and github annotates the hook's own declaration line", async () => {
     setUpLaunchFailProject();
     // Expects something a launch failure cannot satisfy, so the case fails
-    // and the launch message — not the raw exitCode/decision diff — is what
-    // both reporters show.
+    // and the launch message is shown alongside the raw exitCode diff — the
+    // launch failure never replaces it (issue #65).
     const fixturePath = launchFailFixturePath({
       cases: [{ event: "PreToolUse", tool: "LaunchFail", expect: { exitCode: 0 } }],
     });
@@ -364,6 +368,7 @@ describe("launch failures (issue #39)", () => {
     expect(pretty.stdout).toContain("hook never launched: spawn python33 ENOENT");
     expect(pretty.stdout).toContain('command "python33"');
     expect(pretty.stdout).toMatch(/settings\.json:\d+\)/);
+    expect(pretty.stdout).toContain("exitCode: expected 0, got -1");
     // The launch message already names the hook and its location, so the
     // "decided by" suffix (only relevant for multi-hook cases anyway) never
     // doubles up on it.
@@ -384,6 +389,286 @@ describe("launch failures (issue #39)", () => {
     );
     expect(github.stdout).toMatch(/::error file=\.claude\/settings\.json,line=\d+/);
     expect(github.stdout).toContain("hook never launched: spawn python33 ENOENT");
+  });
+});
+
+describe("a non-deciding hook's launch failure (issue #65)", () => {
+  // Two hooks, one per settings layer, so they do not collapse on
+  // `dedupeKey` — reusing #42's two-layer helpers with a `FakeSpawner` whose
+  // canned outcome for one script carries `launchError`.
+  let launchFailureProjectDir: string;
+  let launchFailureHomeDir: string;
+
+  afterEach(() => {
+    rmSync(launchFailureProjectDir, { recursive: true, force: true });
+    rmSync(launchFailureHomeDir, { recursive: true, force: true });
+  });
+
+  function settingsDeclaring(script: string): unknown {
+    return {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: process.execPath, args: [script] }],
+          },
+        ],
+      },
+    };
+  }
+
+  /** One hook in the user layer, one in the project layer, each running `userScript`/`projectScript`. */
+  function setUpTwoLayers(userScript: string, projectScript: string): void {
+    launchFailureProjectDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-launch-failure-project-"),
+    );
+    launchFailureHomeDir = mkdtempSync(
+      path.join(tmpdir(), "hookassert-launch-failure-home-"),
+    );
+    mkdirSync(path.join(launchFailureProjectDir, ".claude"), { recursive: true });
+    mkdirSync(path.join(launchFailureHomeDir, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(launchFailureHomeDir, ".claude", "settings.json"),
+      JSON.stringify(settingsDeclaring(userScript), null, 2),
+    );
+    writeFileSync(
+      path.join(launchFailureProjectDir, ".claude", "settings.json"),
+      JSON.stringify(settingsDeclaring(projectScript), null, 2),
+    );
+  }
+
+  function fixturePath(expect_: unknown): string {
+    const filePath = path.join(launchFailureProjectDir, "fixture.yaml");
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        { cases: [{ event: "PreToolUse", tool: "Bash", expect: expect_ }] },
+        null,
+        2,
+      ),
+    );
+    return filePath;
+  }
+
+  const LAUNCH_ERROR = "spawn cmd-launch-fail ENOENT";
+
+  it("a launch failure on a hook the deny outranks is reported and the case still passes", async () => {
+    // User layer never launches; project layer denies (exit 2). The deny
+    // wins the fold (#42), so the case passes despite carrying a launch
+    // failure that lost that fold — the Question 4 answer, pinned.
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([
+        [EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }],
+        [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+      ]),
+    );
+    const fp = fixturePath({ decision: "deny" });
+
+    const result = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.summary.failed).toBe(0);
+    const caseResult = report.cases[0];
+    expect(caseResult?.result.kind).toBe("pass");
+    expect(caseResult?.result.decidedBy?.decision.kind).toBe("deny");
+    expect(caseResult?.launchFailures).toHaveLength(1);
+    expect(caseResult?.launchFailures[0]?.launchError).toBe(LAUNCH_ERROR);
+    expect(caseResult?.launchFailures[0]?.hook.command).toBe(process.execPath);
+  });
+
+  it("the same run exits 0 under --ci", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([
+        [EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }],
+        [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+      ]),
+    );
+    const fp = fixturePath({ decision: "deny" });
+
+    const result = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--ci"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("pretty prints the launch failure on the passing case's own line", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([
+        [EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }],
+        [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+      ]),
+    );
+    const fp = fixturePath({ decision: "deny" });
+
+    const pretty = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    const line = pretty.stdout.split("\n").find((l) => l.startsWith("PASS"));
+    expect(line).toBeDefined();
+    expect(line).toContain(`hook never launched: ${LAUNCH_ERROR}`);
+    expect(line).toContain(`command "${process.execPath}"`);
+    expect(line).toMatch(/settings\.json:\d+\)/);
+  });
+
+  it("github annotates a passing case's launch failure as a warning", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([
+        [EXIT0_SILENT, { exitCode: -1, launchError: LAUNCH_ERROR }],
+        [EXIT2_STDERR, { exitCode: 2, stderr: "blocked by policy\n" }],
+      ]),
+    );
+    const fp = fixturePath({ decision: "deny" });
+
+    const github = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--format", "github"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    expect(github.stdout).toMatch(/::warning file=.*,line=\d+,title=test case #0/);
+    expect(github.stdout).toContain(LAUNCH_ERROR);
+    expect(github.stdout).not.toContain("::error");
+  });
+
+  it("a deciding hook's launch failure and another hook's expectation diff are both printed", async () => {
+    // The user-layer hook never launches and wins the fold ("error"
+    // outranks "pass"); the project-layer hook exits 0 printing nothing,
+    // and the fixture expects stdout it never produced.
+    setUpTwoLayers(EXIT2_STDERR, EXIT0_SILENT);
+    const spawner = new FakeSpawner(
+      new Map([[EXIT2_STDERR, { exitCode: -1, launchError: LAUNCH_ERROR }]]),
+      { exitCode: 0 },
+    );
+    const fp = fixturePath({ stdoutContains: "marker" });
+
+    const pretty = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    expect(pretty.stdout).toContain("FAIL");
+    expect(pretty.stdout).toContain(`hook never launched: ${LAUNCH_ERROR}`);
+    expect(pretty.stdout).toContain("stdoutContains:");
+    expect(pretty.stdout).not.toContain("decided by");
+  });
+
+  it("two hooks that never launch are both reported, in firing order", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const spawner = new FakeSpawner(
+      new Map([
+        [EXIT0_SILENT, { exitCode: -1, launchError: "spawn user-hook ENOENT" }],
+        [EXIT2_STDERR, { exitCode: -1, launchError: "spawn project-hook ENOENT" }],
+      ]),
+    );
+    const fp = fixturePath({ decision: "error" });
+
+    const result = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    const report = parseJsonReport(result.stdout);
+    const caseResult = report.cases[0];
+    expect(caseResult?.launchFailures).toHaveLength(2);
+    // Firing order is the settings merge order: user layer, then project.
+    expect(caseResult?.launchFailures.map((f) => f.launchError)).toEqual([
+      "spawn user-hook ENOENT",
+      "spawn project-hook ENOENT",
+    ]);
+  });
+
+  it("a case where nothing fired carries no launch failures", async () => {
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const filePath = path.join(launchFailureProjectDir, "no-fire.yaml");
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        { cases: [{ event: "SessionStart", expect: { fires: true } }] },
+        null,
+        2,
+      ),
+    );
+
+    const result = await runCli(
+      ["test", filePath, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({
+        cwd: launchFailureProjectDir,
+        home: launchFailureHomeDir,
+        spawner: new FakeSpawner(),
+      }),
+    );
+
+    const report = parseJsonReport(result.stdout);
+    const caseResult = report.cases[0];
+    expect(caseResult?.launchFailures).toEqual([]);
+    expect(caseResult?.result.kind).toBe("fail");
+    const pretty = await runCli(
+      ["test", filePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({
+        cwd: launchFailureProjectDir,
+        home: launchFailureHomeDir,
+        spawner: new FakeSpawner(),
+      }),
+    );
+    expect(pretty.stdout).toContain("no hook is declared under SessionStart");
+    expect(pretty.stdout).not.toContain("hook never launched");
+  });
+
+  it("a stubbed hook contributes no launch failure", async () => {
+    // Both layers declare the same command (`process.execPath`), so one
+    // stub entry keyed by command covers both hooks: neither reaches the
+    // spawner, and a stub's outcome can never carry a `launchError` (see
+    // `executor.ts`'s `stubbedOutcome`) — this proves the report reflects
+    // that rather than merely relying on it.
+    setUpTwoLayers(EXIT0_SILENT, EXIT2_STDERR);
+    const fp = path.join(launchFailureProjectDir, "stub.yaml");
+    writeFileSync(
+      fp,
+      JSON.stringify(
+        {
+          cases: [
+            {
+              event: "PreToolUse",
+              tool: "Bash",
+              stub: { [process.execPath]: { exitCode: 0 } },
+              expect: { fires: true },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const spawner = new FakeSpawner();
+    const result = await runCli(
+      ["test", fp, "--claude-version", "2.1.300", "--yes", "--format", "json"],
+      "hookassert",
+      testDeps({ cwd: launchFailureProjectDir, home: launchFailureHomeDir, spawner }),
+    );
+
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.cases[0]?.launchFailures).toEqual([]);
   });
 });
 


### PR DESCRIPTION
`assertCase` folds every firing hook's `Decision` into one verdict (#42), but `testReport` only ever rendered the winning hook. A launch failure on any *other* firing hook vanished from every output format, and a deciding hook's own launch failure replaced its expectation diffs instead of coexisting with them — so a case could go green (or fail for the wrong stated reason) while a hook silently never started.

`TestCaseReport` gains a `launchFailures` list — every firing hook whose process never started, in firing order — and `pretty`, `json` and `github` all render it without changing any verdict, count, or exit code. Per the issue's decided design, a non-deciding hook's launch failure never fails a case on its own (question 4).

Review follow-ons in the same diff: the `github` reporter no longer treats an `unknown` case like a passing one — an `unknown` case carrying a launch failure now states its `UnknownReason`s alongside the launch failure instead of dropping them (it would otherwise show a bare yellow warning on a run `--ci` exits 3 on), and the UNKNOWN attribution path that #64 fixed gains the regression test it was missing.

Closes #65

## Release impact

Release impact: no — nothing exported from `src/index.ts` changes. The new field lives on the internal `TestCaseReport` and on `test`'s own JSON report shape, whose `reportVersion` stays `"1"` (the same precedent as #64/`eb38271`).

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 40 test files / 1745 tests).
- New `tests/test-cmd.test.ts` coverage: a launch failure that loses the decision fold still passes the case (and under `--ci`); `pretty` prints it on the passing case's own line; `github` annotates it `::warning`, never `::error`; a deciding-hook launch failure and a sibling's expectation diff print together; two simultaneous launch failures print in firing order; a non-firing case and a stubbed hook both carry `[]`.
- New: an `unknown` case that also carries a launch failure states both the launch failure and every unknown reason; a multi-hook UNKNOWN case whose deciding hook never launched still attributes the hook's `file:line` exactly once.
- `tests/reporters.test.ts` schema suite extended with a two-hook `MultiHook` matcher (one launch-failing, one denying), proving the new `launchFailure` `$def` in `schema/test-report.schema.json` validates and that the `$defs` byte-identity test across the three shipped schemas stays green.
- `README.md`'s `test` section updated: launch failures are surfaced for every fired-but-never-launched hook, not only the deciding one.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
