### PR TITLE
docs: fold the Unreleased entry into 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release pull requests update this file as part of the reviewed release process.
 
-## [Unreleased]
-
-### Added
-
-- `hookassert <subcommand> --help` (`explain`, `lint`, `record`, `test`) now prints that
-  subcommand's own usage and options, instead of the identical global usage text every
-  subcommand printed before. `hookassert --help` and a bare `hookassert` are unchanged.
-
 ## [0.1.0] - 2026-09-04
 
 Initial release.
@@ -53,6 +45,9 @@ Initial release.
   `expect` field with nothing firing fails outright instead of silently passing.
 - `pretty`, `json`, and `github` report formats across `explain`, `lint`, and `test`,
   including GitHub Actions error/warning annotations.
+- `hookassert <subcommand> --help` (`explain`, `lint`, `record`, `test`) prints that
+  subcommand's own usage line and options table; `hookassert --help` and a bare
+  `hookassert` print the global usage.
 - A spec-driven matcher and decision engine, versioned against a declared Claude Code
   release range, resolving which hooks fire for a given event and tool and folding every
   firing hook's exit code and JSON output into one case verdict (any deny wins).
@@ -64,5 +59,4 @@ Initial release.
 - A black-box conformance harness proving the CLI's observable behavior — output,
   exit codes, and report shapes — against recorded transcripts.
 
-[unreleased]: https://github.com/tomada1114/hookassert/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/tomada1114/hookassert/releases/tag/v0.1.0


### PR DESCRIPTION
The per-subcommand `--help` work (#75) landed just after the `0.1.0` release PR (#79), so `CHANGELOG.md` carried it under `## [Unreleased]` while `package.json` already read `0.1.0`. Publishing `main` as-is would have shipped that feature under a version its own changelog said it was not in.

Nothing has been published yet — `hookassert` is still unclaimed on npm and no `v0.1.0` tag exists — so `0.1.0` simply includes it:

- the `--help` bullet moves into `0.1.0`'s `Added` list, reworded for an initial release (there is no prior behavior to contrast it against, so "now prints … instead of what it printed before" no longer makes sense);
- the `## [Unreleased]` heading and its now-meaningless `[unreleased]: …/compare/v0.1.0...HEAD` link definition are removed.

#76 needed no fold — it was test-only and correctly carried no changelog entry.

No code changes: `CHANGELOG.md` only.

## Release impact

Release impact: no — documentation only. It makes the existing `0.1.0` entry accurately describe the commit it will be tagged at; no source, no published behavior, and no version number changes.

## Test plan

- `CHANGELOG.md` is the only file touched; `git diff --stat` is 3 insertions, 9 deletions in that one file.
- lefthook's pre-commit hook ran clean (format, staged-content check, related tests).
- CI's own gates run on this PR.

## Follow-up, deliberately not in this PR

Tagging `v0.1.0` and `npm publish` remain maintainer-only steps, to be done after this merges. The `[0.1.0]: …/releases/tag/v0.1.0` link at the bottom of the changelog stays dead until that tag exists.

https://claude.ai/code/session_01Lee28mBxYU3gYMyvaJtHPE
