### PR TITLE
chore: prepare release readiness for v0.1.0 (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,5 @@ Initial release.
   probe used to resolve `undetermined`.
 - A black-box conformance harness proving the CLI's observable behavior — output,
   exit codes, and report shapes — against recorded transcripts.
+
+[0.1.0]: https://github.com/tomada1114/hookassert/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,53 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release pull requests update this file as part of the reviewed release process.
+
+## [0.1.0] - 2026-09-04
+
+Initial release.
+
+### Added
+
+- `hookassert explain <event> [tool]` shows which hooks a tool event fires, and why —
+  every firing hook printed with its settings layer, source file, and line, and every
+  non-firing matcher printed with the reason. It never spawns a process.
+- `hookassert lint` is a zero-execution static check over your settings tree: it reports
+  a dead exact-match matcher, a case mismatch, an unanchored regex that over-matches, and
+  a comma- or hyphen-notation matcher used against a Claude Code version that cannot be
+  confirmed to support it. A version-notation finding distinguishes "version known but
+  outside the spec's declared range" from "version could not be determined".
+- `hookassert record` inserts a side-effect-free capture hook into your local settings
+  layer so a real Claude Code session accumulates real hook payloads as envelope files;
+  `hookassert record --stop` removes it again with a byte-for-byte restore guarantee, or
+  a clear error when something else edited the settings file in the meantime.
+  `hookassert explain --emit-fixtures <dir>` turns captured payloads into ready-to-edit
+  fixture files.
+- `hookassert test <fixture>...` replays one or more YAML fixtures against your merged
+  settings, runs the hooks that actually fire, and asserts what happened against each
+  case's declared `expect` (`fires`, `decision`, `exitCode`, `stdoutContains`,
+  `stderrContains`, `context`, `updatedInput`, `timedOut`). It is the one command that
+  spawns processes, so it asks for consent first — on a terminal it prints every exact
+  command about to run and waits for confirmation; `--yes` and `--ci` skip the prompt,
+  and a non-interactive run given neither exits without spawning anything. `--dry-run`,
+  a fixture case's own `dryRun: true`, and `stub` all keep a case out of the spawn plan.
+  `--timeout`, a repeatable `--env <NAME>`, and `--concurrency <n>` (default 8; the
+  consent prompt states how many commands will run at once) tune a run. A hook whose
+  process never starts at all is reported as `decision: error` (`cause: launch-failed`)
+  rather than mistaken for a hook that ran and exited non-zero, and every firing hook's
+  launch failure for a case is surfaced in the JSON report's `launchFailures[]` array,
+  not only the deciding hook's. When no hook fires at all, `fires: false` passes as the
+  explicit "nothing should fire" case; a case pairing `fires: false` with any other
+  `expect` field is rejected when the fixture loads, and a case that declares any other
+  `expect` field with nothing firing fails outright instead of silently passing.
+- `pretty`, `json`, and `github` report formats across `explain`, `lint`, and `test`,
+  including GitHub Actions error/warning annotations.
+- A spec-driven matcher and decision engine, versioned against a declared Claude Code
+  release range, resolving which hooks fire for a given event and tool and folding every
+  firing hook's exit code and JSON output into one case verdict (any deny wins).
+- A three-layer settings merge (user, project, local) with per-hook provenance (file and
+  line), and a fixture format (`settings`, `defaults`, `cases`) with its own schema for
+  editor validation. A fixture's own `defaults.timeoutMs` is honored as written, never
+  clamped by the spec's timeout ceiling; `--dry-run` never spawns the Claude Code version
+  probe used to resolve `undetermined`.
+- A black-box conformance harness proving the CLI's observable behavior — output,
+  exit codes, and report shapes — against recorded transcripts.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
   "name": "hookassert",
-  "version": "0.0.0",
-  "description": "Test your Claude Code hooks like code: replay tool events against your merged settings, run the matching hooks, and fail CI when one doesn't fire or doesn't block.",
-  "keywords": [],
+  "version": "0.1.0",
+  "description": "Test your Claude Code hooks like code: replay tool events against your merged settings, run the matching hooks, and fail CI when one doesn't fire, doesn't block, or exits in a way you didn't declare.",
+  "keywords": [
+    "claude-code",
+    "claude",
+    "hooks",
+    "testing",
+    "test",
+    "cli",
+    "ci",
+    "lint",
+    "fixtures"
+  ],
   "license": "MIT",
   "author": "tomada <tmasuyama1114@gmail.com>",
   "repository": {

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -467,6 +467,107 @@ export function checkBinCommands(consumer, packageName, manifest) {
 }
 
 /**
+ * Exercise `explain` and `lint` against a tiny fixture project, once
+ * `checkBinCommands` has already proven `--help` works.
+ *
+ * @remarks
+ * `--help` and the type-only import check both pass even when the settings
+ * loader is broken — neither one ever reads a real settings file. This is
+ * the check that would have caught a missing runtime dependency
+ * (`jsonc-parser`, `yaml`) or a broken `bin` entry point once given
+ * something real to load: it writes a one-hook fixture settings file into
+ * the consumer, then runs `explain` and `lint` against it exactly the way a
+ * user's own project would.
+ *
+ * The fixture's hook command is `echo hookassert-smoke-ok` — `echo` is a
+ * shell builtin, so `lint`'s `command-not-found` rule (and the
+ * shebang/executable-bit rules downstream of it) never try to resolve it on
+ * disk. The matcher `"Bash"` is a single, correctly-cased literal, so no
+ * matcher rule fires either. A clean fixture keeps this check about whether
+ * the two commands *run* against a real settings file, not about whether
+ * lint's own rules are correct — that is `tests/cli.test.ts`'s job.
+ *
+ * Specific to hookassert's own subcommands on purpose: skipped entirely for
+ * a packed manifest that does not declare the `hookassert` bin command, so
+ * this stays inert rather than false-failing for anything else built on
+ * this template.
+ *
+ * @param {string} consumer - Consumer directory, already past `checkBinCommands`.
+ * @param {string} packageName - Installed package name.
+ * @param {unknown} manifest - Installed package manifest.
+ * @returns {void}
+ * @throws {SmokeError} When `explain` or `lint` fails against the fixture.
+ *
+ * @remarks
+ * Exported so `tests/smoke-package.test.ts` can exercise both outcomes
+ * directly; see {@link checkRuntimeImports} for why `runNode` is the
+ * boundary mocked rather than a real tarball install.
+ */
+export function checkCliFixtureUsage(consumer, packageName, manifest) {
+  if (!publicBinCommands(manifest, packageName).includes("hookassert")) {
+    step("skipping the explain/lint fixture check: no hookassert bin command");
+    return;
+  }
+
+  step("exercising explain and lint against a tiny fixture project");
+  const projectDir = path.join(consumer, "fixture-project");
+  mkdirSync(projectDir, { recursive: true });
+  const settingsPath = path.join(projectDir, "settings.json");
+  writeFileSync(
+    settingsPath,
+    `${JSON.stringify(
+      {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{ type: "command", command: "echo hookassert-smoke-ok" }],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const executable = path.join(consumer, "node_modules", ".bin", "hookassert");
+
+  const explainResult = runNode(
+    executable,
+    ["explain", "PreToolUse", "Bash", "--settings", settingsPath],
+    { cwd: consumer },
+  );
+  if (
+    explainResult.status !== 0 ||
+    !explainResult.stdout.includes("echo hookassert-smoke-ok")
+  ) {
+    fail("ERR_SMOKE_CLI_EXPLAIN_FAILED", {
+      what: "`hookassert explain` did not report the fixture project's firing hook.",
+      subject: settingsPath,
+      expected: "exit 0, with the fixture hook's command in the firing-hooks list",
+      actual: `exit ${String(explainResult.status)}\n${excerpt(explainResult.stderr || explainResult.stdout)}`,
+      next: "Run `hookassert explain PreToolUse Bash --settings <file>` against the installed tarball by hand.",
+    });
+  }
+  process.stdout.write(explainResult.stdout);
+
+  const lintResult = runNode(executable, ["lint", "--settings", settingsPath], {
+    cwd: consumer,
+  });
+  if (lintResult.status !== 0) {
+    fail("ERR_SMOKE_CLI_LINT_FAILED", {
+      what: "`hookassert lint` did not pass against a clean fixture project.",
+      subject: settingsPath,
+      expected: "exit 0, with no findings",
+      actual: `exit ${String(lintResult.status)}\n${excerpt(lintResult.stderr || lintResult.stdout)}`,
+      next: "Run `hookassert lint --settings <file>` against the installed tarball by hand.",
+    });
+  }
+  process.stdout.write(lintResult.stdout);
+}
+
+/**
  * A CommonJS consumer resolves the package and its manifest.
  *
  * @remarks
@@ -887,6 +988,7 @@ export function main(argv) {
       readKey(installedManifest, "bin") !== undefined,
     );
     checkBinCommands(consumer, packageName, installedManifest);
+    checkCliFixtureUsage(consumer, packageName, installedManifest);
     checkRequireInterop(
       consumer,
       packageName,

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -487,6 +487,17 @@ export function checkBinCommands(consumer, packageName, manifest) {
  * the two commands *run* against a real settings file, not about whether
  * lint's own rules are correct — that is `tests/cli.test.ts`'s job.
  *
+ * Both invocations run with `HOME`/`USERPROFILE` pointed at an empty scratch
+ * directory under the throwaway consumer, and `cwd` set to the fixture
+ * project directory. `--settings` is additive, not exclusive
+ * (`discoverSources`, `src/internal/settings/discover.ts`, always prepends
+ * the user layer at `{home}/.claude/settings.json` and the project/local
+ * layers at `{cwd}/.claude/settings.json(.local)`), and `runNode` otherwise
+ * defaults to `process.env`/the invoking machine's real home. Without this,
+ * the check would lint — and print — whatever hook settings happen to sit in
+ * the developer's or CI runner's own `~/.claude`, rather than only the
+ * fixture the check controls.
+ *
  * Specific to hookassert's own subcommands on purpose: skipped entirely for
  * a packed manifest that does not declare the `hookassert` bin command, so
  * this stays inert rather than false-failing for anything else built on
@@ -533,28 +544,47 @@ export function checkCliFixtureUsage(consumer, packageName, manifest) {
 
   const executable = path.join(consumer, "node_modules", ".bin", "hookassert");
 
+  // An empty scratch HOME, isolated from the invoking machine's own
+  // `~/.claude/settings.json` — see the remark above for why this matters.
+  const scratchHome = path.join(consumer, "smoke-home");
+  mkdirSync(scratchHome, { recursive: true });
+  const isolatedEnv = { ...process.env, HOME: scratchHome, USERPROFILE: scratchHome };
+  const isolatedOptions = { cwd: projectDir, env: isolatedEnv };
+
   const explainResult = runNode(
     executable,
-    ["explain", "PreToolUse", "Bash", "--settings", settingsPath],
-    { cwd: consumer },
+    ["explain", "PreToolUse", "Bash", "--settings", settingsPath, "--format", "json"],
+    isolatedOptions,
   );
-  if (
-    explainResult.status !== 0 ||
-    !explainResult.stdout.includes("echo hookassert-smoke-ok")
-  ) {
+  /** @type {unknown} */
+  let firing;
+  if (explainResult.status === 0) {
+    try {
+      firing = readKey(parseJson(explainResult.stdout), "firing");
+    } catch {
+      firing = undefined;
+    }
+  }
+  const fixtureFired =
+    Array.isArray(firing) &&
+    firing.some((hook) => readString(hook, "command") === "echo hookassert-smoke-ok");
+  if (explainResult.status !== 0 || !fixtureFired) {
     fail("ERR_SMOKE_CLI_EXPLAIN_FAILED", {
-      what: "`hookassert explain` did not report the fixture project's firing hook.",
+      what: "`hookassert explain` did not report the fixture project's hook as firing.",
       subject: settingsPath,
-      expected: "exit 0, with the fixture hook's command in the firing-hooks list",
+      expected:
+        'exit 0, with a firing[] entry whose "command" is "echo hookassert-smoke-ok"',
       actual: `exit ${String(explainResult.status)}\n${excerpt(explainResult.stderr || explainResult.stdout)}`,
-      next: "Run `hookassert explain PreToolUse Bash --settings <file>` against the installed tarball by hand.",
+      next: "Run `hookassert explain PreToolUse Bash --settings <file> --format json` against the installed tarball by hand.",
     });
   }
   process.stdout.write(explainResult.stdout);
 
-  const lintResult = runNode(executable, ["lint", "--settings", settingsPath], {
-    cwd: consumer,
-  });
+  const lintResult = runNode(
+    executable,
+    ["lint", "--settings", settingsPath],
+    isolatedOptions,
+  );
   if (lintResult.status !== 0) {
     fail("ERR_SMOKE_CLI_LINT_FAILED", {
       what: "`hookassert lint` did not pass against a clean fixture project.",

--- a/tests/smoke-package.test.ts
+++ b/tests/smoke-package.test.ts
@@ -261,10 +261,15 @@ describe("checkCliFixtureUsage", () => {
     expect(runNodeMock).not.toHaveBeenCalled();
   });
 
-  it("writes a one-hook fixture and runs explain then lint against it", () => {
+  const explainJsonWithFiring = JSON.stringify({
+    firing: [{ command: "echo hookassert-smoke-ok" }],
+    rejected: [],
+  });
+
+  it("writes a one-hook fixture and runs explain then lint against it, isolated from the real HOME", () => {
     runNodeMock.mockReturnValue({
       status: 0,
-      stdout: "  echo hookassert-smoke-ok\n",
+      stdout: explainJsonWithFiring,
       stderr: "",
     });
     const consumer = makeConsumer();
@@ -273,7 +278,8 @@ describe("checkCliFixtureUsage", () => {
       bin: { hookassert: "./dist/cli.js" },
     });
 
-    const settingsPath = path.join(consumer, "fixture-project", "settings.json");
+    const projectDir = path.join(consumer, "fixture-project");
+    const settingsPath = path.join(projectDir, "settings.json");
     expect(JSON.parse(readFileSync(settingsPath, "utf8")) as unknown).toMatchObject({
       hooks: {
         PreToolUse: [
@@ -285,23 +291,57 @@ describe("checkCliFixtureUsage", () => {
       },
     });
 
+    const scratchHome = path.join(consumer, "smoke-home");
     const executable = path.join(consumer, "node_modules", ".bin", "hookassert");
     expect(runNodeMock).toHaveBeenNthCalledWith(
       1,
       executable,
-      ["explain", "PreToolUse", "Bash", "--settings", settingsPath],
-      expect.objectContaining({ cwd: consumer }),
+      ["explain", "PreToolUse", "Bash", "--settings", settingsPath, "--format", "json"],
+      expect.objectContaining({
+        cwd: projectDir,
+        env: expect.objectContaining({
+          HOME: scratchHome,
+          USERPROFILE: scratchHome,
+        }) as unknown,
+      }),
     );
     expect(runNodeMock).toHaveBeenNthCalledWith(
       2,
       executable,
       ["lint", "--settings", settingsPath],
-      expect.objectContaining({ cwd: consumer }),
+      expect.objectContaining({
+        cwd: projectDir,
+        env: expect.objectContaining({
+          HOME: scratchHome,
+          USERPROFILE: scratchHome,
+        }) as unknown,
+      }),
     );
   });
 
-  it("throws ERR_SMOKE_CLI_EXPLAIN_FAILED when explain fails or omits the fixture hook", () => {
+  it("throws ERR_SMOKE_CLI_EXPLAIN_FAILED when explain fails", () => {
     runNodeMock.mockReturnValue({ status: 1, stdout: "", stderr: "boom" });
+    const consumer = makeConsumer();
+
+    expect(() =>
+      checkCliFixtureUsage(consumer, "hookassert", {
+        bin: { hookassert: "./dist/cli.js" },
+      }),
+    ).toThrow(/ERR_SMOKE_CLI_EXPLAIN_FAILED/);
+    expect(runNodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws ERR_SMOKE_CLI_EXPLAIN_FAILED when explain exits 0 but the fixture hook is not firing", () => {
+    runNodeMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({
+        firing: [],
+        rejected: [
+          { hook: { command: "echo hookassert-smoke-ok" }, reason: "did not match" },
+        ],
+      }),
+      stderr: "",
+    });
     const consumer = makeConsumer();
 
     expect(() =>
@@ -316,7 +356,7 @@ describe("checkCliFixtureUsage", () => {
     runNodeMock.mockImplementation((_script, args) =>
       args[0] === "lint"
         ? { status: 1, stdout: "", stderr: "boom" }
-        : { status: 0, stdout: "echo hookassert-smoke-ok", stderr: "" },
+        : { status: 0, stdout: explainJsonWithFiring, stderr: "" },
     );
     const consumer = makeConsumer();
 

--- a/tests/smoke-package.test.ts
+++ b/tests/smoke-package.test.ts
@@ -47,6 +47,7 @@ vi.mock("../scripts/lib/node-tools.mjs", async (importOriginal) => {
 
 const {
   checkBinCommands,
+  checkCliFixtureUsage,
   checkDeepImportBlocked,
   checkRequireInterop,
   checkRuntimeImports,
@@ -247,6 +248,84 @@ describe("publicBinCommands and checkBinCommands", () => {
       checkBinCommands(consumer, "fixture-package", { bin: { ".": "./dist/cli.js" } }),
     ).toThrow(/ERR_SMOKE_BIN_INVALID/);
     expect(runNodeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkCliFixtureUsage", () => {
+  it("skips, without spawning anything, when the manifest declares no hookassert bin", () => {
+    const consumer = makeConsumer();
+
+    expect(() =>
+      checkCliFixtureUsage(consumer, "fixture-package", { bin: { other: "./x.js" } }),
+    ).not.toThrow();
+    expect(runNodeMock).not.toHaveBeenCalled();
+  });
+
+  it("writes a one-hook fixture and runs explain then lint against it", () => {
+    runNodeMock.mockReturnValue({
+      status: 0,
+      stdout: "  echo hookassert-smoke-ok\n",
+      stderr: "",
+    });
+    const consumer = makeConsumer();
+
+    checkCliFixtureUsage(consumer, "hookassert", {
+      bin: { hookassert: "./dist/cli.js" },
+    });
+
+    const settingsPath = path.join(consumer, "fixture-project", "settings.json");
+    expect(JSON.parse(readFileSync(settingsPath, "utf8")) as unknown).toMatchObject({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "echo hookassert-smoke-ok" }],
+          },
+        ],
+      },
+    });
+
+    const executable = path.join(consumer, "node_modules", ".bin", "hookassert");
+    expect(runNodeMock).toHaveBeenNthCalledWith(
+      1,
+      executable,
+      ["explain", "PreToolUse", "Bash", "--settings", settingsPath],
+      expect.objectContaining({ cwd: consumer }),
+    );
+    expect(runNodeMock).toHaveBeenNthCalledWith(
+      2,
+      executable,
+      ["lint", "--settings", settingsPath],
+      expect.objectContaining({ cwd: consumer }),
+    );
+  });
+
+  it("throws ERR_SMOKE_CLI_EXPLAIN_FAILED when explain fails or omits the fixture hook", () => {
+    runNodeMock.mockReturnValue({ status: 1, stdout: "", stderr: "boom" });
+    const consumer = makeConsumer();
+
+    expect(() =>
+      checkCliFixtureUsage(consumer, "hookassert", {
+        bin: { hookassert: "./dist/cli.js" },
+      }),
+    ).toThrow(/ERR_SMOKE_CLI_EXPLAIN_FAILED/);
+    expect(runNodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws ERR_SMOKE_CLI_LINT_FAILED when lint fails against the clean fixture", () => {
+    runNodeMock.mockImplementation((_script, args) =>
+      args[0] === "lint"
+        ? { status: 1, stdout: "", stderr: "boom" }
+        : { status: 0, stdout: "echo hookassert-smoke-ok", stderr: "" },
+    );
+    const consumer = makeConsumer();
+
+    expect(() =>
+      checkCliFixtureUsage(consumer, "hookassert", {
+        bin: { hookassert: "./dist/cli.js" },
+      }),
+    ).toThrow(/ERR_SMOKE_CLI_LINT_FAILED/);
+    expect(runNodeMock).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
Brings the package to a releasable `0.1.0` state. **`npm publish` is explicitly out of scope** — it is a separate, human, maintainer-only step performed after this merges, and this issue does not close on publishing.

- **`CHANGELOG.md`**: a `0.1.0` entry describing the shipped feature set in consumer-facing terms — the four subcommands, the spec-driven matcher/decision engine, the three-layer settings merge with provenance, the fixture format, the reporters, and the conformance harness — including everything that landed since the issue was written (#44, #48, #50, #65, #68). #49 is deliberately omitted as an internal-only refactor with no consumer-visible effect.
- **Version**: `package.json` goes from the template placeholder `0.0.0` to `0.1.0`.
- **Metadata**: `description` and `keywords` reviewed against what `README.md` actually says (`keywords` was empty per the template default).
- **`package:smoke`**: the throwaway consumer now runs `hookassert explain` and `hookassert lint` against a generated fixture project, not just `--help` and a type-only import — so a broken `bin` entry or a missing runtime dependency in the packed tarball is caught.

Review found two real defects in those new smoke checks, both fixed here:

1. `--settings` is **additive**, not exclusive — `discoverSources` always prepends the user and project layers — so the new `lint` check was reading the invoking machine's real `~/.claude/settings.json` and could fail with `ERR_SMOKE_CLI_LINT_FAILED` for reasons unrelated to the tarball (and print that machine's real hook commands into the log). Both invocations now run with `HOME`/`USERPROFILE` pointed at an empty scratch directory and `cwd` set to the fixture project. Verified by running the whole smoke suite under a deliberately contaminated `HOME` that produces two lint findings on its own: the smoke run still exits 0, with `firing[]` containing only the fixture's own hook.
2. The `explain` check asserted a substring of pretty output, which prints the command in the **"Not firing"** section too — so it passed even when the hook did not fire, the exact regression it exists to catch. It now runs `--format json` and asserts the command is in the report's `firing[]` array.

Closes #20

## npm name re-verification

`GET https://registry.npmjs.org/hookassert` returned **404** (still unclaimed), checked **2026-09-04** (UTC).

## Release impact

Release impact: yes — MINOR. Initial `0.1.0` release: the version bump and CHANGELOG entry for the already-shipped feature set. This PR itself changes no `src/index.ts` surface.

## Test plan

- `pnpm check` → pass
- `pnpm package:check` → pass
- `pnpm package:smoke` → pass, with `explain`/`lint` running against the fixture project through the installed tarball
- `pnpm exec vitest run tests/smoke-package.test.ts` → pass, including a new case proving `ERR_SMOKE_CLI_EXPLAIN_FAILED` fires when `explain` exits 0 but the fixture hook is absent from `firing[]`
- All four re-run after merging `main` (which carries #44).

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
