### PR TITLE
feat: add test --concurrency <n> and name the cap in the consent prompt (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,24 +130,26 @@ hookassert --help
   confirmation; `--yes` and `--ci` both skip the prompt, and a non-interactive run given
   neither exits `6` with `ERR_CONSENT_REQUIRED` instead of running anything. `--dry-run`
   excludes every case from the spawn plan; `--claude-version`, `--settings` and
-  `--format` (`pretty`/`json`/`github`) mean exactly what they do for `explain`, and two
-  options are `test`'s own: `--timeout <ms>` sets the default hook timeout in
+  `--format` (`pretty`/`json`/`github`) mean exactly what they do for `explain`, and
+  three options are `test`'s own: `--timeout <ms>` sets the default hook timeout in
   milliseconds for hooks that declare none (a fixture file's own `defaults.timeoutMs`
-  still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
-  variable into every spawned hook's environment by name — a value is never accepted
-  here, only a name. When several hooks fire for one case, any deny wins; the report
-  names the hook that decided. A hook whose process never starts at all — an exec-form
-  hook (one declaring `args`) naming a command that does not exist, a missing
-  interpreter — resolves to `decision: error` (`cause: launch-failed`) rather than being
-  mistaken for a hook that ran and exited non-zero. A failing case's `pretty` and
-  `github` output then shows the OS-reported reason (`spawn python33 ENOENT`, say)
-  alongside the hook's own declaration, and the JSON report carries it as
-  `decidedBy.launchError`. A shell-form hook (no `args`, the shape Claude Code's own
-  docs show) always launches `/bin/sh` successfully, so a typo'd `command` there is
-  reported by the shell itself — usually exit `127` — not as `launch-failed`. Exits `0`
-  when every case passes (and, with `--ci`, none is `unknown` either), `1` when at least
-  one fails, and `3` when there are no failures but `--ci` was given and at least one
-  case is `unknown`.
+  still wins over it), a repeatable `--env <NAME>` opts one ambient environment variable
+  into every spawned hook's environment by name — a value is never accepted here, only a
+  name — and `--concurrency <n>` runs at most n hooks at once (default 8; use 1 for
+  hooks that must not overlap). The interactive consent prompt names the cap it will run
+  under (`up to 8 at a time`, or `one at a time` under `--concurrency 1`). When several
+  hooks fire for one case, any deny wins; the report names the hook that decided. A hook
+  whose process never starts at all — an exec-form hook (one declaring `args`) naming a
+  command that does not exist, a missing interpreter — resolves to `decision: error`
+  (`cause: launch-failed`) rather than being mistaken for a hook that ran and exited
+  non-zero. A failing case's `pretty` and `github` output then shows the OS-reported
+  reason (`spawn python33 ENOENT`, say) alongside the hook's own declaration, and the
+  JSON report carries it as `decidedBy.launchError`. A shell-form hook (no `args`, the
+  shape Claude Code's own docs show) always launches `/bin/sh` successfully, so a typo'd
+  `command` there is reported by the shell itself — usually exit `127` — not as
+  `launch-failed`. Exits `0` when every case passes (and, with `--ci`, none is `unknown`
+  either), `1` when at least one fails, and `3` when there are no failures but `--ci`
+  was given and at least one case is `unknown`.
 
   ```console
   $ hookassert test fixtures/force-push.fixture.yaml --ci

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import {
 } from "./internal/errors.js";
 import {
   executeHooks,
+  HOOKASSERT_DEFAULT_CONCURRENCY,
   HOOKASSERT_DEFAULT_TIMEOUT_MS,
   NodeVersionProbe,
   type ExecDeps,
@@ -119,7 +120,12 @@ const COMMANDS = [
   ["explain", "Show which hooks a tool event fires, and why."],
   ["lint", "Check hook declarations for matcher and command mistakes."],
   ["record", "Capture real hook payloads from a Claude Code session."],
-  ["test", "Replay recorded events and assert on what the hooks did."],
+  [
+    "test",
+    "Replay recorded events and assert on what the hooks did. " +
+      "--concurrency <n>: run at most n hooks at once (default 8; use 1 for " +
+      "hooks that must not overlap).",
+  ],
 ] as const;
 
 type Subcommand = (typeof COMMANDS)[number][0];
@@ -802,6 +808,7 @@ const TEST_OPTIONS = {
   ci: { type: "boolean" },
   "dry-run": { type: "boolean" },
   timeout: { type: "string" },
+  concurrency: { type: "string" },
   env: { type: "string", multiple: true },
   help: { type: "boolean", short: "h" },
 } as const;
@@ -851,6 +858,29 @@ function parseTimeoutOption(value: string | undefined): number | undefined {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new UsageError(
       `--timeout must be a positive number of milliseconds, got ${JSON.stringify(value)}.`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse `--concurrency`'s value into a positive integer worker-pool cap.
+ *
+ * @remarks
+ * Mirrors {@link parseTimeoutOption}'s shape: validated before any I/O, so an
+ * invalid value fails as a `UsageError` rather than reaching
+ * `executeHooks`'s own `RangeError`, which stays unreachable from the CLI.
+ *
+ * @throws {UsageError} `value` is defined but not an integer `>= 1`.
+ */
+function parseConcurrencyOption(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new UsageError(
+      `--concurrency must be a positive integer, got ${JSON.stringify(value)}.`,
     );
   }
   return parsed;
@@ -962,6 +992,14 @@ function resolveStepCwd(
  * `resolveDefaultTimeoutMs`'s ceiling rather than being silently clamped by
  * it — see `executor.ts`'s own remark on `ExecDeps.explicitDefaultTimeoutMs`.
  * A file's own declared default stays subject to that ceiling, unchanged.
+ *
+ * `cliConcurrencyOverride`, when given, is passed straight through as
+ * `ExecDeps.concurrency` — there is no fixture-level `defaults.concurrency`
+ * to take precedence over it, unlike the timeout fields above, and no
+ * `HOOKASSERT_*` environment variable either (see this issue's design: a
+ * second env var to document for a knob most users never touch was judged
+ * not worth it). Omitted entirely when absent, so `executeHooks` falls back
+ * to {@link HOOKASSERT_DEFAULT_CONCURRENCY} itself.
  */
 function buildExecDepsForFile(
   deps: CliDeps,
@@ -969,6 +1007,7 @@ function buildExecDepsForFile(
   spec: Spec,
   cliTimeoutOverrideMs: number | undefined,
   cliEnvNames: readonly string[],
+  cliConcurrencyOverride: number | undefined,
 ): ExecDeps {
   const fileEnv = file.defaults?.env ?? {};
   const fileTimeoutMs = file.defaults?.timeoutMs;
@@ -984,6 +1023,9 @@ function buildExecDepsForFile(
     ...(fileTimeoutMs === undefined && cliTimeoutOverrideMs !== undefined
       ? { explicitDefaultTimeoutMs: cliTimeoutOverrideMs }
       : {}),
+    ...(cliConcurrencyOverride === undefined
+      ? {}
+      : { concurrency: cliConcurrencyOverride }),
   };
 }
 
@@ -1055,6 +1097,11 @@ function assertConsentReachable(isTTY: boolean, yes: boolean, ci: boolean): void
  * non-interactive invocation that lacked `--yes`/`--ci`, so a non-empty
  * `spawnWorthy` reaching here is always on a TTY.
  *
+ * `concurrency` names the cap this run's commands will actually run under —
+ * `--concurrency`'s value when given, else {@link HOOKASSERT_DEFAULT_CONCURRENCY}
+ * — so a human approving a long command list knows whether they run one after
+ * another or several at once before answering.
+ *
  * @throws {ConsentRequiredError} the interactive prompt was declined.
  */
 async function gateConsent(
@@ -1062,13 +1109,18 @@ async function gateConsent(
   yes: boolean,
   ci: boolean,
   spawnWorthy: readonly ExecutionStep[],
+  concurrency: number,
 ): Promise<void> {
   if (spawnWorthy.length === 0 || yes || ci) {
     return;
   }
 
   const commandList = spawnWorthy.map(describeStepForConsent).join("\n");
-  const prompt = `About to run ${String(spawnWorthy.length)} command(s):\n${commandList}`;
+  const concurrencyNote =
+    concurrency === 1 ? "one at a time" : `up to ${String(concurrency)} at a time`;
+  const prompt =
+    `About to run ${String(spawnWorthy.length)} command(s), ${concurrencyNote}:\n` +
+    commandList;
   const approved = await deps.confirm(prompt);
   if (!approved) {
     throw new ConsentRequiredError(
@@ -1128,7 +1180,7 @@ interface FilePlan {
  * pipeline this issue's design section names end to end.
  *
  * @throws {UsageError} an option was malformed, no `<fixture>` was given, or
- * `--format`/`--timeout` was given an invalid value.
+ * `--format`/`--timeout`/`--concurrency` was given an invalid value.
  * @throws {ConsentRequiredError} consent to spawn was not obtained.
  * (Also propagates every load-time error `loadSpecFile`/`loadFixtures` can
  * throw — see those modules' own documentation.)
@@ -1159,6 +1211,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     );
   }
   const timeoutOverrideMs = parseTimeoutOption(parsed.values.timeout);
+  const concurrencyOverride = parseConcurrencyOption(parsed.values.concurrency);
 
   const explicitSettings = parsed.values.settings;
   const sources = resolveSettingsSources(explicitSettings, deps);
@@ -1205,6 +1258,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
       spec,
       timeoutOverrideMs,
       cliEnvNames,
+      concurrencyOverride,
     );
     const filePlan: FilePlan = {
       fixturePath,
@@ -1272,6 +1326,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     parsed.values.yes === true,
     parsed.values.ci === true,
     spawnWorthy,
+    concurrencyOverride ?? HOOKASSERT_DEFAULT_CONCURRENCY,
   );
 
   // Sequential, not `Promise.all`: each `executeHooks` call runs its own

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,12 +120,7 @@ const COMMANDS = [
   ["explain", "Show which hooks a tool event fires, and why."],
   ["lint", "Check hook declarations for matcher and command mistakes."],
   ["record", "Capture real hook payloads from a Claude Code session."],
-  [
-    "test",
-    "Replay recorded events and assert on what the hooks did. " +
-      "--concurrency <n>: run at most n hooks at once (default 8; use 1 for " +
-      "hooks that must not overlap).",
-  ],
+  ["test", "Replay recorded events and assert on hook behavior [--concurrency <n>]."],
 ] as const;
 
 type Subcommand = (typeof COMMANDS)[number][0];
@@ -1097,10 +1092,13 @@ function assertConsentReachable(isTTY: boolean, yes: boolean, ci: boolean): void
  * non-interactive invocation that lacked `--yes`/`--ci`, so a non-empty
  * `spawnWorthy` reaching here is always on a TTY.
  *
- * `concurrency` names the cap this run's commands will actually run under —
- * `--concurrency`'s value when given, else {@link HOOKASSERT_DEFAULT_CONCURRENCY}
- * — so a human approving a long command list knows whether they run one after
- * another or several at once before answering.
+ * `concurrency` is the configured cap — `--concurrency`'s value when given,
+ * else {@link HOOKASSERT_DEFAULT_CONCURRENCY} — but the prompt reports
+ * `Math.min(concurrency, spawnWorthy.length)`: the cap can never be reached
+ * by fewer commands than the cap allows, so naming the configured cap would
+ * overstate how parallel the run actually is. This is how a human approving
+ * a long command list knows whether they run one after another or several at
+ * once before answering.
  *
  * @throws {ConsentRequiredError} the interactive prompt was declined.
  */
@@ -1116,8 +1114,11 @@ async function gateConsent(
   }
 
   const commandList = spawnWorthy.map(describeStepForConsent).join("\n");
+  const achievableConcurrency = Math.min(concurrency, spawnWorthy.length);
   const concurrencyNote =
-    concurrency === 1 ? "one at a time" : `up to ${String(concurrency)} at a time`;
+    achievableConcurrency === 1
+      ? "one at a time"
+      : `up to ${String(achievableConcurrency)} at a time`;
   const prompt =
     `About to run ${String(spawnWorthy.length)} command(s), ${concurrencyNote}:\n` +
     commandList;

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -53,8 +53,8 @@ export const HOOKASSERT_DEFAULT_TIMEOUT_MS = 10_000;
  * switching), and I/O-bound throughput keeps improving past `8` only with
  * sharply diminishing returns. A fixed default also keeps a run's behavior
  * independent of the machine it happens to run on. {@link ExecDeps.concurrency}
- * overrides this per run; wiring a `--concurrency` flag to it is a
- * CLI-surface addition left for a future change.
+ * overrides this per run; `test --concurrency <n>` in `src/cli.ts` is the CLI
+ * surface that sets it.
  */
 export const HOOKASSERT_DEFAULT_CONCURRENCY = 8;
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -120,6 +120,13 @@ describe("runCli help", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("--help for test mentions --concurrency", async () => {
+    const result = await runCli(["test", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("--concurrency");
+  });
+
   it("exits 0 with the usage text when given no arguments", async () => {
     // Deliberate: a bare invocation stays exit 0, as it was before subcommand
     // dispatch existed. Only the empty stdout changes — printing the commands

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -120,7 +120,7 @@ describe("runCli help", () => {
     expect(result.stderr).toBe("");
   });
 
-  it("--help for test mentions --concurrency", async () => {
+  it("the global usage text mentions --concurrency", async () => {
     const result = await runCli(["test", "--help"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -727,6 +727,48 @@ describe("the consent gate", () => {
     expect(spawner.calls).toHaveLength(1);
     expect(promptSeen).toContain(process.execPath);
   });
+
+  it("names the default cap in the prompt (up to 8 at a time)", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+    let promptSeen = "";
+
+    await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300"],
+      "hookassert",
+      testDeps({
+        spawner,
+        isTTY: true,
+        confirm: (prompt) => {
+          promptSeen = prompt;
+          return Promise.resolve(true);
+        },
+      }),
+    );
+
+    expect(promptSeen).toContain("About to run 1 command(s), up to 8 at a time:");
+  });
+
+  it("names a --concurrency 1 cap in the prompt as one at a time", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = singlePassingCaseFixture();
+    let promptSeen = "";
+
+    await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--concurrency", "1"],
+      "hookassert",
+      testDeps({
+        spawner,
+        isTTY: true,
+        confirm: (prompt) => {
+          promptSeen = prompt;
+          return Promise.resolve(true);
+        },
+      }),
+    );
+
+    expect(promptSeen).toContain("About to run 1 command(s), one at a time:");
+  });
 });
 
 describe("--dry-run and stub-only exclusion from the spawn plan", () => {
@@ -869,6 +911,113 @@ describe("--timeout", () => {
     expect(result.exitCode).toBe(0);
     const hookCall = spawner.calls.find((call) => call.command !== "claude");
     expect(hookCall?.timeoutMs).toBe(900_000);
+  });
+});
+
+describe("--concurrency", () => {
+  it.each(["0", "-1", "1.5", "abc", ""])(
+    "rejects --concurrency %j with ERR_USAGE and spawns nothing",
+    async (value) => {
+      const spawner = new FakeSpawner();
+      const fixturePath = writeFixture({
+        cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+      });
+
+      const result = await runCli(
+        [
+          "test",
+          fixturePath,
+          "--claude-version",
+          "2.1.300",
+          "--yes",
+          "--concurrency",
+          value,
+        ],
+        "hookassert",
+        testDeps({ spawner }),
+      );
+
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr).toContain("ERR_USAGE");
+      expect(spawner.calls).toHaveLength(0);
+    },
+  );
+
+  /**
+   * A `Spawner` whose calls stay pending until manually released one at a
+   * time, and which records the maximum number of calls in flight at once —
+   * the same shape as the `GatedSpawner` in the cross-file concurrency
+   * suite above, but releasing a single call rather than every pending one,
+   * so a test can prove a second call is never issued while the first is
+   * still outstanding.
+   */
+  class SingleReleaseGatedSpawner implements Spawner {
+    readonly calls: SpawnRequest[] = [];
+    readonly #pending: (() => void)[] = [];
+    #current = 0;
+    maxObserved = 0;
+
+    spawn(req: SpawnRequest): Promise<ExecOutcome> {
+      this.calls.push(req);
+      this.#current += 1;
+      this.maxObserved = Math.max(this.maxObserved, this.#current);
+      return new Promise((resolve) => {
+        this.#pending.push(() => {
+          this.#current -= 1;
+          resolve({
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: false,
+            launchError: undefined,
+          });
+        });
+      });
+    }
+
+    /** Resolves the single oldest pending call, letting its worker move on. */
+    releaseOne(): void {
+      const next = this.#pending.shift();
+      next?.();
+    }
+  }
+
+  it("--concurrency 1 runs firing hooks one at a time", async () => {
+    const spawner = new SingleReleaseGatedSpawner();
+    const fixturePath = writeFixture({
+      cases: [
+        { event: "PreToolUse", tool: "Bash", expect: {} },
+        { event: "PreToolUse", tool: "Write", expect: {} },
+        { event: "PreToolUse", tool: "Edit", expect: {} },
+      ],
+    });
+
+    const resultPromise = runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--concurrency",
+        "1",
+      ],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    for (let released = 0; released < 3; released += 1) {
+      await vi.waitFor(() => {
+        expect(spawner.calls.length).toBeGreaterThan(released);
+      });
+      spawner.releaseOne();
+    }
+
+    const result = await resultPromise;
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(3);
+    expect(spawner.maxObserved).toBe(1);
   });
 });
 

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -728,7 +728,38 @@ describe("the consent gate", () => {
     expect(promptSeen).toContain(process.execPath);
   });
 
-  it("names the default cap in the prompt (up to 8 at a time)", async () => {
+  it("names the default cap in the prompt when there are more commands than the cap", async () => {
+    const spawner = new FakeSpawner();
+    const tools = ["Bash", "Write", "Edit"] as const;
+    const fixturePath = writeFixture({
+      // 9 spawn-worthy cases so the default cap of 8 is actually reachable —
+      // with fewer commands than the cap, `gateConsent` reports the smaller
+      // achievable concurrency instead (see the single-command test above).
+      cases: Array.from({ length: 9 }, (_, i) => ({
+        event: "PreToolUse",
+        tool: tools[i % tools.length],
+        expect: {},
+      })),
+    });
+    let promptSeen = "";
+
+    await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300"],
+      "hookassert",
+      testDeps({
+        spawner,
+        isTTY: true,
+        confirm: (prompt) => {
+          promptSeen = prompt;
+          return Promise.resolve(true);
+        },
+      }),
+    );
+
+    expect(promptSeen).toContain("About to run 9 command(s), up to 8 at a time:");
+  });
+
+  it("names the achievable concurrency in the prompt when it is below the cap", async () => {
     const spawner = new FakeSpawner();
     const fixturePath = singlePassingCaseFixture();
     let promptSeen = "";
@@ -746,7 +777,7 @@ describe("the consent gate", () => {
       }),
     );
 
-    expect(promptSeen).toContain("About to run 1 command(s), up to 8 at a time:");
+    expect(promptSeen).toContain("About to run 1 command(s), one at a time:");
   });
 
   it("names a --concurrency 1 cap in the prompt as one at a time", async () => {
@@ -947,7 +978,7 @@ describe("--concurrency", () => {
    * A `Spawner` whose calls stay pending until manually released one at a
    * time, and which records the maximum number of calls in flight at once —
    * the same shape as the `GatedSpawner` in the cross-file concurrency
-   * suite above, but releasing a single call rather than every pending one,
+   * suite below, but releasing a single call rather than every pending one,
    * so a test can prove a second call is never issued while the first is
    * still outstanding.
    */


### PR DESCRIPTION
`hookassert test` has capped hook fan-out at 8 concurrent spawns since #40, but the consent prompt never said so — a user approving 200 commands could reasonably assume they run one after another — and there was no way to lower the cap for hooks that share a lock file or a port.

Adds `--concurrency <n>` to `test` (integer `>= 1`, otherwise `ERR_USAGE` at option-parse time before any spawn, mirroring `--timeout`), wires it through `buildExecDepsForFile` into `ExecDeps.concurrency`, and changes the consent prompt to read `About to run N command(s), up to K at a time:` (`one at a time` when K is 1). Per review, K is `Math.min(configured cap, command count)`, so the note states how parallel the run will actually be rather than a cap it cannot reach.

Closes #50

## Release impact

Release impact: yes — MINOR. Adds a new opt-in CLI flag; behavior is unchanged when it is not passed, and nothing exported from `src/index.ts` changes.

## Notes

The issue's checklist asked for `test --help` to document the flag. There is no per-subcommand help text today — `runCli` returns the same global usage for any argv containing `--help`, and each subcommand's parsed `help` value is never read — so the flag is named compactly in `test`'s row of the global usage text and documented properly in `README.md`, where `test`'s other options already live. Building real per-subcommand help is filed separately as #75.

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 40 test files / 1744 tests), re-run after merging `main`.
- `pnpm exec vitest run tests/test-cmd.test.ts tests/cli.test.ts` → pass.
- New coverage: `it.each(["0", "-1", "1.5", "abc", ""])` rejects each `--concurrency` value with `ERR_USAGE`, exit 4, and zero spawns; `--concurrency 1` against a gated spawner proves at most one hook is in flight across three firing hooks; the consent prompt is asserted to read `up to 8 at a time` with 9 commands, `one at a time` under `--concurrency 1`, and `one at a time` with a single command under the default cap.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
