### PR TITLE
fix: exempt a fixture's own defaults.timeoutMs from the spec ceiling and skip the version probe under --dry-run (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,30 +129,32 @@ hookassert --help
   consent first: on a terminal it prints the exact commands about to run and waits for
   confirmation; `--yes` and `--ci` both skip the prompt, and a non-interactive run given
   neither exits `6` with `ERR_CONSENT_REQUIRED` instead of running anything. `--dry-run`
-  excludes every case from the spawn plan; `--claude-version`, `--settings` and
-  `--format` (`pretty`/`json`/`github`) mean exactly what they do for `explain`, and two
-  options are `test`'s own: `--timeout <ms>` sets the default hook timeout in
-  milliseconds for hooks that declare none (a fixture file's own `defaults.timeoutMs`
-  still wins over it), and a repeatable `--env <NAME>` opts one ambient environment
-  variable into every spawned hook's environment by name — a value is never accepted
-  here, only a name. When several hooks fire for one case, any deny wins; the report
-  names the hook that decided. A hook whose process never starts at all — an exec-form
-  hook (one declaring `args`) naming a command that does not exist, a missing
-  interpreter — resolves to `decision: error` (`cause: launch-failed`) rather than being
-  mistaken for a hook that ran and exited non-zero. Every hook that fired for a case and
-  never launched is surfaced, not only the one whose decision decided the case's
-  verdict: `pretty` and `github` show the OS-reported reason (`spawn python33 ENOENT`,
-  say) alongside the hook's own declaration on the case's own PASS/UNKNOWN/FAIL line,
-  whichever that case's verdict turned out to be — `github` emits an error annotation
-  for a failing case and a warning annotation for a passing or unknown one, since
-  neither of those verdicts is itself a failure. The JSON report carries every launch
-  failure for the case as `launchFailures[]`, including the deciding hook's own, which
-  duplicates what `decidedBy.launchError` already reports. A shell-form hook (no `args`,
-  the shape Claude Code's own docs show) always launches `/bin/sh` successfully, so a
-  typo'd `command` there is reported by the shell itself — usually exit `127` — not as
-  `launch-failed`. Exits `0` when every case passes (and, with `--ci`, none is `unknown`
-  either), `1` when at least one fails, and `3` when there are no failures but `--ci`
-  was given and at least one case is `unknown`.
+  excludes every case from the spawn plan and, when neither `--claude-version` nor
+  `HOOKASSERT_CLAUDE_VERSION` resolves a version, skips the `claude --version` probe too
+  — a dry run launches nothing, and the report header reads `undetermined` accordingly;
+  `--claude-version`, `--settings` and `--format` (`pretty`/`json`/`github`) mean
+  exactly what they do for `explain`, and two options are `test`'s own: `--timeout <ms>`
+  sets the default hook timeout in milliseconds for hooks that declare none (a fixture
+  file's own `defaults.timeoutMs` still wins over it), and a repeatable `--env <NAME>`
+  opts one ambient environment variable into every spawned hook's environment by name —
+  a value is never accepted here, only a name. When several hooks fire for one case, any
+  deny wins; the report names the hook that decided. A hook whose process never starts
+  at all — an exec-form hook (one declaring `args`) naming a command that does not
+  exist, a missing interpreter — resolves to `decision: error` (`cause: launch-failed`)
+  rather than being mistaken for a hook that ran and exited non-zero. Every hook that
+  fired for a case and never launched is surfaced, not only the one whose decision
+  decided the case's verdict: `pretty` and `github` show the OS-reported reason
+  (`spawn python33 ENOENT`, say) alongside the hook's own declaration on the case's own
+  PASS/UNKNOWN/FAIL line, whichever that case's verdict turned out to be — `github`
+  emits an error annotation for a failing case and a warning annotation for a passing or
+  unknown one, since neither of those verdicts is itself a failure. The JSON report
+  carries every launch failure for the case as `launchFailures[]`, including the
+  deciding hook's own, which duplicates what `decidedBy.launchError` already reports. A
+  shell-form hook (no `args`, the shape Claude Code's own docs show) always launches
+  `/bin/sh` successfully, so a typo'd `command` there is reported by the shell itself —
+  usually exit `127` — not as `launch-failed`. Exits `0` when every case passes (and,
+  with `--ci`, none is `unknown` either), `1` when at least one fails, and `3` when
+  there are no failures but `--ci` was given and at least one case is `unknown`.
 
   ```console
   $ hookassert test fixtures/force-push.fixture.yaml --ci

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -815,10 +815,19 @@ const TEST_OPTIONS = {
  * `--claude-version` and {@link CLAUDE_VERSION_ENV_VAR} are resolved exactly
  * as {@link resolveVersionContext} already does for `explain`/`lint`
  * (including its `UsageError` on an invalid value); `probe.detect()` is
- * tried only when both of those came back empty, and "last recorded
- * session's version" — the step between the probe and `"undetermined"` — is
- * a documented no-op until `record`'s own session bookkeeping (`#15`) ships:
- * there is nothing to read yet, so this always falls through past it.
+ * tried only when both of those came back empty *and* `skipProbe` is
+ * `false`, and "last recorded session's version" — the step between the
+ * probe and `"undetermined"` — is a documented no-op until `record`'s own
+ * session bookkeeping (`#15`) ships: there is nothing to read yet, so this
+ * always falls through past it.
+ *
+ * `skipProbe` is `test`'s own `--dry-run`: a dry run launches no hook at
+ * all, and spawning `claude --version` anyway would make "dry run" a lie.
+ * Skipping the step this way — rather than reordering the steps around it —
+ * keeps the fixed four-step order intact for every other case; a dry run
+ * with `--claude-version` or {@link CLAUDE_VERSION_ENV_VAR} set still resolves
+ * to that value, since `skipProbe` is only consulted once the first two
+ * steps have already come back empty.
  *
  * @throws {UsageError} `claudeVersionFlag` (or the environment variable, when
  * the flag is absent) is not a `major.minor.patch` string.
@@ -827,14 +836,17 @@ async function resolveVersionContextForTest(
   claudeVersionFlag: string | undefined,
   env: Readonly<Record<string, string | undefined>>,
   probe: VersionProbe,
+  skipProbe: boolean,
 ): Promise<VersionContext> {
   const direct = resolveVersionContext(claudeVersionFlag, env);
   if (direct.kind === "known") {
     return direct;
   }
-  const probed = await probe.detect();
-  if (probed !== undefined) {
-    return { kind: "known", version: probed };
+  if (!skipProbe) {
+    const probed = await probe.detect();
+    if (probed !== undefined) {
+      return { kind: "known", version: probed };
+    }
   }
   return { kind: "undetermined" };
 }
@@ -957,12 +969,15 @@ function resolveStepCwd(
  * explicit default is more specific than a run-wide override — which in turn
  * takes precedence over `HOOKASSERT_DEFAULT_TIMEOUT_MS`.
  *
- * `explicitDefaultTimeoutMs` is set from `cliTimeoutOverrideMs` only when no
- * `file.defaults.timeoutMs` applies: `--timeout` is what the design calls "an
- * override for the whole run", so it must actually win over
- * `resolveDefaultTimeoutMs`'s ceiling rather than being silently clamped by
- * it — see `executor.ts`'s own remark on `ExecDeps.explicitDefaultTimeoutMs`.
- * A file's own declared default stays subject to that ceiling, unchanged.
+ * `explicitDefaultTimeoutMs` is set from whichever of `file.defaults.timeoutMs`
+ * and `cliTimeoutOverrideMs` applies (the former winning when both do, per the
+ * precedence above): both are an explicit instruction — a value someone
+ * actually wrote down, in a fixture file or on the command line — rather than
+ * a computed fallback, so both bypass `resolveDefaultTimeoutMs`'s ceiling
+ * rather than being silently clamped by it — see `executor.ts`'s own remark on
+ * `ExecDeps.explicitDefaultTimeoutMs`. Only the case where neither is declared
+ * — hookassert's own computed default against the spec's ceiling — stays
+ * subject to that ceiling, unchanged.
  */
 function buildExecDepsForFile(
   deps: CliDeps,
@@ -973,6 +988,7 @@ function buildExecDepsForFile(
 ): ExecDeps {
   const fileEnv = file.defaults?.env ?? {};
   const fileTimeoutMs = file.defaults?.timeoutMs;
+  const explicitDefaultTimeoutMs = fileTimeoutMs ?? cliTimeoutOverrideMs;
   return {
     spawner: deps.spawner,
     projectRoot: deps.cwd,
@@ -980,11 +996,9 @@ function buildExecDepsForFile(
     providedEnvKeys: spec.hookEnv.provided,
     allowedEnvKeys: [...cliEnvNames, ...Object.keys(fileEnv)],
     hookassertDefaultTimeoutMs:
-      fileTimeoutMs ?? cliTimeoutOverrideMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
+      explicitDefaultTimeoutMs ?? HOOKASSERT_DEFAULT_TIMEOUT_MS,
     specDefaultTimeoutMs: spec.defaults.hookTimeoutMs,
-    ...(fileTimeoutMs === undefined && cliTimeoutOverrideMs !== undefined
-      ? { explicitDefaultTimeoutMs: cliTimeoutOverrideMs }
-      : {}),
+    ...(explicitDefaultTimeoutMs === undefined ? {} : { explicitDefaultTimeoutMs }),
   };
 }
 
@@ -1191,6 +1205,7 @@ async function runTest(args: readonly string[], deps: CliDeps): Promise<CliResul
     parsed.values["claude-version"],
     deps.env,
     probe,
+    dryRunFlag,
   );
 
   const discoveredSettings = loadSettings(sources);

--- a/src/internal/exec/executor.ts
+++ b/src/internal/exec/executor.ts
@@ -258,8 +258,9 @@ export interface ExecDeps {
   readonly specDefaultTimeoutMs: number;
 
   /**
-   * A default timeout the caller declared explicitly (`test`'s own
-   * `--timeout <ms>`), rather than one hookassert computed on its own.
+   * A default timeout the caller declared explicitly — `test`'s own
+   * `--timeout <ms>`, or a fixture file's own `defaults.timeoutMs` — rather
+   * than one hookassert computed on its own.
    *
    * @remarks
    * When present, this is the default {@link buildSpawnRequest} uses for a
@@ -267,12 +268,13 @@ export interface ExecDeps {
    * {@link resolveDefaultTimeoutMs}'s ceiling against `specDefaultTimeoutMs`
    * entirely, the same exemption a hook's own declared `timeoutMs` already
    * gets (see `buildSpawnRequest`'s own remark). A value the user typed on
-   * the command line is at least as explicit as one written into a hook's
-   * `settings.json` entry: hookassert's ceiling exists to bound the case
-   * where nobody said how long is acceptable, not to second-guess a duration
-   * the user actually asked for. `undefined` when `--timeout` was not given,
-   * in which case the computed default is still `min(hookassert's default,
-   * spec.defaults.hookTimeoutMs)`, unchanged.
+   * the command line, or wrote into a fixture file's own `defaults`, is at
+   * least as explicit as one written into a hook's `settings.json` entry:
+   * hookassert's ceiling exists to bound the case where nobody said how long
+   * is acceptable, not to second-guess a duration the user actually asked
+   * for. `undefined` when neither `--timeout` nor a fixture file's own
+   * `defaults.timeoutMs` was given, in which case the computed default is
+   * still `min(hookassert's default, spec.defaults.hookTimeoutMs)`, unchanged.
    */
   readonly explicitDefaultTimeoutMs?: number;
 

--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -1259,6 +1259,52 @@ describe("ClaudeVersion resolution order", () => {
     const probeCall = spawner.calls.find((call) => call.command === "claude");
     expect(probeCall?.args).toEqual(["--version"]);
   });
+
+  it("--dry-run skips the version probe and reports the version as undetermined (#44)", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--dry-run", "--format", "json"],
+      "hookassert",
+      testDeps({ spawner, env: {} }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Nothing spawns at all under --dry-run: not the hook (already covered
+    // elsewhere), and — the point of this test — not the version probe either.
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.header.claudeVersion).toBe("undetermined");
+  });
+
+  it("--dry-run still resolves the version from --claude-version, without probing", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--dry-run",
+        "--claude-version",
+        "2.1.300",
+        "--format",
+        "json",
+      ],
+      "hookassert",
+      testDeps({ spawner, env: {} }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(spawner.calls).toHaveLength(0);
+    const report = parseJsonReport(result.stdout);
+    expect(report.header.claudeVersion).toBe("2.1.300");
+  });
 });
 
 describe("--timeout", () => {
@@ -1280,6 +1326,55 @@ describe("--timeout", () => {
         "--yes",
         "--timeout",
         "900000",
+      ],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const hookCall = spawner.calls.find((call) => call.command !== "claude");
+    expect(hookCall?.timeoutMs).toBe(900_000);
+  });
+});
+
+describe("a fixture file's own defaults.timeoutMs", () => {
+  it("above the spec's own ceiling is honored, not clamped", async () => {
+    const spawner = new FakeSpawner();
+    // Mirrors the --timeout test above: a fixture's own explicit default is
+    // exempt from resolveDefaultTimeoutMs's ceiling for the same reason
+    // --timeout and a hook's own declared timeoutMs already are (#44).
+    const fixturePath = writeFixture({
+      defaults: { timeoutMs: 900_000, env: {}, cwd: "." },
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const hookCall = spawner.calls.find((call) => call.command !== "claude");
+    expect(hookCall?.timeoutMs).toBe(900_000);
+  });
+
+  it("wins over --timeout when both are declared, per the documented precedence", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      defaults: { timeoutMs: 900_000, env: {}, cwd: "." },
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      [
+        "test",
+        fixturePath,
+        "--claude-version",
+        "2.1.300",
+        "--yes",
+        "--timeout",
+        "5000",
       ],
       "hookassert",
       testDeps({ spawner }),


### PR DESCRIPTION
Two small, separately verified inconsistencies left over from wiring the `test` subcommand (#11).

**1. A fixture file's own `defaults.timeoutMs` was silently clamped while `--timeout` was not.** `explicitDefaultTimeoutMs` was set only from `cliTimeoutOverrideMs`, so a run-wide `--timeout` bypassed `resolveDefaultTimeoutMs`'s ceiling against the spec's `defaults.hookTimeoutMs` but a fixture file's own declared default did not — inverting the documented precedence, under which the file's value is the *more* specific of the two. Both are now exempt (the file's value winning when both are declared), which is the same exemption a hook's own declared `timeoutMs` already had. Only hookassert's computed fallback stays subject to the ceiling.

**2. `--dry-run` still spawned the version probe.** A dry run excludes every case from the spawn plan, yet `resolveVersionContextForTest` ran `claude --version` anyway. The probe step is now skipped under `--dry-run`, falling back to `undetermined` — and only after the `--claude-version` flag and `HOOKASSERT_CLAUDE_VERSION` steps have come back empty, so a dry run with either of those still resolves the version it was given, without spawning anything.

The issue left fix 2 as an explicit either/or (skip the probe, or keep it and document it); this takes the skip branch, so that "dry run" means what it says.

Closes #44

## Release impact

Release impact: no — internal fixes to `test`'s CLI behavior; no exported symbol in `src/index.ts` and no error `code` changes.

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 40 test files / 1749 tests).
- New tests in `tests/test-cmd.test.ts`: an above-ceiling `defaults.timeoutMs` in a fixture file is honored, and it wins over `--timeout` when both are declared; `--dry-run` with no explicit version spawns nothing and reports `undetermined`; `--dry-run` with `--claude-version` still resolves that version without spawning.
- `README.md`'s `test` section documents both behaviors.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
