### PR TITLE
test: pin --timeout usage rejection and fractional acceptance (#76)

### DIFF
--- a/tests/test-cmd.test.ts
+++ b/tests/test-cmd.test.ts
@@ -1408,6 +1408,54 @@ describe("--timeout", () => {
     const hookCall = spawner.calls.find((call) => call.command !== "claude");
     expect(hookCall?.timeoutMs).toBe(900_000);
   });
+
+  it.each(["0", "-1", "abc", ""])(
+    "rejects --timeout %j with ERR_USAGE and spawns nothing",
+    async (value) => {
+      const spawner = new FakeSpawner();
+      const fixturePath = writeFixture({
+        cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+      });
+
+      const result = await runCli(
+        [
+          "test",
+          fixturePath,
+          "--claude-version",
+          "2.1.300",
+          "--yes",
+          "--timeout",
+          value,
+        ],
+        "hookassert",
+        testDeps({ spawner }),
+      );
+
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr).toContain("ERR_USAGE");
+      expect(spawner.calls).toHaveLength(0);
+    },
+  );
+
+  // Unlike --concurrency 1.5 (rejected: an integer check), --timeout uses a
+  // plain Number(value), so a fractional millisecond count is accepted.
+  // Pinning that difference, not "fixing" it, is this test's point.
+  it("accepts a fractional --timeout, unlike --concurrency", async () => {
+    const spawner = new FakeSpawner();
+    const fixturePath = writeFixture({
+      cases: [{ event: "PreToolUse", tool: "Bash", expect: { decision: "pass" } }],
+    });
+
+    const result = await runCli(
+      ["test", fixturePath, "--claude-version", "2.1.300", "--yes", "--timeout", "1.5"],
+      "hookassert",
+      testDeps({ spawner }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const hookCall = spawner.calls.find((call) => call.command !== "claude");
+    expect(hookCall?.timeoutMs).toBe(1.5);
+  });
 });
 
 describe("a fixture file's own defaults.timeoutMs", () => {


### PR DESCRIPTION
`parseTimeoutOption` (`src/cli.ts`) rejects a non-positive or non-finite `--timeout` with a `UsageError`, but no test exercised that branch — every existing `--timeout` test passed a valid value. #50 added exactly this coverage for the sibling `--concurrency` option, which made the asymmetry plain: the newer option was pinned and the older one was not.

Adds the missing cases, modeled on `--concurrency`'s: `--timeout 0`, `-1`, `abc` and `""` are each rejected with `ERR_USAGE`, exit code 4, and zero spawns. Also pins the one real difference between the two options — `--timeout` uses a plain `Number(value)`, so a fractional `1.5` is *accepted*, where `--concurrency 1.5` is rejected by an integer check. That difference is pinned deliberately, not changed; deciding whether the two should match is a separate call.

Test-only: `src/` is untouched.

Closes #76

## Release impact

Release impact: no — test-only change; no source or published behavior modified.

## Test plan

- `pnpm check:quick` → pass (format check, lint, typecheck, 40 test files / 1764 tests), re-run after merging `main` (which carries the `0.1.0` release commit).
- `pnpm exec vitest run tests/cli.test.ts tests/test-cmd.test.ts` → pass (138 tests).

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
